### PR TITLE
CAT-33 [API] List of organisation integration sources

### DIFF
--- a/api/src/main/java/org/grnet/cat/api/endpoints/IntegrationsEndpoint.java
+++ b/api/src/main/java/org/grnet/cat/api/endpoints/IntegrationsEndpoint.java
@@ -1,0 +1,80 @@
+package org.grnet.cat.api.endpoints;
+
+import io.quarkus.security.Authenticated;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import org.eclipse.microprofile.openapi.annotations.Operation;
+import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
+import org.eclipse.microprofile.openapi.annotations.enums.SecuritySchemeIn;
+import org.eclipse.microprofile.openapi.annotations.enums.SecuritySchemeType;
+import org.eclipse.microprofile.openapi.annotations.media.Content;
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
+import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
+import org.eclipse.microprofile.openapi.annotations.security.SecurityRequirement;
+import org.eclipse.microprofile.openapi.annotations.security.SecurityScheme;
+import org.eclipse.microprofile.openapi.annotations.tags.Tag;
+import org.grnet.cat.dtos.InformativeResponse;
+import org.grnet.cat.services.IntegrationService;
+
+import java.util.List;
+import org.grnet.cat.api.filters.Registration;
+
+@Path("/v1/integrations")
+@Authenticated
+@SecurityScheme(securitySchemeName = "Authentication",
+        description = "JWT token",
+        type = SecuritySchemeType.HTTP,
+        scheme = "bearer",
+        bearerFormat = "JWT",
+        in = SecuritySchemeIn.HEADER)
+
+public class IntegrationsEndpoint {
+
+    @Inject
+    IntegrationService integrationService;
+
+
+    @Tag(name = "Integration")
+    @Operation(
+            summary = "Retrieve a list of integration sources for Organisations.",
+            description = "This endpoint returns a list of integration sources, to retrieve organisations")
+    @APIResponse(
+            responseCode = "200",
+            description = "List of Integrations",
+            content = @Content(schema = @Schema(
+                    type = SchemaType.OBJECT,
+                    implementation = List.class)))
+    @APIResponse(
+            responseCode = "401",
+            description = "User has not been authenticated.",
+            content = @Content(schema = @Schema(
+                    type = SchemaType.OBJECT,
+                    implementation = InformativeResponse.class)))
+    @APIResponse(
+            responseCode = "403",
+            description = "User has not been registered on CAT service.",
+            content = @Content(schema = @Schema(
+                    type = SchemaType.OBJECT,
+                    implementation = InformativeResponse.class)))
+    @APIResponse(
+            responseCode = "500",
+            description = "Internal Server Error.",
+            content = @Content(schema = @Schema(
+                    type = SchemaType.OBJECT,
+                    implementation = InformativeResponse.class)))
+    @SecurityRequirement(name = "Authentication")
+    @GET
+    @Path("/organisations")
+    @Produces(MediaType.APPLICATION_JSON)
+   @Registration
+    public Response organisationSources() {
+
+        var integrations = integrationService.getOrganisationSources();
+
+        return Response.ok().entity(integrations).build();
+    }
+}

