### PR TITLE
[CAT-18] Add User Profile Information

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,10 @@ It provides error handling and other event-related functionalities to ensure rob
 The `exception` module contains the project-specific exceptions. These exceptions are used to handle exceptional situations and provide meaningful error messages or behavior. 
 The module defines custom exception classes that extend the standard exception classes or implement specific interfaces.
 
+8) mapper
+
+The `mapper` module is responsible for mapping entities with DTOs using MapStruct.
+
 ## Instructions for Developers
 
 ### Prerequisites

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -25,6 +25,10 @@
       <artifactId>lombok</artifactId>
     </dependency>
     <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-qute</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.grnet</groupId>
       <artifactId>cat-services</artifactId>
     </dependency>

--- a/api/src/main/java/org/grnet/cat/api/endpoints/UsersEndpoint.java
+++ b/api/src/main/java/org/grnet/cat/api/endpoints/UsersEndpoint.java
@@ -1,14 +1,13 @@
 package org.grnet.cat.api.endpoints;
 
-import io.quarkus.oidc.TokenIntrospection;
 import io.quarkus.security.Authenticated;
 import jakarta.inject.Inject;
+import jakarta.ws.rs.GET;
 import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
-import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.eclipse.microprofile.openapi.annotations.Operation;
 import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
 import org.eclipse.microprofile.openapi.annotations.enums.SecuritySchemeIn;
@@ -16,10 +15,15 @@ import org.eclipse.microprofile.openapi.annotations.enums.SecuritySchemeType;
 import org.eclipse.microprofile.openapi.annotations.media.Content;
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
+import org.eclipse.microprofile.openapi.annotations.security.SecurityRequirement;
 import org.eclipse.microprofile.openapi.annotations.security.SecurityScheme;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
+import org.grnet.cat.api.filters.Registration;
+import org.grnet.cat.api.utils.Utility;
 import org.grnet.cat.dtos.InformativeResponse;
+import org.grnet.cat.dtos.UserProfileDto;
 import org.grnet.cat.services.IdentifiedService;
+import org.grnet.cat.services.UserService;
 
 @Path("/v1/users")
 @Authenticated
@@ -38,14 +42,13 @@ public class UsersEndpoint {
     IdentifiedService identifiedService;
 
     /**
-     * Injection point for the Token Introspection
+     * Injection point for the User Service
      */
     @Inject
-    TokenIntrospection tokenIntrospection;
+    UserService userService;
 
-    @ConfigProperty(name = "oidc.user.unique.id")
-    String key;
-
+    @Inject
+    Utility utility;
 
     @Tag(name = "User")
     @Operation(
@@ -75,18 +78,59 @@ public class UsersEndpoint {
             content = @Content(schema = @Schema(
                     type = SchemaType.OBJECT,
                     implementation = InformativeResponse.class)))
-
+    @SecurityRequirement(name = "Authentication")
     @Path("/register")
     @POST
     @Produces(MediaType.APPLICATION_JSON)
     public Response register() {
 
-        identifiedService.register(tokenIntrospection.getJsonObject().getString(key));
+        identifiedService.register(utility.getUserUniqueIdentifier());
 
         var response = new InformativeResponse();
         response.code = 200;
         response.message = "User has been successfully registered on Cat Service.";
 
         return Response.ok().entity(response).build();
+    }
+
+    @Tag(name = "User")
+    @Operation(
+            summary = "Get User Profile.",
+            description = "This endpoint retrieves the user profile information. User registration is a prerequisite for retrieving user information.")
+    @SecurityScheme
+    @APIResponse(
+            responseCode = "200",
+            description = "User's Profile.",
+            content = @Content(schema = @Schema(
+                    type = SchemaType.OBJECT,
+                    implementation = UserProfileDto.class)))
+    @APIResponse(
+            responseCode = "401",
+            description = "User has not been authenticated.",
+            content = @Content(schema = @Schema(
+                    type = SchemaType.OBJECT,
+                    implementation = InformativeResponse.class)))
+    @APIResponse(
+            responseCode = "403",
+            description = "User has not been registered on CAT service.",
+            content = @Content(schema = @Schema(
+                    type = SchemaType.OBJECT,
+                    implementation = InformativeResponse.class)))
+    @APIResponse(
+            responseCode = "500",
+            description = "Internal Server Error.",
+            content = @Content(schema = @Schema(
+                    type = SchemaType.OBJECT,
+                    implementation = InformativeResponse.class)))
+    @SecurityRequirement(name = "Authentication")
+    @Path("/profile")
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    @Registration
+    public Response profile() {
+
+        var userProfile = userService.getUserProfile(utility.getUserUniqueIdentifier());
+
+        return Response.ok().entity(userProfile).build();
     }
 }

--- a/api/src/main/java/org/grnet/cat/api/filters/Registration.java
+++ b/api/src/main/java/org/grnet/cat/api/filters/Registration.java
@@ -1,0 +1,14 @@
+package org.grnet.cat.api.filters;
+
+import jakarta.ws.rs.NameBinding;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ ElementType.TYPE, ElementType.METHOD })
+@Retention(value = RetentionPolicy.RUNTIME)
+@NameBinding
+public @interface Registration {
+}

