### PR TITLE
[CAT-29] Retrieve the promotion requests submitted by a specific user

### DIFF
--- a/api/src/main/java/org/grnet/cat/api/endpoints/CodelistEndpoint.java
+++ b/api/src/main/java/org/grnet/cat/api/endpoints/CodelistEndpoint.java
@@ -1,0 +1,82 @@
+package org.grnet.cat.api.endpoints;
+
+import io.quarkus.security.Authenticated;
+import jakarta.inject.Inject;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.ws.rs.DefaultValue;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.core.Context;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.UriInfo;
+import org.eclipse.microprofile.openapi.annotations.Operation;
+import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
+import org.eclipse.microprofile.openapi.annotations.media.Content;
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
+import org.eclipse.microprofile.openapi.annotations.parameters.Parameter;
+import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
+import org.eclipse.microprofile.openapi.annotations.security.SecurityRequirement;
+import org.eclipse.microprofile.openapi.annotations.tags.Tag;
+import org.grnet.cat.api.filters.Registration;
+import org.grnet.cat.dtos.InformativeResponse;
+import org.grnet.cat.services.ActorService;
+
+import static org.eclipse.microprofile.openapi.annotations.enums.ParameterIn.QUERY;
+
+@Path("/v1/codelist")
+@Authenticated
+public class CodelistEndpoint {
+
+    @Inject
+    ActorService actorService;
+
+    @Tag(name = "Codelist")
+    @Operation(
+            summary = "Retrieve a list of available actors.",
+            description = "This endpoint returns a list of actors registered in the service. Each actor object includes basic information such as their id and name. " +
+                    " By default, the first page of 10 Actors will be returned. You can tune the default values by using the query parameters page and size.")
+    @APIResponse(
+            responseCode = "200",
+            description = "List of Actors.",
+            content = @Content(schema = @Schema(
+                    type = SchemaType.OBJECT,
+                    implementation = UsersEndpoint.PageableUserProfile.class)))
+    @APIResponse(
+            responseCode = "401",
+            description = "User has not been authenticated.",
+            content = @Content(schema = @Schema(
+                    type = SchemaType.OBJECT,
+                    implementation = InformativeResponse.class)))
+    @APIResponse(
+            responseCode = "403",
+            description = "User has not been registered on CAT service.",
+            content = @Content(schema = @Schema(
+                    type = SchemaType.OBJECT,
+                    implementation = InformativeResponse.class)))
+    @APIResponse(
+            responseCode = "500",
+            description = "Internal Server Error.",
+            content = @Content(schema = @Schema(
+                    type = SchemaType.OBJECT,
+                    implementation = InformativeResponse.class)))
+    @SecurityRequirement(name = "Authentication")
+    @GET
+    @Path("/actors")
+    @Produces(MediaType.APPLICATION_JSON)
+    @Registration
+    public Response actorsByPage(@Parameter(name = "page", in = QUERY,
+            description = "Indicates the page number. Page number must be >= 1.") @DefaultValue("1") @Min(value = 1, message = "Page number must be >= 1.") @QueryParam("page") int page,
+                                @Parameter(name = "size", in = QUERY,
+                                        description = "The page size.") @DefaultValue("10") @Min(value = 1, message = "Page size must be between 1 and 100.")
+                                @Max(value = 100, message = "Page size must be between 1 and 100.") @QueryParam("size") int size,
+                                @Context UriInfo uriInfo) {
+
+        var actors = actorService.getActorsByPage(page-1, size, uriInfo);
+
+        return Response.ok().entity(actors).build();
+    }
+}

--- a/api/src/main/java/org/grnet/cat/api/endpoints/IntegrationsEndpoint.java
+++ b/api/src/main/java/org/grnet/cat/api/endpoints/IntegrationsEndpoint.java
@@ -107,8 +107,20 @@ public class IntegrationsEndpoint {
                     type = SchemaType.OBJECT,
                     implementation = InformativeResponse.class)))
     @APIResponse(
+            responseCode = "404",
+            description = "Organisation Not Found.",
+            content = @Content(schema = @Schema(
+                    type = SchemaType.OBJECT,
+                    implementation = InformativeResponse.class)))
+    @APIResponse(
             responseCode = "500",
             description = "Internal Server Error.",
+            content = @Content(schema = @Schema(
+                    type = SchemaType.OBJECT,
+                    implementation = InformativeResponse.class)))
+    @APIResponse(
+            responseCode = "501",
+            description = "Not Implemented.",
             content = @Content(schema = @Schema(
                     type = SchemaType.OBJECT,
                     implementation = InformativeResponse.class)))

--- a/api/src/main/java/org/grnet/cat/api/endpoints/ValidationsEndpoint.java
+++ b/api/src/main/java/org/grnet/cat/api/endpoints/ValidationsEndpoint.java
@@ -3,16 +3,24 @@ package org.grnet.cat.api.endpoints;
 import io.quarkus.security.Authenticated;
 import jakarta.inject.Inject;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
+import jakarta.ws.rs.DefaultValue;
+import jakarta.ws.rs.GET;
 import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.core.Context;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.UriInfo;
 import org.eclipse.microprofile.openapi.annotations.Operation;
 import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
 import org.eclipse.microprofile.openapi.annotations.media.Content;
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
+import org.eclipse.microprofile.openapi.annotations.parameters.Parameter;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
 import org.eclipse.microprofile.openapi.annotations.security.SecurityRequirement;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
@@ -20,7 +28,15 @@ import org.grnet.cat.api.filters.Registration;
 import org.grnet.cat.api.utils.Utility;
 import org.grnet.cat.dtos.InformativeResponse;
 import org.grnet.cat.dtos.PromotionRequest;
+import org.grnet.cat.dtos.ValidationResponse;
+import org.grnet.cat.dtos.pagination.PageResource;
+import org.grnet.cat.enums.Source;
 import org.grnet.cat.services.IdentifiedService;
+import org.grnet.cat.services.ValidationService;
+
+import java.util.List;
+
+import static org.eclipse.microprofile.openapi.annotations.enums.ParameterIn.QUERY;
 
 @Path("/v1/validations")
 @Authenticated
