### PR TITLE
[CAT-113] Create Endpoint for Admin Users to Create Assessment Templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,8 +22,10 @@ According to [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) , the `Unr
 
 ## Unreleased
 
+### Added
 
 -   [#46](https://github.com/FC4E-CAT/fc4e-cat-api/pull/46)    -  Create API endpoint to serve assessment template json by type for actor.
+-   [#48](https://github.com/FC4E-CAT/fc4e-cat-api/pull/48)    -  Create Endpoint for Admin Users to Create Assessment Templates.
 
 ## 1.0.0 - 2023-07-18
 

--- a/api/config/quarkus-realm.json
+++ b/api/config/quarkus-realm.json
@@ -931,6 +931,22 @@
             "icon_uri": ""
           },
           {
+            "name": "Read Template By Type and Actor",
+            "ownerManagedAccess": false,
+            "displayName": "Read Template By Type and Actor",
+            "attributes": {},
+            "_id": "06e57c4c-de0b-4a9e-b211-583ebbe2c622",
+            "uris": [
+              "/v1/templates/by-type/{type-id}/by-actor/{actor-id}"
+            ],
+            "scopes": [
+              {
+                "name": "read"
+              }
+            ],
+            "icon_uri": ""
+          },
+          {
             "name": "User Resource",
             "ownerManagedAccess": false,
             "displayName": "",
@@ -978,22 +994,6 @@
             "icon_uri": ""
           },
           {
-            "name": "Integration Resource",
-            "ownerManagedAccess": false,
-            "displayName": "Integration Resource",
-            "attributes": {},
-            "_id": "ca960110-a15b-4155-87ce-992d86c68dd3",
-            "uris": [
-              "/v1/integrations/*"
-            ],
-            "scopes": [
-              {
-                "name": "read"
-              }
-            ],
-            "icon_uri": ""
-          },
-          {
             "name": "Template Resource",
             "ownerManagedAccess": false,
             "displayName": "Template Resource",
@@ -1001,6 +1001,25 @@
             "_id": "ca750510-a15b-4155-87cc-992a86c68dd7",
             "uris": [
               "/v1/templates/*"
+            ],
+            "scopes": [
+              {
+                "name": "read"
+              },
+              {
+                "name": "create"
+              }
+            ],
+            "icon_uri": ""
+          },
+          {
+            "name": "Integration Resource",
+            "ownerManagedAccess": false,
+            "displayName": "Integration Resource",
+            "attributes": {},
+            "_id": "ca960110-a15b-4155-87ce-992d86c68dd3",
+            "uris": [
+              "/v1/integrations/*"
             ],
             "scopes": [
               {
@@ -1050,17 +1069,6 @@
             }
           },
           {
-            "id": "b8710fa6-160e-4de0-adf3-398c7007a0af",
-            "name": "Any User Policy",
-            "description": "Any user granted with the user role can access something",
-            "type": "role",
-            "logic": "POSITIVE",
-            "decisionStrategy": "UNANIMOUS",
-            "config": {
-              "roles": "[{\"id\":\"user\",\"required\":false}]"
-            }
-          },
-          {
             "id": "fcef30b2-68b2-4b78-9f3d-9162c6cdf5cb",
             "name": "Only Administrators",
             "description": "Only administrators can access",
@@ -1072,28 +1080,16 @@
             }
           },
           {
-            "id": "bb0808ed-f8a8-47b6-a1ce-a8f110239185",
-            "name": "Create Validation",
+            "id": "693ca2aa-92a1-4caa-a751-451d5ac848ae",
+            "name": "Read Template By Type and Actor",
             "description": "",
             "type": "scope",
             "logic": "POSITIVE",
             "decisionStrategy": "AFFIRMATIVE",
             "config": {
-              "resources": "[\"Validation Resource\"]",
-              "scopes": "[\"create\"]",
-              "applyPolicies": "[\"Any Identified Policy\"]"
-            }
-          },
-          {
-            "id": "3479dd56-02e9-4222-94fe-6a13cd065195",
-            "name": "User Resource Permission",
-            "description": "",
-            "type": "resource",
-            "logic": "POSITIVE",
-            "decisionStrategy": "AFFIRMATIVE",
-            "config": {
-              "resources": "[\"User Resource\"]",
-              "applyPolicies": "[\"Any User Policy\"]"
+              "resources": "[\"Read Template By Type and Actor\"]",
+              "scopes": "[\"read\"]",
+              "applyPolicies": "[\"Any Validated Policy\",\"Only Administrators\"]"
             }
           },
           {
@@ -1102,7 +1098,7 @@
             "description": "",
             "type": "resource",
             "logic": "POSITIVE",
-            "decisionStrategy": "UNANIMOUS",
+            "decisionStrategy": "AFFIRMATIVE",
             "config": {
               "resources": "[\"Role Resource\",\"Administration Resource\",\"Template Resource\"]",
               "applyPolicies": "[\"Only Administrators\"]"
@@ -1118,18 +1114,6 @@
             "config": {
               "resources": "[\"User Resource\",\"Integration Resource\",\"Validation Resource\",\"Codelist Resource\"]",
               "applyPolicies": "[\"Any Identified Policy\"]"
-            }
-          },
-          {
-            "id": "cfb564f9-2d23-4b6d-8042-bf111e5883e2",
-            "name": "Validated Permission",
-            "description": "",
-            "type": "resource",
-            "logic": "POSITIVE",
-            "decisionStrategy": "AFFIRMATIVE",
-            "config": {
-              "resources": "[\"Template Resource\"]",
-              "applyPolicies": "[\"Any Validated Policy\"]"
             }
           }
         ],
@@ -2766,6 +2750,7 @@
       ],
       "clientRoles": {
         "backend-service": [
+          "identified",
           "admin"
         ]
       },

--- a/api/src/main/java/org/grnet/cat/api/endpoints/TemplatesEndpoint.java
+++ b/api/src/main/java/org/grnet/cat/api/endpoints/TemplatesEndpoint.java
@@ -3,91 +3,306 @@ package org.grnet.cat.api.endpoints;
 import io.quarkus.security.Authenticated;
 import jakarta.inject.Inject;
 import jakarta.validation.Valid;
-import jakarta.ws.rs.*;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import jakarta.ws.rs.DefaultValue;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.core.Context;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.UriInfo;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.eclipse.microprofile.openapi.annotations.Operation;
 import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
-import org.eclipse.microprofile.openapi.annotations.enums.SecuritySchemeType;
 import org.eclipse.microprofile.openapi.annotations.media.Content;
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
 import org.eclipse.microprofile.openapi.annotations.parameters.Parameter;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
 import org.eclipse.microprofile.openapi.annotations.security.SecurityRequirement;
-import org.eclipse.microprofile.openapi.annotations.security.SecurityScheme;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
 import org.grnet.cat.api.filters.Registration;
-import org.grnet.cat.api.utils.Utility;
+import org.grnet.cat.api.utils.CatServiceUriInfo;
 import org.grnet.cat.constraints.NotFoundEntity;
+import org.grnet.cat.dtos.TemplateRequest;
 import org.grnet.cat.dtos.InformativeResponse;
+import org.grnet.cat.dtos.TemplateDto;
+import org.grnet.cat.dtos.pagination.PageResource;
 import org.grnet.cat.repositories.ActorRepository;
 import org.grnet.cat.repositories.AssessmentTypeRepository;
-import org.grnet.cat.repositories.ValidationRepository;
+import org.grnet.cat.repositories.TemplateRepository;
 import org.grnet.cat.services.TemplateService;
 
+import java.util.List;
 
+import static org.eclipse.microprofile.openapi.annotations.enums.ParameterIn.QUERY;
 
-    @Path("/v1/templates")
-    @Authenticated
-    public class TemplatesEndpoint {
+@Path("/v1/templates")
+@Authenticated
+public class TemplatesEndpoint {
 
-        @Inject
-        AssessmentTypeRepository assessmentTypeRepository;
+    @Inject
+    TemplateService templateService;
 
-        @Inject
-        ActorRepository actorRepository;
+    @ConfigProperty(name = "server.url")
+    String serverUrl;
 
-        @Inject
-        TemplateService templateService;
-        @Tag(name = "Template")
-        @Operation(
-                summary = "Get Template By Actor.",
-                description = "This endpoint retrieves the template corresponding to an actor")
-        @APIResponse(
-                responseCode = "200",
-                description = "Actor's Template.",
-                content = @Content(schema = @Schema(
-                        type = SchemaType.OBJECT,
-                        implementation = Response.class)))
-        @APIResponse(
-                responseCode = "401",
-                description = "User has not been authenticated.",
-                content = @Content(schema = @Schema(
-                        type = SchemaType.OBJECT,
-                        implementation = InformativeResponse.class)))
-        @APIResponse(
-                responseCode = "403",
-                description = "Not permitted.",
-                content = @Content(schema = @Schema(
-                        type = SchemaType.OBJECT,
-                        implementation = InformativeResponse.class)))
-        @APIResponse(
-                responseCode = "500",
-                description = "Internal Server Error.",
-                content = @Content(schema = @Schema(
-                        type = SchemaType.OBJECT,
-                        implementation = InformativeResponse.class)))
-        @SecurityRequirement(name = "Authentication")
-        @GET
-        @Path("/types/{type-id}/by-actor/{actor-id}")
+    @Tag(name = "Template")
+    @Operation(
+            summary = "Get assessment template By Actor.",
+            description = "This endpoint retrieves the assessment template corresponding to an actor")
+    @APIResponse(
+            responseCode = "200",
+            description = "Actor's assessment template.",
+            content = @Content(schema = @Schema(
+                    type = SchemaType.OBJECT,
+                    implementation = TemplateDto.class)))
+    @APIResponse(
+            responseCode = "401",
+            description = "User has not been authenticated.",
+            content = @Content(schema = @Schema(
+                    type = SchemaType.OBJECT,
+                    implementation = InformativeResponse.class)))
+    @APIResponse(
+            responseCode = "403",
+            description = "Not permitted.",
+            content = @Content(schema = @Schema(
+                    type = SchemaType.OBJECT,
+                    implementation = InformativeResponse.class)))
+    @APIResponse(
+            responseCode = "500",
+            description = "Internal Server Error.",
+            content = @Content(schema = @Schema(
+                    type = SchemaType.OBJECT,
+                    implementation = InformativeResponse.class)))
+    @SecurityRequirement(name = "Authentication")
+    @GET
+    @Path("/by-type/{type-id}/by-actor/{actor-id}")
+    @Produces(MediaType.APPLICATION_JSON)
+    @Registration
+    public Response getAssessmentTemplateByActorAndType(@Parameter(
+            description = "The Actor to retrieve template.",
+            required = true,
+            example = "1",
+            schema = @Schema(type = SchemaType.NUMBER))
+                        @PathParam("actor-id") @Valid @NotFoundEntity(repository = ActorRepository.class, message = "There is no Actor with the following id:") Long actorId,
+                        @Parameter(
+                                description = "The Type to retrieve template.",
+                                required = true,
+                                example = "1",
+                                schema = @Schema(type = SchemaType.NUMBER))
+                        @PathParam("type-id") @Valid @NotFoundEntity(repository = AssessmentTypeRepository.class, message = "There is no Assessment Type with the following id:") Long typeId) {
 
-        @Produces(MediaType.APPLICATION_JSON)
-        @Registration
-        public Response get(@Parameter(
-                description = "The Actor to retrieve template.",
-                required = true,
-                example = "1",
-                schema = @Schema(type = SchemaType.NUMBER))
-                                    @PathParam("actor-id") @Valid @NotFoundEntity(repository = ActorRepository.class, message = "There is no Actor with the following id:") Long actorId,
-                            @Parameter(
-                                    description = "The Type to retrieve template.",
-                                    required = true,
-                                    example = "1",
-                                    schema = @Schema(type = SchemaType.NUMBER))
-                            @PathParam("type-id") @Valid @NotFoundEntity(repository = AssessmentTypeRepository.class, message = "There is no Assessment Type with the following id:")  Long typeId) {
+        var template = templateService.getTemplateByActorAndType(actorId, typeId);
+        return Response.ok().entity(template).build();
+    }
 
-            var template=templateService.getTemplate(actorId,typeId);
-            return Response.ok().entity(template).build();
+    @Tag(name = "Template")
+    @Operation(
+            summary = "Create a new assessment template.",
+            description = "Create a new assessment template (accessible by admin users only).")
+    @APIResponse(
+            responseCode = "201",
+            description = "Template created successfully.",
+            content = @Content(schema = @Schema(
+                    type = SchemaType.OBJECT,
+                    implementation = TemplateDto.class)))
+    @APIResponse(
+            responseCode = "400",
+            description = "Invalid request payload.",
+            content = @Content(schema = @Schema(
+                    type = SchemaType.OBJECT,
+                    implementation = InformativeResponse.class)))
+    @APIResponse(
+            responseCode = "401",
+            description = "User has not been authenticated.",
+            content = @Content(schema = @Schema(
+                    type = SchemaType.OBJECT,
+                    implementation = InformativeResponse.class)))
+    @APIResponse(
+            responseCode = "403",
+            description = "Not permitted.",
+            content = @Content(schema = @Schema(
+                    type = SchemaType.OBJECT,
+                    implementation = InformativeResponse.class)))
+    @APIResponse(
+            responseCode = "500",
+            description = "Internal Server Error.",
+            content = @Content(schema = @Schema(
+                    type = SchemaType.OBJECT,
+                    implementation = InformativeResponse.class)))
+    @SecurityRequirement(name = "Authentication")
+    @POST
+    @Produces(MediaType.APPLICATION_JSON)
+    @Registration
+    public Response create(@Valid @NotNull(message = "The request body is empty.") TemplateRequest request, @Context UriInfo uriInfo) {
+
+        var template = templateService.createAssessmentTemplate(request);
+        var serverInfo = new CatServiceUriInfo(serverUrl.concat(uriInfo.getPath()));
+
+        return Response.created(serverInfo.getAbsolutePathBuilder().path(String.valueOf(template.id)).build()).entity(template).build();
+    }
+
+    @Tag(name = "Template")
+    @Operation(
+            summary = "Get assessment template.",
+            description = "Returns a specific assessment template.")
+    @APIResponse(
+            responseCode = "200",
+            description = "The corresponding assessment template.",
+            content = @Content(schema = @Schema(
+                    type = SchemaType.OBJECT,
+                    implementation = TemplateDto.class)))
+    @APIResponse(
+            responseCode = "401",
+            description = "User has not been authenticated.",
+            content = @Content(schema = @Schema(
+                    type = SchemaType.OBJECT,
+                    implementation = InformativeResponse.class)))
+    @APIResponse(
+            responseCode = "403",
+            description = "Not permitted.",
+            content = @Content(schema = @Schema(
+                    type = SchemaType.OBJECT,
+                    implementation = InformativeResponse.class)))
+    @APIResponse(
+            responseCode = "500",
+            description = "Internal Server Error.",
+            content = @Content(schema = @Schema(
+                    type = SchemaType.OBJECT,
+                    implementation = InformativeResponse.class)))
+    @SecurityRequirement(name = "Authentication")
+    @GET
+    @Path("/{id}")
+    @Produces(MediaType.APPLICATION_JSON)
+    @Registration
+    public Response getAssessmentTemplate(@Parameter(
+            description = "The ID of the assessment template to retrieve.",
+            required = true,
+            example = "1",
+            schema = @Schema(type = SchemaType.NUMBER))
+                                              @PathParam("id")
+                                              @Valid @NotFoundEntity(repository = TemplateRepository.class, message = "There is no assessment template with the following id:") Long id) {
+
+        var template = templateService.getAssessmentTemplate(id);
+
+        return Response.ok().entity(template).build();
+    }
+
+    @Tag(name = "Template")
+    @Operation(
+            summary = "Retrieve assessment templates for a specific type.",
+            description = "This endpoint retrieves the assessment templates for a specific type." +
+                    "By default, the first page of 10 assessment templates will be returned. You can tune the default values by using the query parameters page and size.")
+    @APIResponse(
+            responseCode = "200",
+            description = "List of assessment templates.",
+            content = @Content(schema = @Schema(
+                    type = SchemaType.OBJECT,
+                    implementation = PageableTemplate.class)))
+    @APIResponse(
+            responseCode = "401",
+            description = "User has not been authenticated.",
+            content = @Content(schema = @Schema(
+                    type = SchemaType.OBJECT,
+                    implementation = InformativeResponse.class)))
+    @APIResponse(
+            responseCode = "403",
+            description = "Not permitted.",
+            content = @Content(schema = @Schema(
+                    type = SchemaType.OBJECT,
+                    implementation = InformativeResponse.class)))
+    @APIResponse(
+            responseCode = "500",
+            description = "Internal Server Error.",
+            content = @Content(schema = @Schema(
+                    type = SchemaType.OBJECT,
+                    implementation = InformativeResponse.class)))
+    @SecurityRequirement(name = "Authentication")
+    @GET
+    @Path("/by-type/{type-id}")
+    @Produces(MediaType.APPLICATION_JSON)
+    @Registration
+    public Response getTemplatesByType(@Parameter(name = "page", in = QUERY,
+            description = "Indicates the page number. Page number must be >= 1.") @DefaultValue("1") @Min(value = 1, message = "Page number must be >= 1.") @QueryParam("page") int page,
+                                @Parameter(name = "size", in = QUERY,
+                                        description = "The page size.") @DefaultValue("10") @Min(value = 1, message = "Page size must be between 1 and 100.")
+                                @Max(value = 100, message = "Page size must be between 1 and 100.") @QueryParam("size") int size,
+                                @Parameter(
+                                        description = "The Type to retrieve templates.",
+                                        required = true,
+                                        example = "1",
+                                        schema = @Schema(type = SchemaType.NUMBER))
+                                    @PathParam("type-id") @Valid @NotFoundEntity(repository = AssessmentTypeRepository.class, message = "There is no Assessment Type with the following id:") Long typeId,
+                                @Context UriInfo uriInfo) {
+
+        var templates = templateService.getTemplatesByType(page-1, size, typeId, uriInfo);
+
+        return Response.ok().entity(templates).build();
+    }
+
+    @Tag(name = "Template")
+    @Operation(
+            summary = "Retrieve all the assessment templates.",
+            description = "This endpoint retrieves all the assessment templates." +
+                    "By default, the first page of 10 assessment templates will be returned. You can tune the default values by using the query parameters page and size.")
+    @APIResponse(
+            responseCode = "200",
+            description = "List of all the assessment templates.",
+            content = @Content(schema = @Schema(
+                    type = SchemaType.OBJECT,
+                    implementation = PageableTemplate.class)))
+    @APIResponse(
+            responseCode = "401",
+            description = "User has not been authenticated.",
+            content = @Content(schema = @Schema(
+                    type = SchemaType.OBJECT,
+                    implementation = InformativeResponse.class)))
+    @APIResponse(
+            responseCode = "403",
+            description = "Not permitted.",
+            content = @Content(schema = @Schema(
+                    type = SchemaType.OBJECT,
+                    implementation = InformativeResponse.class)))
+    @APIResponse(
+            responseCode = "500",
+            description = "Internal Server Error.",
+            content = @Content(schema = @Schema(
+                    type = SchemaType.OBJECT,
+                    implementation = InformativeResponse.class)))
+    @SecurityRequirement(name = "Authentication")
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    @Registration
+    public Response getTemplates(@Parameter(name = "page", in = QUERY,
+            description = "Indicates the page number. Page number must be >= 1.") @DefaultValue("1") @Min(value = 1, message = "Page number must be >= 1.") @QueryParam("page") int page,
+                                       @Parameter(name = "size", in = QUERY,
+                                               description = "The page size.") @DefaultValue("10") @Min(value = 1, message = "Page size must be between 1 and 100.")
+                                       @Max(value = 100, message = "Page size must be between 1 and 100.") @QueryParam("size") int size,
+                                       @Context UriInfo uriInfo) {
+
+        var templates = templateService.getTemplates(page-1, size, uriInfo);
+
+        return Response.ok().entity(templates).build();
+    }
+
+    public class PageableTemplate extends PageResource<TemplateDto> {
+
+        private List<TemplateDto> content;
+
+        @Override
+        public List<TemplateDto> getContent() {
+            return content;
+        }
+
+        @Override
+        public void setContent(List<TemplateDto> content) {
+            this.content = content;
         }
     }
+}

--- a/api/src/main/resources/application.properties
+++ b/api/src/main/resources/application.properties
@@ -12,15 +12,10 @@ quarkus.oidc.introspection-path=/protocol/openid-connect/token/introspect
 quarkus.keycloak.policy-enforcer.enable=true
 quarkus.keycloak.policy-enforcer.lazy-load-paths=false
 
-#quarkus.keycloak.policy-enforcer.paths.1.name=Create Validation
-#quarkus.keycloak.policy-enforcer.paths.1.path=/v1/validations
-#quarkus.keycloak.policy-enforcer.paths.1.methods.post.method=POST
-#quarkus.keycloak.policy-enforcer.paths.1.methods.post.scopes=create
-#
-#quarkus.keycloak.policy-enforcer.paths.2.name=Read Validation
-#quarkus.keycloak.policy-enforcer.paths.2.path=/v1/validations
-#quarkus.keycloak.policy-enforcer.paths.2.methods.get.method=GET
-#quarkus.keycloak.policy-enforcer.paths.2.methods.get.scopes=read
+quarkus.keycloak.policy-enforcer.paths.1.name=Read Template By Type and Actor
+quarkus.keycloak.policy-enforcer.paths.1.path=/v1/templates/by-type/{type-id}/by-actor/{actor-id}
+quarkus.keycloak.policy-enforcer.paths.1.methods.get.method=GET
+quarkus.keycloak.policy-enforcer.paths.1.methods.get.scopes=read
 
 quarkus.keycloak.devservices.realm-path=quarkus-realm.json
 
@@ -58,3 +53,6 @@ quarkus.http.cors.origins=https://cat.argo.grnet.gr,https://api.cat.argo.grnet.g
 
 # The server URL that acts on behalf of the Cat Service
 server.url=${SERVER_URL:http://localhost:8080}
+
+quarkus.index-dependency.json_simple.group-id=com.googlecode.json-simple
+quarkus.index-dependency.json_simple.artifact-id=json-simple

--- a/data-transfer-object/src/main/java/org/grnet/cat/dtos/TemplateDto.java
+++ b/data-transfer-object/src/main/java/org/grnet/cat/dtos/TemplateDto.java
@@ -1,11 +1,8 @@
 package org.grnet.cat.dtos;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import io.vertx.core.json.JsonObject;
-import jakarta.json.Json;
 import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
-import org.grnet.cat.entities.AssessmentType;
 import org.json.simple.JSONObject;
 
 @Schema(name = "Template", description = "This object represents the Template.")
@@ -23,20 +20,18 @@ public class TemplateDto {
     @Schema(
             type = SchemaType.OBJECT,
             implementation = AssessmentTypeDto.class,
-            description = "The assessment type of the template")
+            description = "The assessment type of the template.")
     @JsonProperty("type")
     public AssessmentTypeDto type;
 
     @Schema(
             type = SchemaType.OBJECT,
             implementation = ActorDto.class,
-            description = "The actor of the template")
+            description = "The actor of the template.")
     @JsonProperty("actor")
     public ActorDto actor;
-    @Schema(
-            type = SchemaType.OBJECT,
-            implementation = JSONObject.class,
-            description = "The template doc")
+
+    @Schema(description = "The template doc.")
     @JsonProperty("template_doc")
-    public JSONObject template_doc;
+    public JSONObject templateDoc;
 }

--- a/data-transfer-object/src/main/java/org/grnet/cat/dtos/TemplateRequest.java
+++ b/data-transfer-object/src/main/java/org/grnet/cat/dtos/TemplateRequest.java
@@ -1,0 +1,48 @@
+package org.grnet.cat.dtos;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
+import org.grnet.cat.constraints.NotFoundEntity;
+import org.grnet.cat.repositories.ActorRepository;
+import org.grnet.cat.repositories.AssessmentTypeRepository;
+import org.json.simple.JSONObject;
+
+@Schema(name="TemplateRequest", description="This object represents a request for creating a new assessment template.")
+public class TemplateRequest {
+
+    @Schema(
+            required = true,
+            description = "The assessment template in JSON format.",
+            example = "7827fbb605a23b0cbd5cb4db292fe6dd6c7734a27057eb163d616a6ecd02d2ec@einfra.grnet.gr"
+    )
+    @JsonProperty("template_doc")
+    @NotNull(message = "template_doc may not be empty.")
+    public JSONObject templateDoc;
+
+    @Schema(
+            type = SchemaType.NUMBER,
+            implementation = Long.class,
+            required = true,
+            description = "The actor to whom this template belongs.",
+            example = "6"
+    )
+    @JsonProperty("actor_id")
+    @NotNull(message = "actor_id may not be empty.")
+    @NotFoundEntity(repository = ActorRepository.class, message = "There is no Actor with the following id:")
+    public Long actorId;
+
+    @Schema(
+            type = SchemaType.STRING,
+            implementation = String.class,
+            required = true,
+            description = "The type of the template.",
+            example = "6"
+    )
+    @JsonProperty("type_id")
+    @NotNull(message = "type_id may not be empty.")
+    @NotFoundEntity(repository = AssessmentTypeRepository.class, message = "There is no Assessment Type with the following id:")
+    public Long typeId;
+}

--- a/entity/src/main/java/org/grnet/cat/entities/Template.java
+++ b/entity/src/main/java/org/grnet/cat/entities/Template.java
@@ -18,13 +18,14 @@ public class Template {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
-    @Column(name = "template_doc", columnDefinition = "json")
 
-    private String template_doc;
+    @Column(name = "template_doc", columnDefinition = "json")
+    private String templateDoc;
 
     @ManyToOne
-    @JoinColumn(name = "assessment_type_id",referencedColumnName = "id")
+    @JoinColumn(name = "assessment_type_id", referencedColumnName = "id")
     private AssessmentType type;
+
     @ManyToOne
     @JoinColumn(name = "actor_id",referencedColumnName = "id")
     private Actor actor;
@@ -40,7 +41,6 @@ public class Template {
     public void setId(Long id) {
         this.id = id;
     }
-
 
     public Actor getActor() {
         return actor;
@@ -58,12 +58,12 @@ public class Template {
         this.createdOn = createdOn;
     }
 
-    public String getTemplate_doc() {
-        return template_doc;
+    public String getTemplateDoc() {
+        return templateDoc;
     }
 
-    public void setTemplate_doc(String template_doc) {
-        this.template_doc = template_doc;
+    public void setTemplateDoc(String templateDoc) {
+        this.templateDoc = templateDoc;
     }
 
     public AssessmentType getType() {
@@ -73,6 +73,4 @@ public class Template {
     public void setType(AssessmentType type) {
         this.type = type;
     }
-
-
 }

--- a/mapper/src/main/java/org/grnet/cat/mappers/TemplateMapper.java
+++ b/mapper/src/main/java/org/grnet/cat/mappers/TemplateMapper.java
@@ -1,39 +1,42 @@
 package org.grnet.cat.mappers;
 
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import io.vertx.core.json.JsonObject;
-import jakarta.json.Json;
 import org.grnet.cat.dtos.TemplateDto;
-import org.grnet.cat.dtos.UserProfileDto;
-import org.grnet.cat.entities.Role;
+import org.grnet.cat.dtos.TemplateRequest;
 import org.grnet.cat.entities.Template;
-import org.grnet.cat.entities.User;
 import org.json.simple.JSONObject;
 import org.json.simple.parser.JSONParser;
 import org.json.simple.parser.ParseException;
+import org.mapstruct.IterableMapping;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
+import org.mapstruct.Named;
 import org.mapstruct.factory.Mappers;
 
+import java.sql.Timestamp;
+import java.time.Instant;
 import java.util.List;
 
 /**
  * The TemplateMapper is responsible for mapping Template entities to DTOs.
  */
-@Mapper
+@Mapper(imports = {Timestamp.class, Instant.class})
 public interface TemplateMapper {
 
     TemplateMapper INSTANCE = Mappers.getMapper(TemplateMapper.class);
 
-    @Mapping(target = "template_doc", expression = "java(convertToJson(template.getTemplate_doc()))")
+    @Named("mapWithExpression")
+    @Mapping(target = "templateDoc", expression = "java(stringToJson(template.getTemplateDoc()))")
     TemplateDto templateToDto(Template template);
 
+    @Mapping(target = "templateDoc", expression = "java(jsonToString(request.templateDoc))")
+    @Mapping(target = "createdOn", expression = "java(Timestamp.from(Instant.now()))")
+    Template dtoToTemplate(TemplateRequest request);
+
+    @IterableMapping(qualifiedByName="mapWithExpression")
     List<TemplateDto> templatesToDto(List<Template> templates);
 
+    default JSONObject stringToJson(String doc) {
 
-    default JSONObject convertToJson(String doc) {
         JSONParser parser = new JSONParser();
         JSONObject json = null;
         try {
@@ -42,5 +45,10 @@ public interface TemplateMapper {
             throw new RuntimeException(e);
         }
         return json;
+    }
+
+    default String jsonToString(JSONObject object) {
+
+        return object.toJSONString();
     }
 }

--- a/repository/src/main/java/org/grnet/cat/repositories/TemplateRepository.java
+++ b/repository/src/main/java/org/grnet/cat/repositories/TemplateRepository.java
@@ -2,9 +2,11 @@ package org.grnet.cat.repositories;
 
 import io.quarkus.hibernate.orm.panache.PanacheRepositoryBase;
 import jakarta.enterprise.context.ApplicationScoped;
+import org.grnet.cat.entities.Page;
+import org.grnet.cat.entities.PageQuery;
+import org.grnet.cat.entities.PageQueryImpl;
 import org.grnet.cat.entities.Template;
 
-import java.util.List;
 import java.util.Optional;
 
 @ApplicationScoped
@@ -15,9 +17,53 @@ public class TemplateRepository implements PanacheRepositoryBase<Template, Long>
         return findByIdOptional(id);
     }
 
-    public Template fetchTemplateByActorAndType(Long actorId, Long typeId){
+    public Optional<Template> fetchTemplateByActorAndType(Long actorId, Long typeId){
 
-          return find("from Template t where t.actor.id = ?1 and t.type.id= ?2",actorId, typeId).singleResult();
+          return find("from Template t where t.actor.id = ?1 and t.type.id= ?2",actorId, typeId)
+                  .stream()
+                  .findFirst();
     }
 
+    /**
+     * Retrieves from the database a page of assessment templates for a specific type.
+     *
+     * @param page The index of the page to retrieve (starting from 0).
+     * @param size The maximum number of templates to include in a page.
+     * @param typeId The Assessment Type the templates belong to.
+     * @return A list of Template objects representing the assessment templates in the requested page.
+     */
+    public PageQuery<Template> fetchTemplatesByType(int page, int size, Long typeId){
+
+        var panache = find("from Template t where t.type.id = ?1", typeId).page(page, size);
+
+        var pageable = new PageQueryImpl<Template>();
+        pageable.list = panache.list();
+        pageable.index = page;
+        pageable.size = size;
+        pageable.count = panache.count();
+        pageable.page = Page.of(page, size);
+
+        return pageable;
+    }
+
+    /**
+     * Retrieves from the database a page of assessment templates.
+     *
+     * @param page The index of the page to retrieve (starting from 0).
+     * @param size The maximum number of templates to include in a page.
+     * @return A list of Template objects representing the assessment templates in the requested page.
+     */
+    public PageQuery<Template> fetchTemplates(int page, int size){
+
+        var panache = findAll().page(page, size);
+
+        var pageable = new PageQueryImpl<Template>();
+        pageable.list = panache.list();
+        pageable.index = page;
+        pageable.size = size;
+        pageable.count = panache.count();
+        pageable.page = Page.of(page, size);
+
+        return pageable;
+    }
 }

--- a/service/src/main/java/org/grnet/cat/services/TemplateService.java
+++ b/service/src/main/java/org/grnet/cat/services/TemplateService.java
@@ -1,30 +1,112 @@
 package org.grnet.cat.services;
 
-import io.quarkus.security.ForbiddenException;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
+import jakarta.transaction.Transactional;
+import jakarta.ws.rs.core.UriInfo;
+import org.grnet.cat.dtos.TemplateRequest;
 import org.grnet.cat.dtos.TemplateDto;
-import org.grnet.cat.entities.AssessmentType;
-import org.grnet.cat.enums.ValidationStatus;
+import org.grnet.cat.dtos.pagination.PageResource;
+import org.grnet.cat.exceptions.ConflictException;
 import org.grnet.cat.exceptions.EntityNotFoundException;
 import org.grnet.cat.mappers.TemplateMapper;
-import org.grnet.cat.mappers.UserMapper;
+import org.grnet.cat.repositories.ActorRepository;
 import org.grnet.cat.repositories.AssessmentTypeRepository;
 import org.grnet.cat.repositories.TemplateRepository;
-import org.grnet.cat.repositories.ValidationRepository;
 
 
 @ApplicationScoped
 public class TemplateService {
-        /**
+
+    /**
      * Injection point for the Template Repository
      */
     @Inject
     TemplateRepository templateRepository;
 
-    public TemplateDto getTemplate(Long actorId, Long typeId) {
+    /**
+     * Injection point for the AssessmentType Repository
+     */
+    @Inject
+    AssessmentTypeRepository assessmentTypeRepository;
 
-        var template = templateRepository.fetchTemplateByActorAndType(actorId, typeId);
+    @Inject
+    ActorRepository actorRepository;
+
+    public TemplateDto getTemplateByActorAndType(Long actorId, Long typeId) {
+
+        var optionalTemplate = templateRepository.fetchTemplateByActorAndType(actorId, typeId);
+
+        var template = optionalTemplate.orElseThrow(()->new EntityNotFoundException("There is no Template."));
         return TemplateMapper.INSTANCE.templateToDto(template);
+    }
+
+    /**
+     * Creates a new assessment template.
+     *
+     * @param request The assessment template to be created.
+     * @return The created template.
+     */
+    @Transactional
+    public TemplateDto createAssessmentTemplate(TemplateRequest request) {
+
+        var optionalTemplate = templateRepository.fetchTemplateByActorAndType(request.actorId, request.typeId);
+
+        if(optionalTemplate.isPresent()){
+            throw new ConflictException(String.format("The template for actor with id {%s} and type with id {%s} exists.", request.actorId, request.typeId));
+        }
+
+        var type = assessmentTypeRepository.findById(request.typeId);
+        var actor = actorRepository.findById(request.actorId);
+
+        var template = TemplateMapper.INSTANCE.dtoToTemplate(request);
+        template.setType(type);
+        template.setActor(actor);
+
+        templateRepository.persist(template);
+        return TemplateMapper.INSTANCE.templateToDto(template);
+    }
+
+    /**
+     * Retrieves a specific assessment template.
+     *
+     * @param id The ID of the assessment template to retrieve.
+     * @return The corresponding assessment template.
+     */
+    public TemplateDto getAssessmentTemplate(Long id){
+
+        var template = templateRepository.findById(id);
+        return TemplateMapper.INSTANCE.templateToDto(template);
+    }
+
+    /**
+     * Retrieves a page of assessment templates for a specific type.
+     *
+     * @param page The index of the page to retrieve (starting from 0).
+     * @param size The maximum number of templates to include in a page.
+     * @param typeId The Assessment Type the templates belong to.
+     * @param uriInfo The Uri Info.
+     * @return A list of TemplateDto objects representing the assessment templates in the requested page.
+     */
+    public PageResource<TemplateDto> getTemplatesByType(int page, int size, Long typeId, UriInfo uriInfo){
+
+        var templates = templateRepository.fetchTemplatesByType(page, size, typeId);
+
+        return new PageResource<>(templates, TemplateMapper.INSTANCE.templatesToDto(templates.list()), uriInfo);
+    }
+
+    /**
+     * Retrieves a page of assessment templates.
+     *
+     * @param page The index of the page to retrieve (starting from 0).
+     * @param size The maximum number of templates to include in a page.
+     * @param uriInfo The Uri Info.
+     * @return A list of TemplateDto objects representing the assessment templates in the requested page.
+     */
+    public PageResource<TemplateDto> getTemplates(int page, int size, UriInfo uriInfo){
+
+        var templates = templateRepository.fetchTemplates(page, size);
+
+        return new PageResource<>(templates, TemplateMapper.INSTANCE.templatesToDto(templates.list()), uriInfo);
     }
 }


### PR DESCRIPTION
This Pull Request introduces a new API endpoint that allows admin users to create assessment templates. The new endpoint ensures that only admin users can access it, and it accepts a JSON object representing the assessment template, along with additional parameters like the actor and template type.