--- a/api/src/main/java/org/grnet/cat/api/filters/RegistrationFilter.java
+++ b/api/src/main/java/org/grnet/cat/api/filters/RegistrationFilter.java
@@ -1,0 +1,33 @@
+package org.grnet.cat.api.filters;
+
+import jakarta.inject.Inject;
+import jakarta.ws.rs.ForbiddenException;
+import jakarta.ws.rs.container.ContainerRequestContext;
+import jakarta.ws.rs.container.ContainerRequestFilter;
+import jakarta.ws.rs.ext.Provider;
+import org.grnet.cat.api.utils.Utility;
+import org.grnet.cat.repositories.UserRepository;
+
+/**
+ * This filter intercepts the requests to the endpoints annotated with the {@link Registration Registration} annotation.
+ * Only the registered users can access those endpoints. Therefore, it checks whether a user has been registered on the CAT database. If not, it throws a ForbiddenException.
+ *
+ */
+@Registration
+@Provider
+public class RegistrationFilter implements ContainerRequestFilter {
+
+    @Inject
+    UserRepository userRepository;
+
+    @Inject
+    Utility utility;
+
+    @Override
+    public void filter(ContainerRequestContext containerRequestContext) {
+
+        var optionalUser = userRepository.findByIdOptional(utility.getUserUniqueIdentifier());
+
+        optionalUser.orElseThrow(()-> new ForbiddenException("User has not been registered on CAT service. User registration is a prerequisite for accessing this API resource."));
+    }
+}

--- a/api/src/main/java/org/grnet/cat/api/templates/OidcClientTemplate.java
+++ b/api/src/main/java/org/grnet/cat/api/templates/OidcClientTemplate.java
@@ -1,0 +1,45 @@
+package org.grnet.cat.api.templates;
+
+import io.quarkus.qute.Template;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+
+/**
+ * This endpoint is responsible for rendering the client.html.
+ * The web page is created by processing template file. Templates are located under src/main/resources/templates.
+ * Obtain the keycloak application properties and feed them to the keycloak template.
+ * The client.html is responsible for redirecting a user to Keycloak login page in order to be authenticated and displaying the obtained token.
+ */
+@Path("/oidc-client")
+public class OidcClientTemplate {
+
+    @Inject
+    Template client;
+
+    @ConfigProperty(name = "keycloak.server.url")
+    String keycloakServerUrl;
+
+    @ConfigProperty(name = "keycloak.server.realm")
+    String keycloakServerRealm;
+
+    @ConfigProperty(name = "keycloak.server.client.id")
+    String keycloakServerClientId;
+
+    @ConfigProperty(name = "keycloak.server.javascript.adapter")
+    String keycloakServerJavascriptAdapter;
+
+    @GET
+    @Produces(MediaType.TEXT_HTML)
+    public String keycloakClient() {
+        return client
+                .data("keycloak_server_url", keycloakServerUrl,
+                "keycloak_server_realm", keycloakServerRealm,
+                "keycloak_server_client_id", keycloakServerClientId,
+                "keycloak_server_javascript_adapter", keycloakServerJavascriptAdapter)
+                .render();
+    }
+}

--- a/api/src/main/java/org/grnet/cat/api/utils/Utility.java
+++ b/api/src/main/java/org/grnet/cat/api/utils/Utility.java
@@ -1,0 +1,36 @@
+package org.grnet.cat.api.utils;
+
+import io.quarkus.oidc.TokenIntrospection;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.BadRequestException;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+
+@ApplicationScoped
+public class Utility {
+
+    /**
+     * Injection point for the Token Introspection
+     */
+    @Inject
+    TokenIntrospection tokenIntrospection;
+
+    @ConfigProperty(name = "oidc.user.unique.id")
+    String key;
+
+    public String getUserUniqueIdentifier(){
+
+        String id;
+
+        try{
+
+            id = tokenIntrospection.getJsonObject().getString(key);
+        } catch (Exception e){
+
+            String message = String.format("The User's unique identifier {%s} is missing from the access token.", key);
+            throw new BadRequestException(message);
+        }
+
+        return id;
+    }
+}

