### PR TITLE
[CAT-69] Implement API communication with Keycloak to change user role upon validation approval

### DIFF
--- a/api/config/quarkus-realm.json
+++ b/api/config/quarkus-realm.json
@@ -672,13 +672,17 @@
       ]
     },
     {
-      "id": "16fb473f-45e3-40bb-81bf-4c7f69b92ae2",
       "clientId": "admin-cli",
       "name": "${client_admin-cli}",
+      "description": "",
+      "rootUrl": "",
+      "adminUrl": "",
+      "baseUrl": "",
       "surrogateAuthRequired": false,
       "enabled": true,
       "alwaysDisplayInConsole": false,
       "clientAuthenticatorType": "client-secret",
+      "secret": "jzm0zlNllvrH4QqJ7dF330n7yNC7wA0b",
       "redirectUris": [],
       "webOrigins": [],
       "notBefore": 0,
@@ -687,14 +691,63 @@
       "standardFlowEnabled": false,
       "implicitFlowEnabled": false,
       "directAccessGrantsEnabled": true,
-      "serviceAccountsEnabled": false,
-      "publicClient": true,
+      "serviceAccountsEnabled": true,
+      "publicClient": false,
       "frontchannelLogout": false,
       "protocol": "openid-connect",
-      "attributes": {},
+      "attributes": {
+        "oidc.ciba.grant.enabled": "false",
+        "client.secret.creation.time": "1688466401",
+        "backchannel.logout.session.required": "true",
+        "post.logout.redirect.uris": "+",
+        "display.on.consent.screen": "false",
+        "oauth2.device.authorization.grant.enabled": "false",
+        "backchannel.logout.revoke.offline.tokens": "false"
+      },
       "authenticationFlowBindingOverrides": {},
       "fullScopeAllowed": false,
       "nodeReRegistrationTimeout": 0,
+      "protocolMappers": [
+        {
+          "name": "Client IP Address",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usersessionmodel-note-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.session.note": "clientAddress",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "clientAddress",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "name": "Client ID",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usersessionmodel-note-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.session.note": "clientId",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "clientId",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "name": "Client Host",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usersessionmodel-note-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.session.note": "clientHost",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "clientHost",
+            "jsonType.label": "String"
+          }
+        }
+      ],
       "defaultClientScopes": [
         "web-origins",
         "acr",
@@ -707,7 +760,12 @@
         "phone",
         "offline_access",
         "microprofile-jwt"
-      ]
+      ],
+      "access": {
+        "view": true,
+        "configure": true,
+        "manage": true
+      }
     },
     {
       "id": "371a2b90-ebb3-4255-9d2e-bc3949d5bd2a",
@@ -831,7 +889,7 @@
         "offline_access",
         "microprofile-jwt"
       ],