@@ -37,6 +53,12 @@ public class ValidationsEndpoint {
      */
     @Inject
     Utility utility;
+
+    /**
+     * Injection point for the Validation service
+     */
+    @Inject
+    ValidationService validationService;
 
 
     @Tag(name = "Validation")
@@ -69,6 +91,12 @@ public class ValidationsEndpoint {
                     type = SchemaType.OBJECT,
                     implementation = InformativeResponse.class)))
     @APIResponse(
+            responseCode = "404",
+            description = "Entity Not Found.",
+            content = @Content(schema = @Schema(
+                    type = SchemaType.OBJECT,
+                    implementation = InformativeResponse.class)))
+    @APIResponse(
             responseCode = "409",
             description = "Promotion request already exists.",
             content = @Content(schema = @Schema(
@@ -80,11 +108,19 @@ public class ValidationsEndpoint {
             content = @Content(schema = @Schema(
                     type = SchemaType.OBJECT,
                     implementation = InformativeResponse.class)))
+    @APIResponse(
+            responseCode = "501",
+            description = "Not Implemented.",
+            content = @Content(schema = @Schema(
+                    type = SchemaType.OBJECT,
+                    implementation = InformativeResponse.class)))
     @SecurityRequirement(name = "Authentication")
     @POST
     @Produces(MediaType.APPLICATION_JSON)
     @Registration
     public Response validate(@Valid @NotNull(message = "The request body is empty.") PromotionRequest request) {
+
+        Source.valueOf(request.organisationSource).execute(request.organisationId);
 
         identifiedService.validate(utility.getUserUniqueIdentifier(), request);
 
@@ -93,5 +129,65 @@ public class ValidationsEndpoint {
         response.message = "User promotion request submitted.";
 
         return Response.ok().entity(response).build();
+    }
+
+    @Tag(name = "Validation")
+    @Operation(
+            summary = "Retrieve validation requests for a specific user.",
+            description = "This endpoint retrieves the validation requests submitted by the specified user." +
+                    "By default, the first page of 10 validation requests will be returned. You can tune the default values by using the query parameters page and size.")
+    @APIResponse(
+            responseCode = "200",
+            description = "List of validation requests.",
+            content = @Content(schema = @Schema(
+                    type = SchemaType.OBJECT,
+                    implementation = PageableValidationResponse.class)))
+    @APIResponse(
+            responseCode = "401",
+            description = "User has not been authenticated.",
+            content = @Content(schema = @Schema(
+                    type = SchemaType.OBJECT,
+                    implementation = InformativeResponse.class)))
+    @APIResponse(
+            responseCode = "403",
+            description = "User has not been registered on CAT service.",
+            content = @Content(schema = @Schema(
+                    type = SchemaType.OBJECT,
+                    implementation = InformativeResponse.class)))
+    @APIResponse(
+            responseCode = "500",
+            description = "Internal Server Error.",
+            content = @Content(schema = @Schema(
+                    type = SchemaType.OBJECT,
+                    implementation = InformativeResponse.class)))
+    @SecurityRequirement(name = "Authentication")
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    @Registration
+    public Response validations(@Parameter(name = "page", in = QUERY,
+            description = "Indicates the page number. Page number must be >= 1.") @DefaultValue("1") @Min(value = 1, message = "Page number must be >= 1.") @QueryParam("page") int page,
+                                @Parameter(name = "size", in = QUERY,
+                                        description = "The page size.") @DefaultValue("10") @Min(value = 1, message = "Page size must be between 1 and 100.")
+                                @Max(value = 100, message = "Page size must be between 1 and 100.") @QueryParam("size") int size,
+                                @Context UriInfo uriInfo) {
+
+        var validations = validationService.getValidationsByPage(page-1, size, uriInfo, utility.getUserUniqueIdentifier());
+
+        return Response.ok().entity(validations).build();
+    }
+
+    public static class PageableValidationResponse extends PageResource<ValidationResponse> {
+
+        private List<ValidationResponse> content;
+
+        @Override
+        public List<ValidationResponse> getContent() {
+            return content;
+        }
+
+        @Override
+        public void setContent(List<ValidationResponse> content) {
+            this.content = content;
+        }
     }
 }

--- a/api/src/test/java/org/grnet/cat/api/IntegrationsEndpointTest.java
+++ b/api/src/test/java/org/grnet/cat/api/IntegrationsEndpointTest.java
@@ -40,9 +40,7 @@ public class IntegrationsEndpointTest extends KeycloakTest {
                 .as(SourceResponseDto[].class);
 
         assertEquals(3, response.length);
-
     }
-//
 
     @Test
     public void fetchOrganisationBySourceAndId() {
@@ -55,7 +53,6 @@ public class IntegrationsEndpointTest extends KeycloakTest {
                 .basePath("/v1/users")
                 .post("/register");
 
-//
         var response = given()
                 .auth()
                 .oauth2(getAccessToken("alice"))
@@ -66,14 +63,12 @@ public class IntegrationsEndpointTest extends KeycloakTest {
                 .extract()
                 .as(OrganisationResponseDto.class);
 
-        assertEquals("h00tjv0s33", response.id);
+        assertEquals("00tjv0s33", response.id);
 
         assertEquals("Keimyung University", response.name);
 
         assertEquals("http://www.kmu.ac.kr/main.jsp", response.website);
-
     }
-//
 
     @Test
     public void nonRegisterUserRequestsOrganisation() {
@@ -89,7 +84,6 @@ public class IntegrationsEndpointTest extends KeycloakTest {
                 .as(InformativeResponse.class);
 
         assertEquals("User has not been registered on CAT service. User registration is a prerequisite for accessing this API resource.", informativeResponse.message);
-
     }
 
     @Test
@@ -113,7 +107,6 @@ public class IntegrationsEndpointTest extends KeycloakTest {
 
     }
 
-
     @Test
     public void fetchOrganisationBySourceAndIdNotFound() {
 
@@ -133,6 +126,5 @@ public class IntegrationsEndpointTest extends KeycloakTest {
 
         assertEquals(404, response.statusCode());
         userService.deleteIdentifiedUsers();
-
     }
 }

--- a/api/src/test/java/org/grnet/cat/api/ValidationsEndpointTest.java
+++ b/api/src/test/java/org/grnet/cat/api/ValidationsEndpointTest.java
@@ -39,6 +39,7 @@ public class ValidationsEndpointTest extends KeycloakTest {
         request.organisationSource = "ROR";
         request.organisationName = "Keimyung University";
         request.organisationId = "https://ror.org/00tjv0s33";
+        request.actorId = 5L;
 
         var response = given()
                 .auth()
@@ -62,6 +63,7 @@ public class ValidationsEndpointTest extends KeycloakTest {
         request.organisationRole = "Manager";
         request.organisationSource = "ROR";
         request.organisationId = "https://ror.org/00tjv0s33";
+        request.actorId = 5L;
 
         var response = given()
                 .auth()
@@ -85,6 +87,7 @@ public class ValidationsEndpointTest extends KeycloakTest {
         request.organisationRole = "Manager";
         request.organisationSource = "ROR";
         request.organisationName = "Keimyung University";
+        request.actorId = 5L;
 
         var response = given()
                 .auth()
@@ -108,6 +111,7 @@ public class ValidationsEndpointTest extends KeycloakTest {
         request.organisationRole = "Manager";
         request.organisationId = "https://ror.org/00tjv0s33";
         request.organisationName = "Keimyung University";
+        request.actorId = 5L;
 
         var response = given()
                 .auth()
@@ -132,6 +136,7 @@ public class ValidationsEndpointTest extends KeycloakTest {
         request.organisationId = "https://ror.org/00tjv0s33";
         request.organisationName = "Keimyung University";
         request.organisationSource = "NOT_VALID";
+        request.actorId = 5L;
 
         var response = given()
                 .auth()
@@ -149,6 +154,109 @@ public class ValidationsEndpointTest extends KeycloakTest {
     }
 
     @Test
+    public void validationActorIsEmpty() {
+
+        var request = new PromotionRequest();
+        request.organisationRole = "Manager";
+        request.organisationId = "https://ror.org/00tjv0s33";
+        request.organisationName = "Keimyung University";
+        request.organisationSource = "ROR";
+        request.organisationWebsite = "http://www.kmu.ac.kr/main.jsp";
+
+        var response = given()
+                .auth()
+                .oauth2(getAccessToken("alice"))
+                .body(request)
+                .contentType(ContentType.JSON)
+                .post()
+                .then()
+                .assertThat()
+                .statusCode(400)
+                .extract()
+                .as(InformativeResponse.class);
+
+        assertEquals("actor_id may not be empty.", response.message);
+    }
+
+    @Test
+    public void validationActorIsNotFound() {
+
+        var request = new PromotionRequest();
+        request.organisationRole = "Manager";
+        request.organisationId = "https://ror.org/00tjv0s33";
+        request.organisationName = "Keimyung University";
+        request.organisationSource = "ROR";
+        request.organisationWebsite = "http://www.kmu.ac.kr/main.jsp";
+        request.actorId = 18L;
+
+        var response = given()
+                .auth()
+                .oauth2(getAccessToken("alice"))
+                .body(request)
+                .contentType(ContentType.JSON)
+                .post()
+                .then()
+                .assertThat()
+                .statusCode(404)
+                .extract()
+                .as(InformativeResponse.class);
+
+        assertEquals("There is no Actor with the following id: "+18, response.message);
+    }
+
+    @Test
+    public void validationSourceNotFound() {
+
+        var request = new PromotionRequest();
+        request.organisationRole = "Manager";
+        request.organisationId = "https://ror.org/00tjv0s33";
+        request.organisationName = "Keimyung University";
+        request.organisationSource = "EOSC";
+        request.organisationWebsite = "http://www.kmu.ac.kr/main.jsp";
+        request.actorId = 5L;
+
+        var response = given()
+                .auth()
+                .oauth2(getAccessToken("alice"))
+                .body(request)
+                .contentType(ContentType.JSON)
+                .post()
+                .then()
+                .assertThat()
+                .statusCode(404)
+                .extract()
+                .as(InformativeResponse.class);
+
+        assertEquals("Organisation https://ror.org/00tjv0s33, not found in EOSC", response.message);
+    }
+
+    @Test
+    public void validationSourceNotSupported() {
+
+        var request = new PromotionRequest();
+        request.organisationRole = "Manager";
+        request.organisationId = "https://ror.org/00tjv0s33";
+        request.organisationName = "Keimyung University";
+        request.organisationSource = "RE3DATA";
+        request.organisationWebsite = "http://www.kmu.ac.kr/main.jsp";
+        request.actorId = 5L;
+
+        var response = given()
+                .auth()
+                .oauth2(getAccessToken("alice"))
+                .body(request)
+                .contentType(ContentType.JSON)
+                .post()
+                .then()
+                .assertThat()
+                .statusCode(501)
+                .extract()
+                .as(InformativeResponse.class);
+
+        assertEquals("Source re3data is not supported.", response.message);
+    }
+
+    @Test
     public void validation() {
 
         var request = new PromotionRequest();
@@ -157,6 +265,7 @@ public class ValidationsEndpointTest extends KeycloakTest {
         request.organisationName = "Keimyung University";
         request.organisationSource = "ROR";
         request.organisationWebsite = "http://www.kmu.ac.kr/main.jsp";
+        request.actorId = 5L;
 
         var response = given()
                 .auth()
@@ -182,6 +291,7 @@ public class ValidationsEndpointTest extends KeycloakTest {
         request.organisationName = "Keimyung University";
         request.organisationSource = "ROR";
         request.organisationWebsite = "http://www.kmu.ac.kr/main.jsp";
+        request.actorId = 5L;
 
         var response = given()
                 .auth()

--- a/data-transfer-object/pom.xml
+++ b/data-transfer-object/pom.xml
@@ -18,6 +18,10 @@
       <artifactId>quarkus-smallrye-openapi</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.grnet</groupId>
+      <artifactId>cat-repositories</artifactId>
+    </dependency>
+    <dependency>
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-hibernate-orm-panache</artifactId>
     </dependency>

--- a/data-transfer-object/src/main/java/org/grnet/cat/dtos/ActorDto.java
+++ b/data-transfer-object/src/main/java/org/grnet/cat/dtos/ActorDto.java
@@ -1,0 +1,36 @@
+package org.grnet.cat.dtos;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
+
+@Schema(name="Actor", description="An object represents an Actor.")
+public class ActorDto {
+
+    @Schema(
+            type = SchemaType.NUMBER,
+            implementation = Long.class,
+            description = "The ID of Actor.",
+            example = "3"
+    )
+    @JsonProperty("id")
+    public Long id;
+
+    @Schema(
+            type = SchemaType.STRING,
+            implementation = String.class,
+            description = "The name of Actor.",
+            example = "PID Manager"
+    )
+    @JsonProperty("name")
+    public String name;
+
+    @Schema(
+            type = SchemaType.STRING,
+            implementation = String.class,
+            description = "The description of Actor.",
+            example = "PID Managers have responsibilities to maintain the integrity of the relationship between entities and their PIDs."
+    )
+    @JsonProperty("description")
+    public String description;
+}

--- a/data-transfer-object/src/main/java/org/grnet/cat/dtos/ValidationResponse.java
+++ b/data-transfer-object/src/main/java/org/grnet/cat/dtos/ValidationResponse.java
@@ -2,61 +2,57 @@ package org.grnet.cat.dtos;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.validation.constraints.NotEmpty;
-import jakarta.validation.constraints.NotNull;
 import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
-import org.grnet.cat.constraints.NotFoundEntity;
-import org.grnet.cat.constraints.StringEnumeration;
 import org.grnet.cat.enums.Source;
-import org.grnet.cat.repositories.ActorRepository;
+import org.grnet.cat.enums.ValidationStatus;
 
-@Schema(name="PromotionRequest", description="Request promotion to validated user.")
-public class PromotionRequest {
-
+@Schema(name="ValidationResponse", description="This object represents a submitted promotion request.")
+public class ValidationResponse {
 
     @Schema(
             type = SchemaType.STRING,
             implementation = String.class,
-            required = true,
+            description = "The unique validation request id.",
+            example = "5"
+    )
+    @JsonProperty("id")
+    public String id;
+
+    @Schema(
+            type = SchemaType.STRING,
+            implementation = String.class,
             description = "The user's role on the organisation.",
             example = "Manager"
     )
     @JsonProperty("organisation_role")
-    @NotEmpty(message = "organisation_role may not be empty.")
     public String organisationRole;
 
     @Schema(
             type = SchemaType.STRING,
             implementation = String.class,
-            required = true,
             description = "The organisation id the user belongs to.",
             example = "https://ror.org/00tjv0s33"
     )
     @JsonProperty("organisation_id")
-    @NotEmpty(message = "organisation_id may not be empty.")
     public String organisationId;
 
     @Schema(
             type = SchemaType.STRING,
             implementation = Source.class,
-            required = true,
             description = "The organisation source (e.g., ROR, EOSC, RE3DATA).",
             example = "ROR"
     )
     @JsonProperty("organisation_source")
-    @StringEnumeration(enumClass = Source.class, message = "organisation_source")
-    @NotEmpty(message = "organisation_source may not be empty.")
     public String organisationSource;
 
     @Schema(
             type = SchemaType.STRING,
             implementation = String.class,
-            required = true,
             description = "The organisation name.",
             example = "Keimyung University"
     )
     @JsonProperty("organisation_name")
-    @NotEmpty(message = "organisation_name may not be empty.")
     public String organisationName;
 
     @Schema(
@@ -72,11 +68,27 @@ public class PromotionRequest {
             type = SchemaType.NUMBER,
             implementation = Long.class,
             required = true,
-            description = "The ID of Actor. It should refer to one of the available Actors.",
+            description = "The ID of Actor.",
             example = "5"
     )
     @JsonProperty("actor_id")
-    @NotNull(message = "actor_id may not be empty.")
-    @NotFoundEntity(repository = ActorRepository.class, message = "There is no Actor with the following id:")
     public Long actorId;
+
+    @Schema(
+            type = SchemaType.STRING,
+            implementation = ValidationStatus.class,
+            description = "The status of the validation request.",
+            example = "APPROVED"
+    )
+    @JsonProperty("status")
+    public String status;
+
+    @Schema(
+            type = SchemaType.STRING,
+            implementation = String.class,
+            description = "The date and time the validation request has been created.",
+            example = "2023-06-22T15:21:53.277+03:00"
+    )
+    @JsonProperty("createdOn")
+    public String createdOn;
 }

--- a/entity/src/main/java/org/grnet/cat/entities/Actor.java
+++ b/entity/src/main/java/org/grnet/cat/entities/Actor.java
@@ -1,0 +1,45 @@
+package org.grnet.cat.entities;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.validation.constraints.NotNull;
+
+@Entity
+public class Actor {
+
+    @Id
+    @GeneratedValue(strategy= GenerationType.IDENTITY)
+    private Long id;
+
+    @NotNull
+    private String name;
+
+    @NotNull
+    private String description;
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+}

--- a/entity/src/main/java/org/grnet/cat/entities/Organisation.java
+++ b/entity/src/main/java/org/grnet/cat/entities/Organisation.java
@@ -1,9 +1,5 @@
 package org.grnet.cat.entities;
 
-import com.google.gson.JsonElement;
-import com.google.gson.JsonObject;
-import com.google.gson.JsonParser;
-
 public class Organisation {
     
     public String id;
@@ -15,8 +11,6 @@ public class Organisation {
         this.name = name;
         this.website = website;
     }
-    
-    
 
     public String getWebsite() {
         return website;
@@ -29,32 +23,4 @@ public class Organisation {
     public String getName() {
         return name;
     }
-    
-    
-    public static Organisation buildFromString(String content) {
-
-        JsonParser jsonParser = new JsonParser();
-        // Grab the first - and only line of json from ops data
-        JsonElement jElement = jsonParser.parse(content);
-
-        JsonObject jRoot = jElement.getAsJsonObject();
-        String id = jRoot.get("id").getAsString();
-        id = id.replaceAll("ttps://ror.org/", "");
-
-        String name = jRoot.get("name").getAsString();
-        String website = null;
-        if (jRoot.has("links")) {
-            website = jRoot.get("links").getAsJsonArray().get(0).getAsString();
-
-        } else if (jRoot.has("website")) {
-            website = jRoot.get("website").getAsString();
-
-        }
-
-        Organisation org = new Organisation(id, name, website);
-        return org;
-    }
-
-
-    
 }

--- a/entity/src/main/java/org/grnet/cat/entities/User.java
+++ b/entity/src/main/java/org/grnet/cat/entities/User.java
@@ -11,14 +11,14 @@ import jakarta.persistence.InheritanceType;
 
 import java.sql.Timestamp;
 
-@Entity
-@Inheritance(strategy = InheritanceType.SINGLE_TABLE)
-@DiscriminatorColumn(name="user_type",
-        discriminatorType = DiscriminatorType.STRING)
 /**
  * This entity represents the User table in database.
  *
  */
+@Entity
+@Inheritance(strategy = InheritanceType.SINGLE_TABLE)
+@DiscriminatorColumn(name="user_type",
+        discriminatorType = DiscriminatorType.STRING)
 public abstract class User {
 
     /**

--- a/entity/src/main/java/org/grnet/cat/entities/Validated.java
+++ b/entity/src/main/java/org/grnet/cat/entities/Validated.java
@@ -6,11 +6,11 @@ import jakarta.persistence.DiscriminatorValue;
 import jakarta.persistence.Entity;
 import java.sql.Timestamp;
 
-@Entity
-@DiscriminatorValue("Validated")
 /**
  * As an Validated entity, we consider the Users who have successfully been validated in the CAT service.
  */
+@Entity
+@DiscriminatorValue("Validated")
 public class Validated extends User {
 
     @Column(name = "validated_on")

--- a/entity/src/main/java/org/grnet/cat/entities/Validation.java
+++ b/entity/src/main/java/org/grnet/cat/entities/Validation.java
@@ -10,16 +10,17 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToOne;
 import jakarta.validation.constraints.NotNull;
 import org.grnet.cat.enums.Source;
 import org.grnet.cat.enums.ValidationStatus;
 
 import java.sql.Timestamp;
 
-@Entity
 /**
  * This entity represents an application that an identified user can request to be promoted to a validated user.
  */
+@Entity
 public class Validation {
 
     @Id
@@ -49,6 +50,11 @@ public class Validation {
 
     @Column(name = "organisation_website")
     private String organisationWebsite;
+
+    @OneToOne
+    @JoinColumn(name = "actor_id", referencedColumnName = "id")
+    @NotNull
+    private Actor actor;
 
     @Column(name = "created_on")
     @NotNull
@@ -129,5 +135,13 @@ public class Validation {
 
     public void setOrganisationSource(Source organisationSource) {
         this.organisationSource = organisationSource;
+    }
+
+    public Actor getActor() {
+        return actor;
+    }
+
+    public void setActor(Actor actor) {
+        this.actor = actor;
     }
 }

--- a/entity/src/main/resources/db/migration/V1.3__actor.sql
+++ b/entity/src/main/resources/db/migration/V1.3__actor.sql
@@ -1,0 +1,28 @@
+-- ------------------------------------------------
+-- Version: v1.3
+--
+-- Description: Migration that introduces the Actor table
+-- -------------------------------------------------
+
+-- actor table
+CREATE TABLE Actor (
+   id BIGINT AUTO_INCREMENT PRIMARY KEY,
+   name varchar(255) NOT NULL,
+   description varchar(455) NOT NULL
+ );
+
+INSERT INTO
+      Actor(name, description)
+VALUES
+      ('PID Standards Body','A PID Standardisation organisation (IETF, IANA, The DONA Foundation, ISO) which appoints the PID Authority and is responsible for the PID Scheme.'),
+      ('PID Authority','A controller responsible for maintaining the rules for defining the integrity of PIDs within a PID Scheme. These rules may include setting standards for lexical formats, algorithms and protocols to ensure global uniqueness, together with setting quality of service conditions to enforce compliance to the rules. PID Authorities may be organisations (e.g. DOI.org), which enforce control over a PID infrastructure.'),
+      ('PID Service Provider','An organisation which provides PID services in conformance to a PID Scheme, subject to its PID Authority. PID Service Providers have responsibility for the provision, integrity, reliability and scalability of PID Services, in particular the issuing and resolution of PIDs, but also lookup and search services, and interoperability with a generic resolution system.'),
+      ('Multi-Primary Administrator','Each credentialed MPA operates its own GHR Services in accordance with the DONA Foundation Policies & Procedures for the GHR, and coordinates its GHR Services with other MPAs and DONA in the distributed operation of the GHR on a multi-primary basis.'),
+      ('PID Manager','PID Managers have responsibilities to maintain the integrity of the relationship between entities and their PIDs, in conformance to a PID Scheme defined by a PID Authority. A PID Manager will typically subscribe to PID services to offer functionality to PID Owners within the PID Manager’s services.'),
+      ('PID Owner','An actor (an organisation or individual) who has the authority to create a PID, assign PID to an entity, provide and maintain accurate Kernel Information for the PID. A new PID Owner must be identified and these responsibilities transferred, if the current PID Owner is no longer able to carry them out.'),
+      ('End User','The end user of PID Services, for example researchers, or software, or services produced to support researchers.'),
+      ('Compliance Monitoring','On completion, the work will support an additional role and associated component for the EOSC PID Policy, as follows: Compliance Monitoring (Role) - One or more organisations that provide services to monitor and/ or enforce compliance (with PID Policy), resulting in interoperable and aggregatable compliance metrics for the roles and components foreseen in the policy.');
+
+
+
+

--- a/entity/src/main/resources/db/migration/V1.4__update_validation.sql
+++ b/entity/src/main/resources/db/migration/V1.4__update_validation.sql
@@ -1,0 +1,7 @@
+-- ------------------------------------------------
+-- Version: v1.4
+--
+-- -------------------------------------------------
+
+ALTER TABLE Validation ADD COLUMN actor_id BIGINT NOT NULL;
+ALTER TABLE Validation ADD FOREIGN KEY (actor_id) REFERENCES Actor(id);

--- a/enum/pom.xml
+++ b/enum/pom.xml
@@ -36,6 +36,11 @@
             <groupId>org.grnet</groupId>
             <artifactId>cat-exceptions</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <scope>provided</scope>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/exception/pom.xml
+++ b/exception/pom.xml
@@ -17,6 +17,10 @@
             <groupId>jakarta.ws.rs</groupId>
             <artifactId>jakarta.ws.rs-api</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-hibernate-validator</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/exception/src/main/java/org/grnet/cat/exceptions/CustomValidationException.java
+++ b/exception/src/main/java/org/grnet/cat/exceptions/CustomValidationException.java
@@ -1,0 +1,18 @@
+package org.grnet.cat.exceptions;
+
+
+import jakarta.validation.ValidationException;
+
+public class CustomValidationException extends ValidationException {
+
+    private int code;
+
+    public CustomValidationException(String message, int status){
+        super(message);
+        this.code = status;
+    }
+
+    public int getCode() {
+        return code;
+    }
+}

--- a/exception/src/main/java/org/grnet/cat/exceptions/InternalServerErrorException.java
+++ b/exception/src/main/java/org/grnet/cat/exceptions/InternalServerErrorException.java
@@ -1,11 +1,10 @@
 package org.grnet.cat.exceptions;
 
-import jakarta.ws.rs.ClientErrorException;
-import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.ServerErrorException;
 
-public class InternalServerErrorException extends ClientErrorException {
+public class InternalServerErrorException extends ServerErrorException {
 
-    public InternalServerErrorException(String message) {
-        super(message, Response.Status.INTERNAL_SERVER_ERROR);
+    public InternalServerErrorException(String message, int status) {
+        super(message, status);
     }
 }

--- a/handler/src/main/java/org/grnet/cat/handlers/exception/AuthenticationExceptionHandler.java
+++ b/handler/src/main/java/org/grnet/cat/handlers/exception/AuthenticationExceptionHandler.java
@@ -1,0 +1,21 @@
+package org.grnet.cat.handlers.exception;
+
+import io.quarkus.security.AuthenticationFailedException;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.ext.ExceptionMapper;
+import jakarta.ws.rs.ext.Provider;
+import org.grnet.cat.dtos.InformativeResponse;
+
+@Provider
+public class AuthenticationExceptionHandler implements ExceptionMapper<AuthenticationFailedException> {
+
+    @Override
+    public Response toResponse(AuthenticationFailedException e) {
+
+        var response = new InformativeResponse();
+        response.code = 401;
+        response.message = "User has not been authenticated.";
+
+        return Response.status(401).entity(response).build();
+    }
+}

--- a/handler/src/main/java/org/grnet/cat/handlers/exception/ExceptionHandler.java
+++ b/handler/src/main/java/org/grnet/cat/handlers/exception/ExceptionHandler.java
@@ -6,7 +6,7 @@ import jakarta.ws.rs.ext.Provider;
 import org.grnet.cat.dtos.InformativeResponse;
 
 @Provider
-public class InternalServerExceptionHandler implements ExceptionMapper<Exception> {
+public class ExceptionHandler implements ExceptionMapper<Exception> {
 
 
     @Override

--- a/handler/src/main/java/org/grnet/cat/handlers/exception/ServerErrorExceptionHandler.java
+++ b/handler/src/main/java/org/grnet/cat/handlers/exception/ServerErrorExceptionHandler.java
@@ -1,0 +1,21 @@
+package org.grnet.cat.handlers.exception;
+
+
+import jakarta.ws.rs.ServerErrorException;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.ext.ExceptionMapper;
+import jakarta.ws.rs.ext.Provider;
+import org.grnet.cat.dtos.InformativeResponse;
+
+@Provider
+public class ServerErrorExceptionHandler implements ExceptionMapper<ServerErrorException> {
+
+    @Override
+    public Response toResponse(ServerErrorException e) {
+        var response = new InformativeResponse();
+        response.message = e.getMessage();
+        response.code = e.getResponse().getStatus();
+
+        return Response.status(e.getResponse().getStatus()).entity(response).build();
+    }
+}

--- a/handler/src/main/java/org/grnet/cat/handlers/exception/ValidationExceptionHandler.java
+++ b/handler/src/main/java/org/grnet/cat/handlers/exception/ValidationExceptionHandler.java
@@ -6,6 +6,7 @@ import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.ext.ExceptionMapper;
 import jakarta.ws.rs.ext.Provider;
 import org.grnet.cat.dtos.InformativeResponse;
+import org.grnet.cat.exceptions.CustomValidationException;
 
 @Provider
 public class ValidationExceptionHandler implements ExceptionMapper<ValidationException> {
@@ -21,6 +22,12 @@ public class ValidationExceptionHandler implements ExceptionMapper<ValidationExc
             response.message = ((ResteasyReactiveViolationException) e).getConstraintViolations().stream().findFirst().get().getMessageTemplate();
             response.code = Response.Status.BAD_REQUEST.getStatusCode();
             return Response.status(Response.Status.BAD_REQUEST).entity(response).build();
+        } else if(e.getCause() instanceof CustomValidationException){
+
+            CustomValidationException exception = (CustomValidationException) e.getCause();
+            response.message = exception.getMessage();
+            response.code = exception.getCode();
+            return Response.status(exception.getCode()).entity(response).build();
         } else {
 
             response.message = e.getMessage();

--- a/mapper/src/main/java/org/grnet/cat/mappers/ActorMapper.java
+++ b/mapper/src/main/java/org/grnet/cat/mappers/ActorMapper.java
@@ -1,0 +1,19 @@
+package org.grnet.cat.mappers;
+
+import org.grnet.cat.dtos.ActorDto;
+import org.grnet.cat.entities.Actor;
+import org.mapstruct.Mapper;
+import org.mapstruct.factory.Mappers;
+
+import java.util.List;
+
+/**
+ * The ActorMapper is responsible for mapping Actor entities to DTOs and vice versa.
+ */
+@Mapper
+public interface ActorMapper {
+
+    ActorMapper INSTANCE = Mappers.getMapper( ActorMapper.class );
+
+    List<ActorDto> actorsToDto(List<Actor> actors);
+}

--- a/mapper/src/main/java/org/grnet/cat/mappers/ValidationMapper.java
+++ b/mapper/src/main/java/org/grnet/cat/mappers/ValidationMapper.java
@@ -1,0 +1,28 @@
+package org.grnet.cat.mappers;
+
+import org.grnet.cat.dtos.ValidationResponse;
+import org.grnet.cat.entities.Validation;
+import org.mapstruct.IterableMapping;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.Named;
+import org.mapstruct.factory.Mappers;
+
+import java.util.List;
+
+/**
+ * The ValidationMapper is responsible for mapping Validation entities to DTOs and vice versa.
+ */
+@Mapper
+public interface ValidationMapper {
+
+    ValidationMapper INSTANCE = Mappers.getMapper( ValidationMapper.class );
+
+    @IterableMapping(qualifiedByName="mapWithExpression")
+    List<ValidationResponse> validationsToDto(List<Validation> validations);
+
+    @Named("mapWithExpression")
+    @Mapping(target = "actorId", expression = "java(validation.getActor().getId())")
+    ValidationResponse validationToDto(Validation validation);
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -35,6 +35,8 @@
     <jandex.version>1.2.3</jandex.version>
     <cat.version>1.0.0-SNAPSHOT</cat.version>
     <mapstruct.version>1.5.5.Final</mapstruct.version>
+    <apache.common3.version>3.12.0</apache.common3.version>
+    <vavr.version>0.10.4</vavr.version>
   </properties>
   <dependencyManagement>
     <dependencies>
@@ -105,6 +107,16 @@
         <groupId>org.mapstruct</groupId>
         <artifactId>mapstruct-processor</artifactId>
         <version>${mapstruct.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.commons</groupId>
+        <artifactId>commons-lang3</artifactId>
+        <version>${apache.common3.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.vavr</groupId>
+        <artifactId>vavr</artifactId>
+        <version>${vavr.version}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/repository/src/main/java/org/grnet/cat/repositories/ActorRepository.java
+++ b/repository/src/main/java/org/grnet/cat/repositories/ActorRepository.java
@@ -1,0 +1,26 @@
+package org.grnet.cat.repositories;
+
+import io.quarkus.hibernate.orm.panache.PanacheQuery;
+import io.quarkus.hibernate.orm.panache.PanacheRepositoryBase;
+import jakarta.enterprise.context.ApplicationScoped;
+import org.grnet.cat.entities.Actor;
+
+
+/**
+ * The ActorRepository interface provides data access methods for the Actor entity.
+ */
+@ApplicationScoped
+public class ActorRepository implements PanacheRepositoryBase<Actor, Long> {
+
+    /**
+     * Retrieves a page of from the database.
+     *
+     * @param page The index of the page to retrieve (starting from 0).
+     * @param size The maximum number of Actors to include in a page.
+     * @return A list of Actor objects representing the Actors in the requested page.
+     */
+    public PanacheQuery<Actor> fetchActorsByPage(int page, int size){
+
+        return findAll().page(page, size);
+    }
+}

--- a/repository/src/main/java/org/grnet/cat/repositories/ValidationRepository.java
+++ b/repository/src/main/java/org/grnet/cat/repositories/ValidationRepository.java
@@ -1,5 +1,6 @@
 package org.grnet.cat.repositories;
 
+import io.quarkus.hibernate.orm.panache.PanacheQuery;
 import io.quarkus.hibernate.orm.panache.PanacheRepositoryBase;
 import jakarta.enterprise.context.ApplicationScoped;
 import org.grnet.cat.entities.Validation;
@@ -21,12 +22,26 @@ public class ValidationRepository implements PanacheRepositoryBase<Validation, L
      * @param id The ID of the user.
      * @param organisationId The ID of the organisation.
      * @param organisationSource The source of the organisation.
+     * @param actorId The actor id.
      * @return {@code true} if a promotion request exists for the user and organization, {@code false} otherwise
      */
-    public boolean hasPromotionRequest(String id, String organisationId, String organisationSource){
+    public boolean hasPromotionRequest(String id, String organisationId, String organisationSource, Long actorId){
 
         List<ValidationStatus> statuses = Arrays.asList(ValidationStatus.REVIEW, ValidationStatus.APPROVED, ValidationStatus.PENDING);
 
-        return find("from Validation v where v.user.id = ?1 and v.organisationId = ?2 and v.organisationSource = ?3 and v.status IN (?4)", id, organisationId, Source.valueOf(organisationSource), statuses).stream().findAny().isPresent();
+        return find("from Validation v where v.user.id = ?1 and v.organisationId = ?2 and v.organisationSource = ?3 and v.status IN (?4) and v.actor.id = ?5", id, organisationId, Source.valueOf(organisationSource), statuses, actorId).stream().findAny().isPresent();
+    }
+
+    /**
+     * Retrieves a page of validation requests submitted by the specified user.
+     *
+     * @param page The index of the page to retrieve (starting from 0).
+     * @param size The maximum number of validation requests to include in a page.
+     * @param userID The ID of the user.
+     * @return A list of Validation objects representing the validation requests in the requested page.
+     */
+    public PanacheQuery<Validation> fetchValidationsByPage(int page, int size, String userID){
+
+        return find("from Validation v where v.user.id = ?1", userID).page(page, size);
     }
 }

--- a/service/src/main/java/org/grnet/cat/services/ActorService.java
+++ b/service/src/main/java/org/grnet/cat/services/ActorService.java
@@ -1,0 +1,39 @@
+package org.grnet.cat.services;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.core.UriInfo;
+import org.grnet.cat.dtos.ActorDto;
+import org.grnet.cat.dtos.pagination.PageResource;
+import org.grnet.cat.mappers.ActorMapper;
+import org.grnet.cat.repositories.ActorRepository;
+
+/**
+ * The ActorService provides operations for managing Actor entities.
+ */
+
+@ApplicationScoped
+public class ActorService {
+
+    /**
+     * Injection point for the User Repository
+     */
+    @Inject
+    ActorRepository actorRepository;
+
+
+    /**
+     * Retrieves a page of actors from the database.
+     *
+     * @param page The index of the page to retrieve (starting from 0).
+     * @param size The maximum number of actors to include in a page.
+     * @param uriInfo The Uri Info.
+     * @return A list of ActorDto objects representing the actors in the requested page.
+     */
+    public PageResource<ActorDto> getActorsByPage(int page, int size, UriInfo uriInfo){
+
+        var actors = actorRepository.fetchActorsByPage(page, size);
+
+        return new PageResource<>(actors, ActorMapper.INSTANCE.actorsToDto(actors.list()), uriInfo);
+    }
+}

--- a/service/src/main/java/org/grnet/cat/services/IdentifiedService.java
+++ b/service/src/main/java/org/grnet/cat/services/IdentifiedService.java
@@ -10,6 +10,7 @@ import org.grnet.cat.entities.Validation;
 import org.grnet.cat.enums.Source;
 import org.grnet.cat.enums.ValidationStatus;
 import org.grnet.cat.exceptions.ConflictException;
+import org.grnet.cat.repositories.ActorRepository;
 import org.grnet.cat.repositories.IdentifiedRepository;
 import org.grnet.cat.repositories.ValidationRepository;
 
@@ -28,6 +29,12 @@ public class IdentifiedService {
      */
     @Inject
     IdentifiedRepository identifiedRepository;
+
+    /**
+     * Injection point for the Actor Repository
+     */
+    @Inject
+    ActorRepository actorRepository;
 
     /**
      * Injection point for the Validation Service
@@ -67,9 +74,12 @@ public class IdentifiedService {
 
         var user = identifiedRepository.findById(id);
 
+        var actor = actorRepository.findById(promotionRequest.actorId);
+
         var validation = new Validation();
 
         validation.setUser(user);
+        validation.setActor(actor);
         validation.setCreatedOn(Timestamp.from(Instant.now()));
         validation.setStatus(ValidationStatus.REVIEW);
         validation.setOrganisationId(promotionRequest.organisationId);

--- a/service/src/main/java/org/grnet/cat/services/IntegrationService.java
+++ b/service/src/main/java/org/grnet/cat/services/IntegrationService.java
@@ -1,10 +1,6 @@
 package org.grnet.cat.services;
 
-import com.google.gson.JsonElement;
-import com.google.gson.JsonObject;
-import com.google.gson.JsonParser;
 import jakarta.enterprise.context.ApplicationScoped;
-import java.io.IOException;
 import java.util.Arrays;
 
 import java.util.List;
@@ -44,10 +40,9 @@ public class IntegrationService {
      * @return An Organisation sources.
      */
 
-    public OrganisationResponseDto getOrganisation(Source source, String id) throws IOException  {
+    public OrganisationResponseDto getOrganisation(Source source, String id){
         
-        String resp= source.connectHttpClient(id);
-        Organisation org=Organisation.buildFromString(resp);
-        return OrganisationMapper.INSTANCE.organisationToResponse(org);
+        var map= source.execute(id);
+        return OrganisationMapper.INSTANCE.organisationToResponse(new Organisation(map.get("id"), map.get("name"), map.get("website")));
   }
 }

--- a/service/src/main/java/org/grnet/cat/services/ValidationService.java
+++ b/service/src/main/java/org/grnet/cat/services/ValidationService.java
@@ -3,9 +3,13 @@ package org.grnet.cat.services;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import jakarta.transaction.Transactional;
+import jakarta.ws.rs.core.UriInfo;
 import org.grnet.cat.dtos.PromotionRequest;
+import org.grnet.cat.dtos.ValidationResponse;
+import org.grnet.cat.dtos.pagination.PageResource;
 import org.grnet.cat.entities.Validation;
 import org.grnet.cat.exceptions.ConflictException;
+import org.grnet.cat.mappers.ValidationMapper;
 import org.grnet.cat.repositories.ValidationRepository;
 
 /**
@@ -28,7 +32,7 @@ public class ValidationService {
     public void hasPromotionRequest(String userId, PromotionRequest request) {
 
         // Call the repository method to check if a promotion request exists
-        var exists = validationRepository.hasPromotionRequest(userId, request.organisationId, request.organisationSource);
+        var exists = validationRepository.hasPromotionRequest(userId, request.organisationId, request.organisationSource, request.actorId);
 
         if(exists){
             throw new ConflictException("There is a promotion request for this user and organisation.");
@@ -44,5 +48,21 @@ public class ValidationService {
     public void store(Validation validation){
 
         validationRepository.persist(validation);
+    }
+
+    /**
+     * Retrieves a page of validation requests submitted by the specified user.
+     *
+     * @param page The index of the page to retrieve (starting from 0).
+     * @param size The maximum number of validation requests to include in a page.
+     * @param uriInfo The Uri Info.
+     * @param userID The ID of the user.
+     * @return A list of PromotionResponse objects representing the submitted promotion requests in the requested page.
+     */
+    public PageResource<ValidationResponse> getValidationsByPage(int page, int size, UriInfo uriInfo, String userID){
+
+        var validations = validationRepository.fetchValidationsByPage(page, size, userID);
+
+        return new PageResource<>(validations, ValidationMapper.INSTANCE.validationsToDto(validations.list()), uriInfo);
     }
 }

--- a/validator/pom.xml
+++ b/validator/pom.xml
@@ -16,6 +16,22 @@
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-hibernate-validator</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-hibernate-orm-panache</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.grnet</groupId>
+            <artifactId>cat-exceptions</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.vavr</groupId>
+            <artifactId>vavr</artifactId>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/validator/src/main/java/org/grnet/cat/constraints/NotFoundEntity.java
+++ b/validator/src/main/java/org/grnet/cat/constraints/NotFoundEntity.java
@@ -1,0 +1,24 @@
+package org.grnet.cat.constraints;
+
+import io.quarkus.hibernate.orm.panache.PanacheRepositoryBase;
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+import org.grnet.cat.validators.NotFoundEntityValidator;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.FIELD, ElementType.PARAMETER, ElementType.TYPE_USE})
+@Retention(RetentionPolicy.RUNTIME)
+@Constraint(validatedBy = NotFoundEntityValidator.class)
+@Documented
+public @interface NotFoundEntity {
+
+    String message() default "Not founded:";
+    Class<?>[] groups() default {};
+    Class<? extends Payload>[] payload() default {};
+    Class<? extends PanacheRepositoryBase<?,?>> repository();
+}

--- a/validator/src/main/java/org/grnet/cat/validators/NotFoundEntityValidator.java
+++ b/validator/src/main/java/org/grnet/cat/validators/NotFoundEntityValidator.java
@@ -1,0 +1,52 @@
+package org.grnet.cat.validators;
+
+
+import io.quarkus.hibernate.orm.panache.PanacheRepositoryBase;
+import io.vavr.control.Try;
+import jakarta.enterprise.inject.spi.CDI;
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+import org.apache.commons.lang3.StringUtils;
+import org.grnet.cat.constraints.NotFoundEntity;
+import org.grnet.cat.exceptions.CustomValidationException;
+
+import java.util.Objects;
+
+/**
+ * This {@link NotFoundEntityValidator} defines the logic to validate the {@link NotFoundEntity}.
+ * Essentially, it checks if the given Entity exists in the database.
+ * If not exists, it throws a {@link CustomValidationException} with http status 404.
+ */
+public class NotFoundEntityValidator implements ConstraintValidator<NotFoundEntity, Object> {
+
+    private String message;
+    private Class<? extends PanacheRepositoryBase<?,?>> repository;
+
+    @Override
+    public void initialize(NotFoundEntity constraintAnnotation) {
+        this.message = constraintAnnotation.message();
+        this.repository = constraintAnnotation.repository();
+    }
+
+    @Override
+    public boolean isValid(Object value, ConstraintValidatorContext constraintValidatorContext) {
+        if(Objects.isNull(value)){
+            return true;
+        }
+
+        StringBuilder builder = new StringBuilder();
+
+        builder.append(message);
+        builder.append(StringUtils.SPACE);
+        builder.append(value);
+
+        PanacheRepositoryBase repository = CDI.current().select(this.repository).get();
+
+        Try
+                .run(()->repository.findByIdOptional(value).orElseThrow(()->new CustomValidationException(builder.toString(), 404)))
+                .getOrElseThrow(()->new CustomValidationException(builder.toString(), 404));
+
+        return true;
+    }
+
+}

--- a/validator/src/main/resources/application.properties
+++ b/validator/src/main/resources/application.properties
@@ -1,0 +1,2 @@
+# hibernate validator
+quarkus.hibernate-validator.fail-fast=true


### PR DESCRIPTION
This Pull Request adds a new API endpoint GET /v1//validations to retrieve the promotion requests submitted by a specific user. The endpoint allows users to track the status of their requests and take appropriate actions based on the response.

## Changes Made
- Added a new endpoint to handle GET requests for /v1/validations.
- Implemented the necessary service and repository methods to fetch the validation requests for the specified user.
- Updated the Swagger API documentation to include the new endpoint, including its purpose, input parameters, and expected response.