--- a/api/src/main/resources/application.properties
+++ b/api/src/main/resources/application.properties
@@ -1,10 +1,10 @@
-%prod.quarkus.oidc.auth-server-url=https://aai-demo.eosc-portal.eu/auth/realms/core
+%prod.quarkus.oidc.auth-server-url=https://login-devel.einfra.grnet.gr/auth/realms/einfra
 quarkus.oidc.authorization-path=/protocol/openid-connect/auth
 quarkus.oidc.token-path=/protocol/openid-connect/token
 quarkus.oidc.discovery-enabled=false
 quarkus.oidc.introspection-path=/protocol/openid-connect/token/introspect
-quarkus.oidc.client-id=client
-quarkus.oidc.credentials.secret=secret
+quarkus.oidc.client-id=client-id
+quarkus.oidc.credentials.secret=client-secret
 %prod.quarkus.oidc.user-info-path=/protocol/openid-connect/userinfo
 %prod.quarkus.oidc.authentication.user-info-required=true
 
@@ -18,3 +18,9 @@ quarkus.smallrye-openapi.path=/open-api
 # swagger
 quarkus.swagger-ui.always-include=true
 quarkus.swagger-ui.path=/swagger-ui
+
+# keycloak properties for feeding the oidc_client html template
+keycloak.server.url=https://login-devel.einfra.grnet.gr/auth
+keycloak.server.realm=einfra
+keycloak.server.client.id=fc4e-cat-ui
+keycloak.server.javascript.adapter=https://login-devel.einfra.grnet.gr/auth/js/keycloak.js

--- a/api/src/main/resources/templates/client.html
+++ b/api/src/main/resources/templates/client.html
@@ -1,0 +1,74 @@
+<!DOCTYPE html>
+<html lang="en">
+	<head>
+		<link href="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-EVSTQN3/azprG1Anm3QDgpJLIm9Nao0Yz1ztcQTwFspd3yD65VohhpuuCOmLASjC" crossorigin="anonymous">
+		<script src="{keycloak_server_javascript_adapter}"></script>
+		<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/js/bootstrap.bundle.min.js" integrity="sha384-MrcW6ZMFYlzcLA8Nl+NtUVF0sA7MsXsP1UyJoMp4YLEuNSfAP+JcXn/tWtIaxVXM" crossorigin="anonymous"></script>
+		<meta charset="UTF-8">
+		<title>Keycloak Client</title>
+	</head>
+	<body>
+		<div class="row mb-3 mt-3 md-3 mx-3">
+			<div class="col align-self-start" id="token">
+			</div>
+			<div class="col align-self-center" id="copy_token">
+			</div>
+			<div class="col align-self-end" id="logout">
+			</div>
+		</div>
+
+		<script>
+
+		let initConfig = {
+              onLoad: 'login-required',
+              checkLoginIframe: true,
+              checkLoginIframeInterval: 1,
+              pkceMethod: 'S256',
+              scope: "voperson_id"
+        };
+
+        var keycloak = new Keycloak(
+            {
+                "url": "{keycloak_server_url}",
+                "realm": "{keycloak_server_realm}",
+                "clientId": "{keycloak_server_client_id}"
+            }
+        );
+
+        keycloak.init(initConfig).then(function(authenticated) {
+
+
+            var tokenDiv = document.getElementById('token');
+
+            var _text = document.createElement("input");
+            _text.id = "token_value";
+            _text.value = keycloak.token;
+            _text.className="form-control"
+
+            _text.for = "token_value";
+
+            tokenDiv.appendChild(_text);
+
+            var copyTokenDiv = document.getElementById('copy_token');
+
+            var _copy = document.createElement("button");
+            _copy.type="button";
+           _copy.data = "Copy Access Token";
+           _copy.innerHTML = 'Copy Access Token';
+           _copy.className="btn btn-primary";
+           _copy.onclick = function()
+            {
+                 var copyText = document.getElementById("token_value");
+                 copyText.select();
+                 copyText.setSelectionRange(0, 99999);
+                 navigator.clipboard.writeText(copyText.value);
+                 <!--alert("Copied the text: " + copyText.value);-->
+            }
+
+            copyTokenDiv.appendChild(_copy);
+        }).catch(function() {
+            console.log('failed to initialize');
+        });
+    </script>
+	</body>
+</html>