-      "authorizationSettings": {
+      "authorizationSettings":{
         "allowRemoteResourceManagement": true,
         "policyEnforcementMode": "ENFORCING",
         "resources": [
@@ -932,6 +990,22 @@
               }
             ],
             "icon_uri": ""
+          },
+          {
+            "name": "Role Resource",
+            "ownerManagedAccess": false,
+            "displayName": "",
+            "attributes": {},
+            "_id": "afc4b539-eedb-4752-b514-aa51cfda6905",
+            "uris": [
+              "/v1/roles/*"
+            ],
+            "scopes": [
+              {
+                "name": "read"
+              }
+            ],
+            "icon_uri": ""
           }
         ],
         "policies": [
@@ -1007,11 +1081,12 @@
           {
             "id": "60188298-d55b-4066-b231-6a7c56ff7cc5",
             "name": "Administration Resource Permission",
+            "description": "",
             "type": "resource",
             "logic": "POSITIVE",
             "decisionStrategy": "UNANIMOUS",
             "config": {
-              "resources": "[\"Administration Resource\"]",
+              "resources": "[\"Role Resource\",\"Administration Resource\"]",
               "applyPolicies": "[\"Only Administrators\"]"
             }
           },
@@ -2632,6 +2707,15 @@
   },
   "users": [
     {
+      "id": "21bcf607-c3a2-45a4-993e-0314f57fb906",
+      "username": "service-account-admin-cli",
+      "enabled": true,
+      "serviceAccountClientId": "admin-cli",
+      "clientRoles": {
+        "realm-management": ["manage-users", "manage-clients"]
+      }
+    },
+    {
       "id": "af134cab-f41c-4675-b141-205f975db679",
       "username": "admin",
       "enabled": true,
@@ -2711,6 +2795,9 @@
     {
       "username": "identified",
       "enabled": true,
+      "attributes": {
+        "voperson_id": ["identified_voperson_id"]
+      },
       "credentials": [
         {
           "type": "password",
@@ -2726,6 +2813,9 @@
     {
       "username": "bob",
       "enabled": true,
+      "attributes": {
+        "voperson_id": ["bob_voperson_id"]
+      },
       "credentials": [
         {
           "type": "password",
@@ -2741,6 +2831,9 @@
     {
       "username": "validated",
       "enabled": true,
+      "attributes": {
+        "voperson_id": ["validated_voperson_id"]
+      },
       "credentials": [
         {
           "type": "password",

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -63,17 +63,14 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>io.rest-assured</groupId>
-            <artifactId>rest-assured</artifactId>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit5-mockito</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-rest-client-reactive</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-rest-client-reactive-jackson</artifactId>
+            <groupId>io.rest-assured</groupId>
+            <artifactId>rest-assured</artifactId>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 <build>

--- a/api/src/main/java/org/grnet/cat/api/endpoints/RolesEndpoint.java
+++ b/api/src/main/java/org/grnet/cat/api/endpoints/RolesEndpoint.java
@@ -1,0 +1,105 @@
+package org.grnet.cat.api.endpoints;
+
+import io.quarkus.security.Authenticated;
+import jakarta.inject.Inject;
+import jakarta.inject.Named;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.ws.rs.DefaultValue;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.core.Context;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.UriInfo;
+import org.eclipse.microprofile.openapi.annotations.Operation;
+import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
+import org.eclipse.microprofile.openapi.annotations.media.Content;
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
+import org.eclipse.microprofile.openapi.annotations.parameters.Parameter;
+import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
+import org.eclipse.microprofile.openapi.annotations.security.SecurityRequirement;
+import org.eclipse.microprofile.openapi.annotations.tags.Tag;
+import org.grnet.cat.api.filters.Registration;
+import org.grnet.cat.dtos.InformativeResponse;
+import org.grnet.cat.dtos.RoleDto;
+import org.grnet.cat.dtos.pagination.PageResource;
+import org.grnet.cat.services.RoleService;
+
+import java.util.List;
+
+import static org.eclipse.microprofile.openapi.annotations.enums.ParameterIn.QUERY;
+
+@Path("/v1/roles")
+@Authenticated
+public class RolesEndpoint {
+
+    /**
+     * Injection point for the keycloakAdminConnection
+     */
+    @Inject
+    @Named("keycloak-service")
+    RoleService roleService;
+
+    @Tag(name = "Roles")
+    @Operation(
+            summary = "Retrieve available roles for the cat service.",
+            description = "This endpoint Retrieves the list of available roles for the service. " +
+                    " By default, the first page of 10 Roles will be returned. You can tune the default values by using the query parameters page and size.")
+    @APIResponse(
+            responseCode = "200",
+            description = "List of Roles.",
+            content = @Content(schema = @Schema(
+                    type = SchemaType.OBJECT,
+                    implementation = PageableRole.class)))
+    @APIResponse(
+            responseCode = "401",
+            description = "User has not been authenticated.",
+            content = @Content(schema = @Schema(
+                    type = SchemaType.OBJECT,
+                    implementation = InformativeResponse.class)))
+    @APIResponse(
+            responseCode = "403",
+            description = "Not permitted.",
+            content = @Content(schema = @Schema(
+                    type = SchemaType.OBJECT,
+                    implementation = InformativeResponse.class)))
+    @APIResponse(
+            responseCode = "500",
+            description = "Internal Server Error.",
+            content = @Content(schema = @Schema(
+                    type = SchemaType.OBJECT,
+                    implementation = InformativeResponse.class)))
+    @SecurityRequirement(name = "Authentication")
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    @Registration
+    public Response actorsByPage(@Parameter(name = "page", in = QUERY,
+            description = "Indicates the page number. Page number must be >= 1.") @DefaultValue("1") @Min(value = 1, message = "Page number must be >= 1.") @QueryParam("page") int page,
+                                 @Parameter(name = "size", in = QUERY,
+                                         description = "The page size.") @DefaultValue("10") @Min(value = 1, message = "Page size must be between 1 and 100.")
+                                 @Max(value = 100, message = "Page size must be between 1 and 100.") @QueryParam("size") int size,
+                                 @Context UriInfo uriInfo) {
+
+        var roles = roleService.getRolesByPage(page-1, size, uriInfo);
+
+        return Response.ok().entity(roles).build();
+    }
+
+    public static class PageableRole extends PageResource<RoleDto> {
+
+        private List<RoleDto> content;
+
+        @Override
+        public List<RoleDto> getContent() {
+            return content;
+        }
+
+        @Override
+        public void setContent(List<RoleDto> content) {
+            this.content = content;
+        }
+    }
+}

--- a/api/src/main/resources/application.properties
+++ b/api/src/main/resources/application.properties
@@ -26,9 +26,7 @@ quarkus.keycloak.devservices.realm-path=quarkus-realm.json
 
 quarkus.keycloak.devservices.port=58080
 
-%prod.oidc.user.unique.id=voperson_id
-%dev.oidc.user.unique.id=sub
-%test.oidc.user.unique.id=sub
+oidc.user.unique.id=voperson_id
 
 # open api
 quarkus.smallrye-openapi.path=/open-api

--- a/api/src/test/java/org/grnet/cat/api/IntegrationsEndpointTest.java
+++ b/api/src/test/java/org/grnet/cat/api/IntegrationsEndpointTest.java
@@ -3,7 +3,6 @@ package org.grnet.cat.api;
 import io.quarkus.test.common.http.TestHTTPEndpoint;
 import io.quarkus.test.junit.QuarkusTest;
 import static io.restassured.RestAssured.given;
-import jakarta.inject.Inject;
 import org.grnet.cat.api.endpoints.IntegrationsEndpoint;
 import org.grnet.cat.dtos.InformativeResponse;
 import org.grnet.cat.dtos.OrganisationResponseDto;
@@ -11,24 +10,11 @@ import org.grnet.cat.dtos.SourceResponseDto;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.grnet.cat.dtos.pagination.PageResource;
-import org.grnet.cat.services.UserService;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-
-import java.util.List;
 
 @QuarkusTest
 @TestHTTPEndpoint(IntegrationsEndpoint.class)
 public class IntegrationsEndpointTest extends KeycloakTest {
-
-    @Inject
-    UserService userService;
-
-    @BeforeEach
-    public void setup(){
-
-        userService.deleteAll();
-    }
 
     @Test
     public void fetchAllIntegrationSources() {

--- a/api/src/test/java/org/grnet/cat/api/KeycloakTest.java
+++ b/api/src/test/java/org/grnet/cat/api/KeycloakTest.java
@@ -1,13 +1,33 @@
 package org.grnet.cat.api;
 
+import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.keycloak.client.KeycloakTestClient;
+import jakarta.inject.Inject;
 import org.grnet.cat.dtos.InformativeResponse;
+import org.grnet.cat.services.UserService;
+import org.grnet.cat.services.ValidationService;
+import org.junit.jupiter.api.BeforeEach;
 
 import static io.restassured.RestAssured.given;
 
+@QuarkusTest
 public class KeycloakTest {
 
     KeycloakTestClient keycloakClient = new KeycloakTestClient();
+
+    @Inject
+    UserService userService;
+
+    @Inject
+    ValidationService validationService;
+
+    @BeforeEach
+    public void setup(){
+
+        validationService.deleteAll();
+        userService.deleteAll();
+    }
+
 
     protected InformativeResponse register(String username){
 

--- a/api/src/test/java/org/grnet/cat/api/UsersEndpointTest.java
+++ b/api/src/test/java/org/grnet/cat/api/UsersEndpointTest.java
@@ -8,26 +8,14 @@ import org.grnet.cat.dtos.InformativeResponse;
 import org.grnet.cat.dtos.UpdateUserProfileDto;
 import org.grnet.cat.dtos.UserProfileDto;
 import org.grnet.cat.dtos.pagination.PageResource;
-import org.grnet.cat.services.UserService;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import static io.restassured.RestAssured.given;
-import jakarta.inject.Inject;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @QuarkusTest
 @TestHTTPEndpoint(UsersEndpoint.class)
 public class UsersEndpointTest extends KeycloakTest {
-
-    @Inject
-    UserService userService;
-
-    @BeforeEach
-    public void setup(){
-
-        userService.deleteAll();
-    }
 
     @Test
     public void unauthorizedUser(){

--- a/api/src/test/java/org/grnet/cat/api/ValidationsEndpointTest.java
+++ b/api/src/test/java/org/grnet/cat/api/ValidationsEndpointTest.java
@@ -2,38 +2,28 @@ package org.grnet.cat.api;
 
 import io.quarkus.test.common.http.TestHTTPEndpoint;
 import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.mockito.InjectMock;
 import io.restassured.http.ContentType;
-import jakarta.inject.Inject;
 import org.grnet.cat.api.endpoints.ValidationsEndpoint;
 import org.grnet.cat.dtos.InformativeResponse;
 import org.grnet.cat.dtos.UpdateValidationStatus;
 import org.grnet.cat.dtos.ValidationRequest;
 import org.grnet.cat.dtos.ValidationResponse;
-import org.grnet.cat.services.UserService;
-import org.grnet.cat.services.ValidationService;
-import org.junit.jupiter.api.BeforeEach;
+import org.grnet.cat.services.KeycloakAdminRoleService;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 
 import static io.restassured.RestAssured.given;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doNothing;
 
 @QuarkusTest
 @TestHTTPEndpoint(ValidationsEndpoint.class)
 public class ValidationsEndpointTest extends KeycloakTest {
 
-    @Inject
-    ValidationService validationService;
-
-    @Inject
-    UserService userService;
-
-
-    @BeforeEach
-    public void setUp(){
-
-        validationService.deleteAll();
-        userService.deleteAll();
-    }
+    @InjectMock
+    KeycloakAdminRoleService keycloakAdminRoleService;
 
     @Test
     public void validationRequestBodyIsEmpty() {
@@ -415,6 +405,8 @@ public class ValidationsEndpointTest extends KeycloakTest {
 
     @Test
     public void updateValidationRequestStatusByAdmin() {
+
+        doNothing().when(keycloakAdminRoleService).addRoleToUser(any(), any());
 
         register("alice");
         register("admin");

--- a/data-transfer-object/src/main/java/org/grnet/cat/dtos/RoleDto.java
+++ b/data-transfer-object/src/main/java/org/grnet/cat/dtos/RoleDto.java
@@ -1,0 +1,39 @@
+package org.grnet.cat.dtos;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
+
+@Schema(name="Role", description="This object represents a Role.")
+public class RoleDto {
+
+    @Schema(
+            type = SchemaType.STRING,
+            implementation = String.class,
+            description = "The unique identifier of the role.",
+            example = "identifier"
+    )
+    @JsonProperty("id")
+    public String id;
+
+
+    @Schema(
+            type = SchemaType.STRING,
+            implementation = String.class,
+            description = "The name of the role.",
+            example = "identifier"
+    )
+    @JsonProperty("name")
+    public String name;
+
+    @Schema(
+            type = SchemaType.STRING,
+            implementation = String.class,
+            description = "The description of the role.",
+            example = "The identified role."
+    )
+    @JsonProperty("description")
+    public String description;
+
+
+}

--- a/entity/src/main/java/org/grnet/cat/entities/ListQuery.java
+++ b/entity/src/main/java/org/grnet/cat/entities/ListQuery.java
@@ -72,7 +72,7 @@ public class ListQuery<Entity> implements PanacheQuery<Entity> {
     public int pageCount() {
 
         long count = this.count;
-        return count == 0L ? 1 : (int)Math.ceil((double)count / (double)this.size);
+        return count == 0L ? 1 : (int) Math.ceil((double) count / (double) this.size);
     }
 
     @Override

--- a/entity/src/main/java/org/grnet/cat/entities/Role.java
+++ b/entity/src/main/java/org/grnet/cat/entities/Role.java
@@ -1,0 +1,38 @@
+package org.grnet.cat.entities;
+
+public class Role {
+
+    private String id;
+    private String name;
+    private String description;
+
+    public Role(String id, String name, String description) {
+        this.id = id;
+        this.name = name;
+        this.description = description;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+}

--- a/handler/src/main/java/org/grnet/cat/handlers/exception/AuthenticationExceptionHandler.java
+++ b/handler/src/main/java/org/grnet/cat/handlers/exception/AuthenticationExceptionHandler.java
@@ -5,12 +5,17 @@ import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.ext.ExceptionMapper;
 import jakarta.ws.rs.ext.Provider;
 import org.grnet.cat.dtos.InformativeResponse;
+import org.jboss.logging.Logger;
 
 @Provider
 public class AuthenticationExceptionHandler implements ExceptionMapper<AuthenticationFailedException> {
 
+    private static final Logger LOG = Logger.getLogger(AuthenticationExceptionHandler.class);
+
     @Override
     public Response toResponse(AuthenticationFailedException e) {
+
+        LOG.error("Authentication Error", e);
 
         var response = new InformativeResponse();
         response.code = 401;

--- a/handler/src/main/java/org/grnet/cat/handlers/exception/AuthorizationForbiddenExceptionHandler.java
+++ b/handler/src/main/java/org/grnet/cat/handlers/exception/AuthorizationForbiddenExceptionHandler.java
@@ -5,12 +5,17 @@ import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.ext.ExceptionMapper;
 import jakarta.ws.rs.ext.Provider;
 import org.grnet.cat.dtos.InformativeResponse;
+import org.jboss.logging.Logger;
 
 @Provider
 public class AuthorizationForbiddenExceptionHandler implements ExceptionMapper<ForbiddenException> {
 
+    private static final Logger LOG = Logger.getLogger(AuthorizationForbiddenExceptionHandler.class);
+
     @Override
     public Response toResponse(ForbiddenException e) {
+
+        LOG.error("Authorization Error", e);
 
         var response = new InformativeResponse();
         response.code = 403;

--- a/handler/src/main/java/org/grnet/cat/handlers/exception/ClientErrorExceptionHandler.java
+++ b/handler/src/main/java/org/grnet/cat/handlers/exception/ClientErrorExceptionHandler.java
@@ -6,12 +6,17 @@ import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.ext.ExceptionMapper;
 import jakarta.ws.rs.ext.Provider;
 import org.grnet.cat.dtos.InformativeResponse;
+import org.jboss.logging.Logger;
 
 @Provider
 public class ClientErrorExceptionHandler implements ExceptionMapper<ClientErrorException> {
 
+    private static final Logger LOG = Logger.getLogger(ClientErrorExceptionHandler.class);
+
     @Override
     public Response toResponse(ClientErrorException e) {
+
+        LOG.error("Client Error", e);
 
         var response = new InformativeResponse();
         response.message = e.getMessage();

--- a/handler/src/main/java/org/grnet/cat/handlers/exception/ExceptionHandler.java
+++ b/handler/src/main/java/org/grnet/cat/handlers/exception/ExceptionHandler.java
@@ -4,13 +4,17 @@ import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.ext.ExceptionMapper;
 import jakarta.ws.rs.ext.Provider;
 import org.grnet.cat.dtos.InformativeResponse;
+import org.jboss.logging.Logger;
 
 @Provider
 public class ExceptionHandler implements ExceptionMapper<Exception> {
 
+    private static final Logger LOG = Logger.getLogger(ExceptionHandler.class);
 
     @Override
     public Response toResponse(Exception e) {
+
+        LOG.error("Internal Server Error", e);
 
         var response = new InformativeResponse();
         response.message = e.getMessage();

--- a/handler/src/main/java/org/grnet/cat/handlers/exception/ServerErrorExceptionHandler.java
+++ b/handler/src/main/java/org/grnet/cat/handlers/exception/ServerErrorExceptionHandler.java
@@ -6,12 +6,18 @@ import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.ext.ExceptionMapper;
 import jakarta.ws.rs.ext.Provider;
 import org.grnet.cat.dtos.InformativeResponse;
+import org.jboss.logging.Logger;
 
 @Provider
 public class ServerErrorExceptionHandler implements ExceptionMapper<ServerErrorException> {
 
+    private static final Logger LOG = Logger.getLogger(ServerErrorExceptionHandler.class);
+
     @Override
     public Response toResponse(ServerErrorException e) {
+
+        LOG.error("Server Error", e);
+
         var response = new InformativeResponse();
         response.message = e.getMessage();
         response.code = e.getResponse().getStatus();

--- a/handler/src/main/java/org/grnet/cat/handlers/exception/ValidationExceptionHandler.java
+++ b/handler/src/main/java/org/grnet/cat/handlers/exception/ValidationExceptionHandler.java
@@ -7,13 +7,17 @@ import jakarta.ws.rs.ext.ExceptionMapper;
 import jakarta.ws.rs.ext.Provider;
 import org.grnet.cat.dtos.InformativeResponse;
 import org.grnet.cat.exceptions.CustomValidationException;
+import org.jboss.logging.Logger;
 
 @Provider
 public class ValidationExceptionHandler implements ExceptionMapper<ValidationException> {
 
+    private static final Logger LOG = Logger.getLogger(ValidationExceptionHandler.class);
+
     @Override
     public Response toResponse(ValidationException e) {
 
+        LOG.error("Validation Error", e);
 
         InformativeResponse response = new InformativeResponse();
 

--- a/mapper/src/main/java/org/grnet/cat/mappers/RoleMapper.java
+++ b/mapper/src/main/java/org/grnet/cat/mappers/RoleMapper.java
@@ -1,0 +1,19 @@
+package org.grnet.cat.mappers;
+
+import org.grnet.cat.dtos.RoleDto;
+import org.grnet.cat.entities.Role;
+import org.mapstruct.Mapper;
+import org.mapstruct.factory.Mappers;
+
+import java.util.List;
+
+/**
+ * The ActorMapper is responsible for mapping Role entities to DTOs and vice versa.
+ */
+@Mapper
+public interface RoleMapper {
+
+    RoleMapper INSTANCE = Mappers.getMapper(RoleMapper.class );
+
+    List<RoleDto> rolesToDto(List<Role> roles);
+}

--- a/pom.xml
+++ b/pom.xml
@@ -37,6 +37,7 @@
     <mapstruct.version>1.5.5.Final</mapstruct.version>
     <apache.common3.version>3.12.0</apache.common3.version>
     <vavr.version>0.10.4</vavr.version>
+    <pivovarit.version>1.5.1</pivovarit.version>
   </properties>
   <dependencyManagement>
     <dependencies>
@@ -117,6 +118,11 @@
         <groupId>io.vavr</groupId>
         <artifactId>vavr</artifactId>
         <version>${vavr.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.pivovarit</groupId>
+        <artifactId>throwing-function</artifactId>
+        <version>${pivovarit.version}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/repository/pom.xml
+++ b/repository/pom.xml
@@ -20,6 +20,10 @@
             <groupId>org.grnet</groupId>
             <artifactId>cat-entities</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-keycloak-admin-client-reactive</artifactId>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/repository/src/main/java/org/grnet/cat/repositories/KeycloakAdminRepository.java
+++ b/repository/src/main/java/org/grnet/cat/repositories/KeycloakAdminRepository.java
@@ -1,0 +1,140 @@
+package org.grnet.cat.repositories;
+
+import io.quarkus.hibernate.orm.panache.PanacheQuery;
+import io.quarkus.panache.common.Page;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.inject.Named;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.grnet.cat.entities.ListQuery;
+import org.grnet.cat.entities.Role;
+import org.grnet.cat.exceptions.EntityNotFoundException;
+import org.keycloak.admin.client.Keycloak;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+/**
+ * The KeycloakAdminRepository class provides methods to connect and interact with the Keycloak admin API.
+ */
+@ApplicationScoped
+@Named("keycloak-repository")
+public class KeycloakAdminRepository implements RoleRepository{
+
+    @ConfigProperty(name = "quarkus.oidc.client-id")
+    String clientId;
+
+    /**
+     * Injection point for the Keycloak admin client
+     */
+    @Inject
+    Keycloak keycloak;
+
+    @ConfigProperty(name = "quarkus.keycloak.admin-client.realm")
+    String realm;
+
+    @ConfigProperty(name = "keycloak.admin-client.search.user.by.attribute")
+    String attribute;
+
+    /**
+     * This method retrieves all the available roles for a specific realm and client ID.
+     * @return A list of Role objects representing the available roles.
+     */
+    @Override
+    public List<Role> fetchRoles() {
+
+        var realmResource = keycloak.realm(realm);
+
+        var clientRepresentation = realmResource.clients().findByClientId(clientId).stream().findFirst().get();
+
+        var clientResource = realmResource.clients().get(clientRepresentation.getId());
+
+        var roleRepresentations = clientResource.roles().list();
+
+        return roleRepresentations
+                .stream()
+                .filter(roleRepresentation -> !roleRepresentation.getName().equals("uma_protection"))
+                .map(roleRepresentation -> new Role(roleRepresentation.getId(), roleRepresentation.getName(), roleRepresentation.getDescription()))
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * Retrieves a page of roles from the keycloak.
+     *
+     * @param page The index of the page to retrieve (starting from 0).
+     * @param size The maximum number of roles to include in a page.
+     * @return A list of Role objects representing the roles in the requested page.
+     */
+    @Override
+    public PanacheQuery<Role> fetchRolesByPage(int page, int size) {
+
+        var allRoles = fetchRoles();
+
+        var partition = partition(allRoles, size);
+
+        var roles = partition.get(page) == null ? Collections.EMPTY_LIST : partition.get(page);
+
+        var pageable = new ListQuery<Role>();
+
+        pageable.list = roles;
+        pageable.index = page;
+        pageable.size = size;
+        pageable.count = allRoles.size();
+        pageable.page = Page.of(page, size);
+
+        return pageable;
+    }
+
+    @Override
+    public void addRoleToUser(String role, String userId){
+
+        try{
+
+            var realmResource = keycloak.realm(realm);
+
+            var clientRepresentation = realmResource.clients().findByClientId(clientId).stream().findFirst().get();
+
+            var clientResource = realmResource.clients().get(clientRepresentation.getId());
+
+            var usersResource = realmResource.users();
+
+            var userRepresentation = realmResource.users().searchByAttributes(String.format("%s:%s", attribute, userId)).stream().findFirst().get();
+
+            var userResource = usersResource.get(userRepresentation.getId());
+
+            // Get client level role
+            var userClientRole = clientResource.roles().get(role).toRepresentation();
+
+            // Assign client level role to user
+            userResource.roles().clientLevel(clientRepresentation.getId()).add(Collections.singletonList(userClientRole));
+
+        } catch (Exception e){
+
+            throw new RuntimeException("Cannot communicate with keycloak.");
+        }
+    }
+
+    @Override
+    public Optional<Role> findRoleByName(String name) {
+
+        return fetchRoles()
+                .stream()
+                .filter(role->role.getName().equals(name))
+                .findFirst();
+               // .orElseThrow(()-> new EntityNotFoundException("Role "+name+" doesn't exist."));
+    }
+
+    /**
+     * Checks if a role exists by searching for the role with the given name.
+     *
+     * @param name the name of the role to search for
+     * @throws EntityNotFoundException if the role with the specified name is not found.
+     */
+    @Override
+    public void doesRoleExist(String name) {
+
+        findRoleByName(name).orElseThrow(()->new EntityNotFoundException(String.format("The role {%s} is not found.", name)));
+    }
+}

--- a/repository/src/main/java/org/grnet/cat/repositories/RoleRepository.java
+++ b/repository/src/main/java/org/grnet/cat/repositories/RoleRepository.java
@@ -1,0 +1,71 @@
+package org.grnet.cat.repositories;
+
+import io.quarkus.hibernate.orm.panache.PanacheQuery;
+import org.grnet.cat.entities.Role;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.IntStream;
+
+import static java.lang.Math.min;
+import static java.util.stream.Collectors.toMap;
+
+/**
+ * The RoleRepository interface provides data access methods for the Role entity.
+ */
+public interface RoleRepository {
+
+    /**
+     * This method retrieves all the available roles.
+     * @return A list of Role objects representing the available roles.
+     */
+    List<Role> fetchRoles();
+
+    /**
+     * Retrieves a page of roles.
+     *
+     * @param page The index of the page to retrieve (starting from 0).
+     * @param size The maximum number of roles to include in a page.
+     * @return A list of Role objects representing the roles in the requested page.
+     */
+    PanacheQuery<Role> fetchRolesByPage(int page, int size);
+
+    /**
+     * Adds a given role to a specified user ID.
+     * @param role The role to be added.
+     * @param userId The identifier of the user.
+     */
+    void addRoleToUser(String role, String userId);
+
+    /**
+     * Searches for a role by its name.
+     *
+     * @param name the name of the role to search for
+     * @return the Role object if found, or empty object if not found
+     */
+    Optional<Role> findRoleByName(String name);
+
+    /**
+     * Checks if a role exists by searching for the role with the given name.
+     *
+     * @param name the name of the role to search for
+     */
+    void doesRoleExist(String name);
+
+    /**
+     * This method paginates a list of objects.
+     *
+     * @param list The list to be paginated.
+     * @param pageSize The page size.
+     * @return A map containing the pages of objects.
+     */
+    default <T> Map<Integer, List<T>> partition(List<T> list, int pageSize) {
+
+        return IntStream.iterate(0, i -> i + pageSize)
+                .limit((list.size() + pageSize - 1) / pageSize)
+                .boxed()
+                .collect(toMap(i -> i / pageSize,
+                        i -> list.subList(i, min(i + pageSize, list.size()))));
+    }
+}

--- a/repository/src/main/resources/application.properties
+++ b/repository/src/main/resources/application.properties
@@ -1,0 +1,25 @@
+# keycloak admin cli
+quarkus.keycloak.admin-client.enabled=true
+
+%prod.quarkus.keycloak.admin-client.server-url=https://login-devel.einfra.grnet.gr/auth
+%prod.quarkus.keycloak.admin-client.realm=einfra
+%prod.quarkus.keycloak.admin-client.client-id=admin-cli
+%prod.quarkus.keycloak.admin-client.client-secret=secret
+%prod.quarkus.keycloak.admin-client.grant-type=CLIENT_CREDENTIALS
+%prod.keycloak.admin-client.search.user.by.attribute=voPersonID
+
+%dev.quarkus.keycloak.admin-client.server-url=http://localhost:58080
+%dev.quarkus.keycloak.admin-client.realm=quarkus
+%dev.quarkus.keycloak.admin-client.client-id=admin-cli
+%dev.quarkus.keycloak.admin-client.client-secret=jzm0zlNllvrH4QqJ7dF330n7yNC7wA0b
+%dev.quarkus.keycloak.admin-client.grant-type=CLIENT_CREDENTIALS
+%dev.keycloak.admin-client.search.user.by.attribute=voperson_id
+
+%test.quarkus.keycloak.admin-client.server-url=http://localhost:58080
+%test.quarkus.keycloak.admin-client.realm=quarkus
+%test.quarkus.keycloak.admin-client.client-id=admin-cli
+%test.quarkus.keycloak.admin-client.client-secret=jzm0zlNllvrH4QqJ7dF330n7yNC7wA0b
+%test.quarkus.keycloak.admin-client.grant-type=CLIENT_CREDENTIALS
+%test.keycloak.admin-client.search.user.by.attribute=voperson_id
+
+

--- a/service/pom.xml
+++ b/service/pom.xml
@@ -24,6 +24,10 @@
             <groupId>org.grnet</groupId>
             <artifactId>cat-mappers</artifactId>
         </dependency>
+        <dependency>
+            <groupId>com.pivovarit</groupId>
+            <artifactId>throwing-function</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/service/src/main/java/org/grnet/cat/services/KeycloakAdminRoleService.java
+++ b/service/src/main/java/org/grnet/cat/services/KeycloakAdminRoleService.java
@@ -1,0 +1,48 @@
+package org.grnet.cat.services;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.inject.Named;
+import jakarta.ws.rs.core.UriInfo;
+import org.grnet.cat.dtos.RoleDto;
+import org.grnet.cat.dtos.pagination.PageResource;
+import org.grnet.cat.mappers.RoleMapper;
+import org.grnet.cat.repositories.RoleRepository;
+
+/**
+ * The KeycloakAdminRoleService class provides methods to connect and interact with the Keycloak admin API.
+ */
+@ApplicationScoped
+@Named("keycloak-service")
+public class KeycloakAdminRoleService implements RoleService {
+
+    @Inject
+    @Named("keycloak-repository")
+    RoleRepository roleRepository;
+
+    /**
+     * Retrieves a page of roles from the keycloak.
+     *
+     * @param page The index of the page to retrieve (starting from 0).
+     * @param size The maximum number of roles to include in a page.
+     * @param uriInfo The Uri Info.
+     * @return A list of Role objects representing the roles in the requested page.
+     */
+    public PageResource<RoleDto> getRolesByPage(int page, int size, UriInfo uriInfo){
+
+        var roles = roleRepository.fetchRolesByPage(page, size);
+
+        return new PageResource<>(roles, RoleMapper.INSTANCE.rolesToDto(roles.list()), uriInfo);
+    }
+
+    /**
+     * Adds a given role to a specified user ID.
+     * @param role The role to be added.
+     * @param userId The identifier of the user.
+     */
+    public void addRoleToUser(String role, String userId){
+
+        roleRepository.doesRoleExist(role);
+        roleRepository.addRoleToUser(role, userId);
+    }
+}

--- a/service/src/main/java/org/grnet/cat/services/RoleService.java
+++ b/service/src/main/java/org/grnet/cat/services/RoleService.java
@@ -1,0 +1,12 @@
+package org.grnet.cat.services;
+
+import jakarta.ws.rs.core.UriInfo;
+import org.grnet.cat.dtos.RoleDto;
+import org.grnet.cat.dtos.pagination.PageResource;
+
+public interface RoleService {
+
+    PageResource<RoleDto> getRolesByPage(int page, int size, UriInfo uriInfo);
+
+    void addRoleToUser(String userId, String role);
+}


### PR DESCRIPTION
This Pull Request introduces the necessary changes to enable API communication with Keycloak. The goal is to automatically update the user role to "validated" upon admin validation approval.

## Changes Made:

- Integrated Keycloak Admin-CLI API
- Implemented the code to send the appropriate request to Keycloak, specifying the user's unique identifier and the new role.