--- a/api/src/main/java/org/grnet/cat/api/endpoints/UsersEndpoint.java
+++ b/api/src/main/java/org/grnet/cat/api/endpoints/UsersEndpoint.java
@@ -116,7 +116,6 @@ public class UsersEndpoint {
     @Operation(
             summary = "Get User Profile.",
             description = "This endpoint retrieves the user profile information. User registration is a prerequisite for retrieving user information.")
-    @SecurityScheme
     @APIResponse(
             responseCode = "200",
             description = "User's Profile.",
@@ -158,7 +157,6 @@ public class UsersEndpoint {
             summary = "Retrieve a list of available users.",
             description = "This endpoint returns a list of users registered in the service. Each user object includes basic information such as their type and unique id. " +
                     " By default, the first page of 10 Users will be returned. You can tune the default values by using the query parameters page and size.")
-    @SecurityScheme
     @APIResponse(
             responseCode = "200",
             description = "List of Users.",
@@ -203,7 +201,6 @@ public class UsersEndpoint {
     @Operation(
             summary = "Update User Profile Metadata.",
             description = "Updates the metadata for a user's profile. The user can provide their name, surname, and email.")
-    @SecurityScheme
     @APIResponse(
             responseCode = "200",
             description = "User's metadata updated successfully.",

--- a/api/src/test/java/org/grnet/cat/api/IntegrationsEndpointTest.java
+++ b/api/src/test/java/org/grnet/cat/api/IntegrationsEndpointTest.java
@@ -1,0 +1,53 @@
+package org.grnet.cat.api;
+
+import io.quarkus.test.common.http.TestHTTPEndpoint;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.keycloak.client.KeycloakTestClient;
+import static io.restassured.RestAssured.given;
+import jakarta.inject.Inject;
+import org.grnet.cat.api.endpoints.IntegrationsEndpoint;
+import org.grnet.cat.dtos.SourceResponseDto;
+import org.grnet.cat.services.UserService;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import org.junit.jupiter.api.Test;
+
+
+
+@QuarkusTest
+@TestHTTPEndpoint(IntegrationsEndpoint.class)
+public class IntegrationsEndpointTest {
+    
+        KeycloakTestClient keycloakClient = new KeycloakTestClient();
+  @Inject
+  UserService userService;
+        @Test
+    public void fetchAllIntegrationSources() {
+        
+        userService.deleteUsers();
+        
+            var success = given()
+                .auth()
+                
+                .oauth2(getAccessToken("alice"))
+                .basePath("/v1/users")
+                .post("/register");
+              
+//
+        
+        var response = given()
+                .auth()
+                .oauth2(getAccessToken("alice"))
+                .get("/organisations")               
+               .then()
+                .assertThat()
+                .statusCode(200)
+                .extract()
+                .as(SourceResponseDto[].class);
+
+            assertEquals(3, response.length);
+    }
+    protected String getAccessToken(String userName) {
+        return keycloakClient.getAccessToken(userName);
+    }
+
+}

--- a/api/src/test/java/org/grnet/cat/api/UsersEndpointTest.java
+++ b/api/src/test/java/org/grnet/cat/api/UsersEndpointTest.java
@@ -12,6 +12,8 @@ import org.grnet.cat.dtos.pagination.PageResource;
 import org.junit.jupiter.api.Test;
 
 import static io.restassured.RestAssured.given;
+import jakarta.inject.Inject;
+import org.grnet.cat.services.UserService;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @QuarkusTest
@@ -19,6 +21,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 public class UsersEndpointTest {
 
     KeycloakTestClient keycloakClient = new KeycloakTestClient();
+  @Inject
+  UserService userService;
 
     @Test
     public void unauthorizedUser(){
@@ -34,7 +38,9 @@ public class UsersEndpointTest {
 
     @Test
     public void registerUser(){
-
+        userService.deleteUsers();
+      
+  
         var success = given()
                 .auth()
                 .oauth2(getAccessToken("alice"))
@@ -50,7 +56,6 @@ public class UsersEndpointTest {
 
     @Test
     public void userAlreadyExistsInTheDatabase(){
-
         var success = given()
                 .auth()
                 .oauth2(getAccessToken("alice"))

--- a/data-transfer-object/src/main/java/org/grnet/cat/dtos/SourceResponseDto.java
+++ b/data-transfer-object/src/main/java/org/grnet/cat/dtos/SourceResponseDto.java
@@ -1,0 +1,47 @@
+package org.grnet.cat.dtos;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
+
+@Schema(name="Source", description="This object represents the Source.")
+public class SourceResponseDto {
+    
+    @Schema(
+            type = SchemaType.STRING,
+            implementation = String.class,
+            description = "Label of Source",
+            example = "ror"
+    )
+    @JsonProperty("label")
+    public String label;
+
+
+    @Schema(
+            type = SchemaType.STRING,
+            implementation = String.class,
+            description = "Display Value of Source",
+            example = "ROR"
+    )
+    @JsonProperty("display_value")
+    public String displayValue;
+
+
+    public String getLabel() {
+        return label;
+    }
+
+    public void setLabel(String label) {
+        this.label = label;
+    }
+
+    public String getDisplayValue() {
+        return displayValue;
+    }
+
+    public void setDisplayValue(String displayValue) {
+        this.displayValue = displayValue;
+    }
+
+    
+}

--- a/data-transfer-object/src/main/java/org/grnet/cat/dtos/pagination/PageResource.java
+++ b/data-transfer-object/src/main/java/org/grnet/cat/dtos/pagination/PageResource.java
@@ -68,14 +68,12 @@ public class PageResource<R> {
     }
 
     public PageResource(PanacheQuery panacheQuery, List<R> content, UriInfo uriInfo){
-
         links = new ArrayList<>();
         this.content = content;
         this.sizeOfPage = panacheQuery.list().size();
         this.numberOfPage = panacheQuery.page().index+1;
         this.totalElements = panacheQuery.count();
         this.totalPages = panacheQuery.pageCount();
-
         if(totalPages !=1 && numberOfPage <= totalPages){
             links.add(buildPageLink(uriInfo, 1, sizeOfPage, "first"));
             links.add(buildPageLink(uriInfo, totalPages, sizeOfPage, "last"));

--- a/entity/src/main/java/org/grnet/cat/enums/Source.java
+++ b/entity/src/main/java/org/grnet/cat/enums/Source.java
@@ -1,0 +1,52 @@
+package org.grnet.cat.enums;
+
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ *
+ * Enumeration of  Integration Sources
+ */
+public enum Source {
+    ROR("ror","ROR","https://api.ror.org/organizations"),    
+    EOSC("eosc","EOSC","http://api.eosc-portal.eu/provider"),
+    RE3DATA("re3data","RE3DATA","");
+
+    public final String label;
+    public final String displayValue;
+    public final String url;
+
+    private Source(String label, String displayValue, String url) {
+        this.label = label;
+        this.displayValue = displayValue;
+        this.url = url;
+    }
+
+
+    public String getLabel(){
+        return label;
+
+    }
+
+    public String getDisplayValue() {
+        return displayValue;
+    }
+
+    public String getUrl() {
+        return url;
+    }
+    
+
+    public static Source getEnumNameForValue(String value){
+        List<Source> values = Arrays.asList(Source.values());
+        for(Source op:values){
+
+            if (op.getLabel().equalsIgnoreCase(value)) {
+                return op;
+            }
+        }
+        return  null;}
+
+
+    
+}

--- a/mapper/src/main/java/org/grnet/cat/mappers/SourceMapper.java
+++ b/mapper/src/main/java/org/grnet/cat/mappers/SourceMapper.java
@@ -1,0 +1,21 @@
+package org.grnet.cat.mappers;
+
+import com.mysql.cj.util.StringUtils;
+import java.util.List;
+import org.grnet.cat.dtos.SourceResponseDto;
+import org.grnet.cat.enums.Source;
+import org.mapstruct.Mapper;
+import org.mapstruct.factory.Mappers;
+
+
+/**
+ * This Mapper converts the available {@link Source source}  to suitable responses.
+ */
+@Mapper(imports = StringUtils.class)
+public interface SourceMapper {
+
+    SourceMapper INSTANCE = Mappers.getMapper(SourceMapper.class );
+
+
+    List<SourceResponseDto> sourcesToResponse(List<Source> sources);
+}

--- a/repository/src/main/java/org/grnet/cat/repositories/UserRepository.java
+++ b/repository/src/main/java/org/grnet/cat/repositories/UserRepository.java
@@ -59,4 +59,10 @@ public class UserRepository implements PanacheRepositoryBase<User, String> {
         user.setEmail(email);
         user.setUpdatedOn(Timestamp.from(Instant.now()));
     }
+    
+    @Transactional
+    public void deleteUsers() {
+
+        deleteAll();
+    }
 }

--- a/service/src/main/java/org/grnet/cat/services/IntegrationService.java
+++ b/service/src/main/java/org/grnet/cat/services/IntegrationService.java
@@ -1,0 +1,28 @@
+package org.grnet.cat.services;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import java.util.Arrays;
+
+import java.util.List;
+import org.grnet.cat.dtos.SourceResponseDto;
+import org.grnet.cat.enums.Source;
+import org.grnet.cat.mappers.SourceMapper;
+
+/**
+ * The IntegrationService provides operations for managing integrations.
+ */
+
+@ApplicationScoped
+
+public class IntegrationService {
+    /**
+     * Retrieves a list  of the integration sources, to retrieve organisations.
+     * @return A list of IntegrationDto objects representing the integration sources.
+     */
+    public List<SourceResponseDto> getOrganisationSources(){
+        
+         var sources = Arrays.asList(Source.values());
+        return SourceMapper.INSTANCE.sourcesToResponse(sources);
+
+    }
+}

--- a/service/src/main/java/org/grnet/cat/services/UserService.java
+++ b/service/src/main/java/org/grnet/cat/services/UserService.java
@@ -2,6 +2,7 @@ package org.grnet.cat.services;
 
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
+import jakarta.transaction.Transactional;
 import jakarta.ws.rs.core.UriInfo;
 import org.grnet.cat.dtos.UserProfileDto;
 import org.grnet.cat.dtos.pagination.PageResource;
@@ -60,5 +61,15 @@ public class UserService {
     public void updateUserProfileMetadata(String id, String name, String surname, String email){
 
         userRepository.updateUserProfileMetadata(id, name, surname, email);
+    
+    }
+     /**
+     * Delete all users from the database.
+     *
+     */
+    public void deleteUsers(){
+
+        userRepository.deleteUsers();
+ 
     }
 }


### PR DESCRIPTION
This PR adds a new resource /integrations to handle the intregration procedures that maybe needed to the CAT service. 
Also it adds a new endpoint GET /organisations to retrieve the integration sources from which the organisations can be retrieved
Integrations Sources are represented from Integration enumeration which keeps a record of {value,label,url} of the source.
example {"ror","ROR","https://api.ror.org/organizations"}. 