--- a/api/src/test/java/org/grnet/cat/api/UsersEndpointTest.java
+++ b/api/src/test/java/org/grnet/cat/api/UsersEndpointTest.java
@@ -3,8 +3,10 @@ package org.grnet.cat.api;
 import io.quarkus.test.common.http.TestHTTPEndpoint;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.keycloak.client.KeycloakTestClient;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.grnet.cat.api.endpoints.UsersEndpoint;
 import org.grnet.cat.dtos.InformativeResponse;
+import org.grnet.cat.dtos.UserProfileDto;
 import org.junit.jupiter.api.Test;
 
 import static io.restassured.RestAssured.given;
@@ -13,6 +15,9 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 @QuarkusTest
 @TestHTTPEndpoint(UsersEndpoint.class)
 public class UsersEndpointTest {
+
+    @ConfigProperty(name = "oidc.user.unique.id")
+    public static String key;
 
     KeycloakTestClient keycloakClient = new KeycloakTestClient();
 
@@ -58,6 +63,38 @@ public class UsersEndpointTest {
                 .as(InformativeResponse.class);
 
         assertEquals("User already exists in the database.", success.message);
+    }
+
+    @Test
+    public void getUserProfile() {
+
+        var userProfile = given()
+                .auth()
+                .oauth2(getAccessToken("alice"))
+                .get("/profile")
+                .then()
+                .assertThat()
+                .statusCode(200)
+                .extract()
+                .as(UserProfileDto.class);
+
+        assertEquals("Identified", userProfile.type);
+    }
+
+    @Test
+    public void nonRegisterUserRequestsTheirUserProfile() {
+
+        var informativeResponse = given()
+                .auth()
+                .oauth2(getAccessToken("bob"))
+                .get("/profile")
+                .then()
+                .assertThat()
+                .statusCode(403)
+                .extract()
+                .as(InformativeResponse.class);
+
+        assertEquals("User has not been registered on CAT service. User registration is a prerequisite for accessing this API resource.", informativeResponse.message);
     }
 
     protected String getAccessToken(String userName) {

--- a/data-transfer-object/src/main/java/org/grnet/cat/dtos/UserProfileDto.java
+++ b/data-transfer-object/src/main/java/org/grnet/cat/dtos/UserProfileDto.java
@@ -1,0 +1,37 @@
+package org.grnet.cat.dtos;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
+
+import java.sql.Timestamp;
+
+@Schema(name="UserProfile", description="This object represents the User Profile.")
+public class UserProfileDto {
+
+    @Schema(
+            type = SchemaType.STRING,
+            implementation = String.class,
+            description = "Unique identifier for the user.",
+            example = "24329fb1b49c7fc0aa668d07410d4857a685c1d365976e42823368faa27442e7@aai.eosc-portal.eu"
+    )
+    public String id;
+
+    @Schema(
+            type = SchemaType.STRING,
+            implementation = Timestamp.class,
+            description = "Date and Time when the user registered on the service.",
+            example = " 2023-06-09 12:19:31.333059"
+    )
+    @JsonProperty("registered_on")
+    public Timestamp registeredOn;
+
+    @Schema(
+            type = SchemaType.STRING,
+            implementation = String.class,
+            description = "Type of user (e.g., Identified, Validated, Admin).",
+            example = " Identified"
+    )
+    @JsonProperty("user_type")
+    public String type;
+}

--- a/entity/src/main/java/org/grnet/cat/entities/Identified.java
+++ b/entity/src/main/java/org/grnet/cat/entities/Identified.java
@@ -1,10 +1,7 @@
 package org.grnet.cat.entities;
 
-import jakarta.persistence.Column;
 import jakarta.persistence.DiscriminatorValue;
 import jakarta.persistence.Entity;
-
-import java.sql.Timestamp;
 
 /**
  * As an Identified entity, we consider all the Users who have successfully been registered in the CAT service.
@@ -12,18 +9,4 @@ import java.sql.Timestamp;
 @Entity
 @DiscriminatorValue("Identified")
 public class Identified extends User{
-
-    /**
-     * The date and time the user is registered into the database.
-     */
-    @Column(name = "registered_on")
-    private Timestamp registeredOn;
-
-    public Timestamp getRegisteredOn() {
-        return registeredOn;
-    }
-
-    public void setRegisteredOn(Timestamp registeredOn) {
-        this.registeredOn = registeredOn;
-    }
 }

--- a/entity/src/main/java/org/grnet/cat/entities/User.java
+++ b/entity/src/main/java/org/grnet/cat/entities/User.java
@@ -19,7 +19,7 @@ import java.sql.Timestamp;
  * This entity represents the User table in database.
  *
  */
-public class User {
+public abstract class User {
 
     /**
      * As id, we use the voperson_id provided by AAI Proxy.
@@ -27,11 +27,35 @@ public class User {
     @Id
     private String id;
 
+    /**
+     * Type of user (e.g., Identified, Validated, Admin).
+     */
+    @Column(name="user_type", insertable = false, updatable = false)
+    private String type;
+
+    /**
+     * The date and time the user is registered into the database.
+     */
+    @Column(name = "registered_on")
+    private Timestamp registeredOn;
+
+    public Timestamp getRegisteredOn() {
+        return registeredOn;
+    }
+
+    public void setRegisteredOn(Timestamp registeredOn) {
+        this.registeredOn = registeredOn;
+    }
+
     public String getId() {
         return id;
     }
 
     public void setId(String id) {
         this.id = id;
+    }
+
+    public String getType() {
+        return type;
     }
 }

--- a/entity/src/main/java/org/grnet/cat/entities/UserProfile.java
+++ b/entity/src/main/java/org/grnet/cat/entities/UserProfile.java
@@ -1,0 +1,22 @@
+package org.grnet.cat.entities;
+
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+import java.sql.Timestamp;
+
+@RegisterForReflection
+public class UserProfile {
+
+    public final String id;
+
+    public final String type;
+
+    public final Timestamp registeredOn;
+
+
+    public UserProfile(String id, String type, Timestamp registeredOn) {
+        this.id = id;
+        this.type = type;
+        this.registeredOn = registeredOn;
+    }
+}

--- a/entity/src/main/resources/application.properties
+++ b/entity/src/main/resources/application.properties
@@ -11,6 +11,7 @@ quarkus.datasource.db-kind=mysql
 %dev.quarkus.datasource.devservices.db-name=cat
 %dev.quarkus.datasource.devservices.username=cat
 %dev.quarkus.datasource.devservices.password=cat
+%dev.quarkus.hibernate-orm.log.sql=true
 
 %dev.quarkus.datasource.devservices.volumes."/var/cat/data"=/var/lib/mysql
 

--- a/mapper/pom.xml
+++ b/mapper/pom.xml
@@ -8,21 +8,26 @@
     </parent>
 
     <modelVersion>4.0.0</modelVersion>
-    <artifactId>cat-services</artifactId>
+    <artifactId>cat-mappers</artifactId>
     <version>1.0.0-SNAPSHOT</version>
-    <name>cat-services</name>
+    <name>cat-mappers</name>
+
     <dependencies>
         <dependency>
             <groupId>org.grnet</groupId>
-            <artifactId>cat-repositories</artifactId>
+            <artifactId>cat-entities</artifactId>
         </dependency>
         <dependency>
             <groupId>org.grnet</groupId>
-            <artifactId>cat-exceptions</artifactId>
+            <artifactId>cat-data-transfer-objects</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.grnet</groupId>
-            <artifactId>cat-mappers</artifactId>
+            <groupId>org.mapstruct</groupId>
+            <artifactId>mapstruct</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.mapstruct</groupId>
+            <artifactId>mapstruct-processor</artifactId>
         </dependency>
     </dependencies>
 

--- a/mapper/src/main/java/org/grnet/cat/mappers/UserMapper.java
+++ b/mapper/src/main/java/org/grnet/cat/mappers/UserMapper.java
@@ -1,0 +1,17 @@
+package org.grnet.cat.mappers;
+
+import org.grnet.cat.dtos.UserProfileDto;
+import org.grnet.cat.entities.UserProfile;
+import org.mapstruct.Mapper;
+import org.mapstruct.factory.Mappers;
+
+/**
+ * The UserMapper is responsible for mapping User entities to DTOs.
+ */
+@Mapper
+public interface UserMapper {
+
+    UserMapper INSTANCE = Mappers.getMapper( UserMapper.class );
+
+    UserProfileDto userProfileToDto(UserProfile userProfile);
+}

--- a/pom.xml
+++ b/pom.xml
@@ -16,6 +16,7 @@
     <module>handler</module>
     <module>data-transfer-object</module>
     <module>exception</module>
+    <module>mapper</module>
   </modules>
 
   <properties>
@@ -31,6 +32,7 @@
     <lombok.version>1.18.26</lombok.version>
     <jandex.version>1.2.3</jandex.version>
     <cat.version>1.0.0-SNAPSHOT</cat.version>
+    <mapstruct.version>1.5.5.Final</mapstruct.version>
   </properties>
   <dependencyManagement>
     <dependencies>
@@ -76,6 +78,21 @@
         <groupId>org.grnet</groupId>
         <artifactId>cat-exceptions</artifactId>
         <version>${cat.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.grnet</groupId>
+        <artifactId>cat-mappers</artifactId>
+        <version>${cat.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.mapstruct</groupId>
+        <artifactId>mapstruct</artifactId>
+        <version>${mapstruct.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.mapstruct</groupId>
+        <artifactId>mapstruct-processor</artifactId>
+        <version>${mapstruct.version}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/repository/src/main/java/org/grnet/cat/repositories/UserRepository.java
+++ b/repository/src/main/java/org/grnet/cat/repositories/UserRepository.java
@@ -1,0 +1,26 @@
+package org.grnet.cat.repositories;
+
+import io.quarkus.hibernate.orm.panache.PanacheRepositoryBase;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import org.grnet.cat.entities.User;
+import org.grnet.cat.entities.UserProfile;
+
+/**
+ * The IdentifiedRepository interface provides data access methods for the User entity.
+ */
+@ApplicationScoped
+public class UserRepository implements PanacheRepositoryBase<User, String> {
+
+
+    /**
+     * It executes a query in database to retrieve user's profile.
+     *
+     * @param id User's Unique identifier (voperson_id)
+     * @return User's Profile.
+     */
+    public UserProfile fetchUserProfile(String id){
+
+        return find("select user.id, user.type, user.registeredOn from User user where user.id = ?1", id).project(UserProfile.class).firstResult();
+    }
+}

--- a/service/src/main/java/org/grnet/cat/services/IdentifiedService.java
+++ b/service/src/main/java/org/grnet/cat/services/IdentifiedService.java
@@ -27,7 +27,7 @@ public class IdentifiedService {
     /**
      * This operations registers a user on the CAT service.
      * Typically, it constructs an {@link User Identified} object and stores it in the database.
-     * @param id The user's voperson_id
+     * @param id User's voperson_id
      */
     @Transactional
     public void register(String id){

--- a/service/src/main/java/org/grnet/cat/services/UserService.java
+++ b/service/src/main/java/org/grnet/cat/services/UserService.java
@@ -1,0 +1,42 @@
+package org.grnet.cat.services;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.transaction.Transactional;
+import org.grnet.cat.dtos.UserProfileDto;
+import org.grnet.cat.entities.Identified;
+import org.grnet.cat.entities.User;
+import org.grnet.cat.exceptions.ConflictException;
+import org.grnet.cat.mappers.UserMapper;
+import org.grnet.cat.repositories.IdentifiedRepository;
+import org.grnet.cat.repositories.UserRepository;
+
+import java.sql.Timestamp;
+import java.time.Instant;
+
+/**
+ * The UserService provides operations for managing User entities.
+ */
+
+@ApplicationScoped
+public class UserService {
+
+    /**
+     * Injection point for the User Repository
+     */
+    @Inject
+    UserRepository userRepository;
+
+    /**
+     * Get User's profile.
+     *
+     * @param id User's voperson_id
+     * @return User's Profile.
+     */
+    public UserProfileDto getUserProfile(String id){
+
+        var userProfile = userRepository.fetchUserProfile(id);
+
+        return UserMapper.INSTANCE.userProfileToDto(userProfile);
+    }
+}


### PR DESCRIPTION
This pull request introduces a new API endpoint that provides user profile information.

**Changes Made**

1. Created a new endpoint '/users/profile' to handle requests for user profile information.
2. Implemented the necessary backend logic to fetch user profile data from the database.
3. Designed the response structure to include essential details such as voperson_id, registration datetime.
4. Added appropriate error handling to ensure graceful handling of invalid requests or database failures.
5. Updated the API documentation to include information about the new endpoint and its usage.

