### PR TITLE
[CAT-70] Implement API Endpoints for Validation Requests

### DIFF
--- a/api/src/main/java/org/grnet/cat/api/endpoints/AdminValidationsEndpoint.java
+++ b/api/src/main/java/org/grnet/cat/api/endpoints/AdminValidationsEndpoint.java
@@ -214,4 +214,49 @@ public class AdminValidationsEndpoint {
 
         return Response.ok().entity(response).build();
     }
+
+    @Tag(name = "Admin")
+    @Operation(
+            summary = "Get Validation Request.",
+            description = "Returns a specific validation request.")
+    @APIResponse(
+            responseCode = "200",
+            description = "The corresponding validation request.",
+            content = @Content(schema = @Schema(
+                    type = SchemaType.OBJECT,
+                    implementation = ValidationResponse.class)))
+    @APIResponse(
+            responseCode = "401",
+            description = "User has not been authenticated.",
+            content = @Content(schema = @Schema(
+                    type = SchemaType.OBJECT,
+                    implementation = InformativeResponse.class)))
+    @APIResponse(
+            responseCode = "403",
+            description = "Not permitted.",
+            content = @Content(schema = @Schema(
+                    type = SchemaType.OBJECT,
+                    implementation = InformativeResponse.class)))
+    @APIResponse(
+            responseCode = "500",
+            description = "Internal Server Error.",
+            content = @Content(schema = @Schema(
+                    type = SchemaType.OBJECT,
+                    implementation = InformativeResponse.class)))
+    @SecurityRequirement(name = "Authentication")
+    @GET
+    @Path("/{id}")
+    @Produces(MediaType.APPLICATION_JSON)
+    @Registration
+    public Response getValidationRequest(@Parameter(
+            description = "The ID of the validation request to retrieve.",
+            required = true,
+            example = "1",
+            schema = @Schema(type = SchemaType.NUMBER)) @PathParam("id")
+                                         @Valid @NotFoundEntity(repository = ValidationRepository.class, message = "There is no Validation with the following id:") Long id) {
+
+        var validations = validationService.getValidationRequest(id);
+
+        return Response.ok().entity(validations).build();
+    }
 }

--- a/api/src/main/java/org/grnet/cat/api/endpoints/ValidationsEndpoint.java
+++ b/api/src/main/java/org/grnet/cat/api/endpoints/ValidationsEndpoint.java
@@ -10,6 +10,7 @@ import jakarta.ws.rs.DefaultValue;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.QueryParam;
 import jakarta.ws.rs.core.Context;
@@ -26,11 +27,13 @@ import org.eclipse.microprofile.openapi.annotations.security.SecurityRequirement
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
 import org.grnet.cat.api.filters.Registration;
 import org.grnet.cat.api.utils.Utility;
+import org.grnet.cat.constraints.NotFoundEntity;
 import org.grnet.cat.dtos.InformativeResponse;
 import org.grnet.cat.dtos.ValidationRequest;
 import org.grnet.cat.dtos.ValidationResponse;
 import org.grnet.cat.dtos.pagination.PageResource;
 import org.grnet.cat.enums.Source;
+import org.grnet.cat.repositories.ValidationRepository;
 import org.grnet.cat.services.UserService;
 import org.grnet.cat.services.ValidationService;
 
@@ -168,6 +171,51 @@ public class ValidationsEndpoint {
                                 @Context UriInfo uriInfo) {
 
         var validations = validationService.getValidationsByUserAndPage(page-1, size, uriInfo, utility.getUserUniqueIdentifier(), utility.getValidationComparator());
+
+        return Response.ok().entity(validations).build();
+    }
+
+    @Tag(name = "Validation")
+    @Operation(
+            summary = "Get Validation Request.",
+            description = "Returns a specific validation request if it belongs to the user.")
+    @APIResponse(
+            responseCode = "200",
+            description = "The corresponding validation request.",
+            content = @Content(schema = @Schema(
+                    type = SchemaType.OBJECT,
+                    implementation = ValidationResponse.class)))
+    @APIResponse(
+            responseCode = "401",
+            description = "User has not been authenticated.",
+            content = @Content(schema = @Schema(
+                    type = SchemaType.OBJECT,
+                    implementation = InformativeResponse.class)))
+    @APIResponse(
+            responseCode = "403",
+            description = "Not permitted.",
+            content = @Content(schema = @Schema(
+                    type = SchemaType.OBJECT,
+                    implementation = InformativeResponse.class)))
+    @APIResponse(
+            responseCode = "500",
+            description = "Internal Server Error.",
+            content = @Content(schema = @Schema(
+                    type = SchemaType.OBJECT,
+                    implementation = InformativeResponse.class)))
+    @SecurityRequirement(name = "Authentication")
+    @GET
+    @Path("/{id}")
+    @Produces(MediaType.APPLICATION_JSON)
+    @Registration
+    public Response getValidationRequest(@Parameter(
+            description = "The ID of the validation request to retrieve.",
+            required = true,
+            example = "1",
+            schema = @Schema(type = SchemaType.NUMBER)) @PathParam("id")
+                                             @Valid @NotFoundEntity(repository = ValidationRepository.class, message = "There is no Validation with the following id:") Long id) {
+
+        var validations = validationService.getValidationRequest(utility.getUserUniqueIdentifier(), id);
 
         return Response.ok().entity(validations).build();
     }

--- a/service/src/main/java/org/grnet/cat/services/ValidationService.java
+++ b/service/src/main/java/org/grnet/cat/services/ValidationService.java
@@ -3,6 +3,7 @@ package org.grnet.cat.services;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import jakarta.transaction.Transactional;
+import jakarta.ws.rs.ForbiddenException;
 import jakarta.ws.rs.core.UriInfo;
 import org.grnet.cat.dtos.ValidationRequest;
 import org.grnet.cat.dtos.ValidationResponse;
@@ -137,6 +138,38 @@ public class ValidationService {
         validation.setStatus(status);
         validation.setValidatedBy(userId);
         validation.setValidatedOn(Timestamp.from(Instant.now()));
+
+        return ValidationMapper.INSTANCE.validationToDto(validation);
+    }
+
+    /**
+     * Retrieves a specific validation request if it belongs to the user.
+     *
+     * @param userId The ID of the user.
+     * @param validationId The ID of the validation request to retrieve.
+     * @return The validation request if it belongs to the user.
+     * @throws ForbiddenException If the user is not authorized to access the validation request.
+     */
+    public ValidationResponse getValidationRequest(String userId, Long validationId) {
+
+        var validation = validationRepository.findById(validationId);
+
+        if(!validation.getUser().getId().equals(userId)){
+            throw new ForbiddenException("Not Permitted.");
+        }
+
+        return ValidationMapper.INSTANCE.validationToDto(validation);
+    }
+
+    /**
+     * Retrieves a specific validation request.
+     *
+     * @param validationId The ID of the validation request to retrieve.
+     * @return The validation request if it belongs to the user.
+     */
+    public ValidationResponse getValidationRequest(Long validationId) {
+
+        var validation = validationRepository.findById(validationId);
 
         return ValidationMapper.INSTANCE.validationToDto(validation);
     }


### PR DESCRIPTION
### Changes Made:

Implemented the API endpoints for validation requests as per the requirements in the ticket.

## Endpoint 1: Get Validation Request for User

- Endpoint: GET /v1/validations/{validationId}
- Implemented the logic to retrieve a specific validation request belonging to a user.
- Handled cases where the user is not authorized or the validation request is not found.

## Endpoint 2: Get All Validation Requests (Admin Only)

- Endpoint: GET v1/admin/validations/{validationId}
- Implemented the logic to retrieve any validation request (admin access only).

### Other Changes:

- Implemented unit tests to ensure the correctness of the implemented endpoints.
