### PR TITLE
[CAT-117] Create an endpoint that retrieves the available assessment types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ According to [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) , the `Unr
 -   [#48](https://github.com/FC4E-CAT/fc4e-cat-api/pull/48)    -  Create Endpoint for Admin Users to Create Assessment Templates.
 -   [#49](https://github.com/FC4E-CAT/fc4e-cat-api/pull/49)    -  Create API endpoint to allow user to store a new assessment.
 -   [#52](https://github.com/FC4E-CAT/fc4e-cat-api/pull/52)    -  Create API endpoint to view an assessment.
+-   [#53](https://github.com/FC4E-CAT/fc4e-cat-api/pull/53)    -  Create an endpoint that retrieves the available assessment types.
 
 ## 1.0.0 - 2023-07-18
 

--- a/api/src/main/java/org/grnet/cat/api/endpoints/CodelistEndpoint.java
+++ b/api/src/main/java/org/grnet/cat/api/endpoints/CodelistEndpoint.java
@@ -23,9 +23,11 @@ import org.eclipse.microprofile.openapi.annotations.security.SecurityRequirement
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
 import org.grnet.cat.api.filters.Registration;
 import org.grnet.cat.dtos.ActorDto;
+import org.grnet.cat.dtos.AssessmentTypeDto;
 import org.grnet.cat.dtos.InformativeResponse;
 import org.grnet.cat.dtos.pagination.PageResource;
 import org.grnet.cat.services.ActorService;
+import org.grnet.cat.services.AssessmentTypeService;
 
 import java.util.List;
 
@@ -37,6 +39,9 @@ public class CodelistEndpoint {
 
     @Inject
     ActorService actorService;
+
+    @Inject
+    AssessmentTypeService assessmentTypeService;
 
     @Tag(name = "Codelist")
     @Operation(
@@ -84,6 +89,52 @@ public class CodelistEndpoint {
         return Response.ok().entity(actors).build();
     }
 
+    @Tag(name = "Codelist")
+    @Operation(
+            summary = "Get available Assessment Types.",
+            description = "This endpoint retrieves a list of available assessment types." +
+                    " By default, the first page of 10 Actors will be returned. You can tune the default values by using the query parameters page and size.")
+    @APIResponse(
+            responseCode = "200",
+            description = "List of Assessment types.",
+            content = @Content(schema = @Schema(
+                    type = SchemaType.OBJECT,
+                    implementation = PageableAssessmentTypes.class)))
+    @APIResponse(
+            responseCode = "401",
+            description = "User has not been authenticated.",
+            content = @Content(schema = @Schema(
+                    type = SchemaType.OBJECT,
+                    implementation = InformativeResponse.class)))
+    @APIResponse(
+            responseCode = "403",
+            description = "Not permitted.",
+            content = @Content(schema = @Schema(
+                    type = SchemaType.OBJECT,
+                    implementation = InformativeResponse.class)))
+    @APIResponse(
+            responseCode = "500",
+            description = "Internal Server Error.",
+            content = @Content(schema = @Schema(
+                    type = SchemaType.OBJECT,
+                    implementation = InformativeResponse.class)))
+    @SecurityRequirement(name = "Authentication")
+    @GET
+    @Path("/assessment-types")
+    @Produces(MediaType.APPLICATION_JSON)
+    @Registration
+    public Response assessmentsByPage(@Parameter(name = "page", in = QUERY,
+            description = "Indicates the page number. Page number must be >= 1.") @DefaultValue("1") @Min(value = 1, message = "Page number must be >= 1.") @QueryParam("page") int page,
+                                 @Parameter(name = "size", in = QUERY,
+                                         description = "The page size.") @DefaultValue("10") @Min(value = 1, message = "Page size must be between 1 and 100.")
+                                 @Max(value = 100, message = "Page size must be between 1 and 100.") @QueryParam("size") int size,
+                                 @Context UriInfo uriInfo) {
+
+        var actors = assessmentTypeService.getAssessmentTypesByPage(page-1, size, uriInfo);
+
+        return Response.ok().entity(actors).build();
+    }
+
     public static class PageableActor extends PageResource<ActorDto> {
 
         private List<ActorDto> content;
@@ -95,6 +146,21 @@ public class CodelistEndpoint {
 
         @Override
         public void setContent(List<ActorDto> content) {
+            this.content = content;
+        }
+    }
+
+    public static class PageableAssessmentTypes extends PageResource<AssessmentTypeDto> {
+
+        private List<AssessmentTypeDto> content;
+
+        @Override
+        public List<AssessmentTypeDto> getContent() {
+            return content;
+        }
+
+        @Override
+        public void setContent(List<AssessmentTypeDto> content) {
             this.content = content;
         }
     }

--- a/data-transfer-object/src/main/java/org/grnet/cat/dtos/AssessmentRequest.java
+++ b/data-transfer-object/src/main/java/org/grnet/cat/dtos/AssessmentRequest.java
@@ -28,7 +28,6 @@ public class AssessmentRequest {
     )
     @JsonProperty("validation_id")
     @NotFoundEntity(repository = ValidationRepository.class, message = "There is no Validation with the following id:")
-
     @NotNull
     public Long validationId;
 
@@ -41,7 +40,6 @@ public class AssessmentRequest {
     )
     @JsonProperty("template_id")
     @NotFoundEntity(repository = TemplateRepository.class, message = "There is no Template with the following id:")
-
     @NotNull
     public Long templateId;
 
@@ -103,7 +101,6 @@ public class AssessmentRequest {
     )
     @JsonProperty("assessment_doc")
     @NotEmpty(message = "assessment doc may not be empty")
-
     @NotNull
     public JSONObject assessmentDoc;
 }

--- a/data-transfer-object/src/main/java/org/grnet/cat/dtos/AssessmentResponseDto.java
+++ b/data-transfer-object/src/main/java/org/grnet/cat/dtos/AssessmentResponseDto.java
@@ -31,13 +31,13 @@ public class AssessmentResponseDto {
             description = "The validation id of the assessment")
     @JsonProperty("validationId")
     public Long validationId;
+
     @Schema(
             type = SchemaType.OBJECT,
             implementation = JSONObject.class,
             description = "The assessment doc")
     @JsonProperty("assessmentDoc")
     public JSONObject assessmentDoc;
-
 
     @Schema(
             type = SchemaType.STRING,
@@ -48,7 +48,6 @@ public class AssessmentResponseDto {
     @JsonProperty("created_on")
     public String createdOn;
 
-
     @Schema(
             type = SchemaType.STRING,
             implementation = String.class,
@@ -57,5 +56,4 @@ public class AssessmentResponseDto {
     )
     @JsonProperty("updated_on")
     public String updatedOn;
-
 }

--- a/data-transfer-object/src/main/java/org/grnet/cat/dtos/AssessmentTypeDto.java
+++ b/data-transfer-object/src/main/java/org/grnet/cat/dtos/AssessmentTypeDto.java
@@ -16,7 +16,6 @@ public class AssessmentTypeDto{
     @JsonProperty("id")
     public Long id;
 
-
     @Schema(
             type = SchemaType.STRING,
             implementation = String.class,
@@ -26,7 +25,6 @@ public class AssessmentTypeDto{
     @JsonProperty("name")
     public String name;
 
-
     @Schema(
             type = SchemaType.STRING,
             implementation = String.class,
@@ -35,6 +33,4 @@ public class AssessmentTypeDto{
     )
     @JsonProperty("label")
     public String label;
-
-
 }

--- a/entity/src/main/java/org/grnet/cat/entities/AssessmentType.java
+++ b/entity/src/main/java/org/grnet/cat/entities/AssessmentType.java
@@ -13,9 +13,9 @@ public class AssessmentType {
     @Column(name = "name")
     private String name;
 
-
     @Column(name = "label")
     private String label;
+
     @OneToMany(fetch = FetchType.LAZY, mappedBy = "type")
     private List<Template> templates;
 

--- a/mapper/src/main/java/org/grnet/cat/mappers/AssessmentTypeMapper.java
+++ b/mapper/src/main/java/org/grnet/cat/mappers/AssessmentTypeMapper.java
@@ -1,0 +1,20 @@
+package org.grnet.cat.mappers;
+
+
+import org.grnet.cat.dtos.AssessmentTypeDto;
+import org.grnet.cat.entities.AssessmentType;
+import org.mapstruct.Mapper;
+import org.mapstruct.factory.Mappers;
+
+import java.util.List;
+
+/**
+ * The AssessmentTypeMapper is responsible for mapping AssessmentType entities to DTOs.
+ */
+@Mapper
+public interface AssessmentTypeMapper {
+
+    AssessmentTypeMapper INSTANCE = Mappers.getMapper(AssessmentTypeMapper.class);
+
+    List<AssessmentTypeDto> assessmentTypesToDto(List<AssessmentType> assessmentTypes);
+}

--- a/mapper/src/main/java/org/grnet/cat/mappers/ValidationMapper.java
+++ b/mapper/src/main/java/org/grnet/cat/mappers/ValidationMapper.java
@@ -29,5 +29,4 @@ public interface ValidationMapper {
     @Mapping(target = "userSurname", expression = "java(validation.getUser().getSurname())")
     @Mapping(target = "userEmail", expression = "java(validation.getUser().getEmail())")
     ValidationResponse validationToDto(Validation validation);
-
 }

--- a/repository/src/main/java/org/grnet/cat/repositories/AssessmentTypeRepository.java
+++ b/repository/src/main/java/org/grnet/cat/repositories/AssessmentTypeRepository.java
@@ -3,6 +3,9 @@ package org.grnet.cat.repositories;
 import io.quarkus.hibernate.orm.panache.PanacheRepositoryBase;
 import jakarta.enterprise.context.ApplicationScoped;
 import org.grnet.cat.entities.AssessmentType;
+import org.grnet.cat.entities.Page;
+import org.grnet.cat.entities.PageQuery;
+import org.grnet.cat.entities.PageQueryImpl;
 
 import java.util.Optional;
 
@@ -14,4 +17,24 @@ public class AssessmentTypeRepository implements PanacheRepositoryBase<Assessmen
         return findByIdOptional(id);
     }
 
+    /**
+     * Retrieves from the database a page of assessment types.
+     *
+     * @param page The index of the page to retrieve (starting from 0).
+     * @param size The maximum number of templates to include in a page.
+     * @return A list of AssessmentType objects representing the assessment types in the requested page.
+     */
+    public PageQuery<AssessmentType> getAssessmentTypesByPage(int page, int size){
+
+        var panache = findAll().page(page, size);
+
+        var pageable = new PageQueryImpl<AssessmentType>();
+        pageable.list = panache.list();
+        pageable.index = page;
+        pageable.size = size;
+        pageable.count = panache.count();
+        pageable.page = Page.of(page, size);
+
+        return pageable;
+    }
 }

--- a/service/src/main/java/org/grnet/cat/services/AssessmentTypeService.java
+++ b/service/src/main/java/org/grnet/cat/services/AssessmentTypeService.java
@@ -1,0 +1,37 @@
+package org.grnet.cat.services;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.core.UriInfo;
+import org.grnet.cat.dtos.AssessmentTypeDto;
+import org.grnet.cat.dtos.pagination.PageResource;
+import org.grnet.cat.mappers.AssessmentTypeMapper;
+import org.grnet.cat.repositories.AssessmentTypeRepository;
+
+/**
+ * The AssessmentTypeService provides operations for managing assessment types.
+ */
+@ApplicationScoped
+public class AssessmentTypeService {
+
+    /**
+     * Injection point for the AssessmentType Repository
+     */
+    @Inject
+    AssessmentTypeRepository assessmentTypeRepository;
+
+    /**
+     * Retrieves a page of assessment types.
+     *
+     * @param page The index of the page to retrieve (starting from 0).
+     * @param size The maximum number of templates to include in a page.
+     * @param uriInfo The Uri Info.
+     * @return A list of AssessmentTypeDto objects representing the assessment types in the requested page.
+     */
+    public PageResource<AssessmentTypeDto> getAssessmentTypesByPage(int page, int size, UriInfo uriInfo){
+
+        var types = assessmentTypeRepository.getAssessmentTypesByPage(page, size);
+
+        return new PageResource<>(types, AssessmentTypeMapper.INSTANCE.assessmentTypesToDto(types.list()), uriInfo);
+    }
+}

--- a/service/src/main/java/org/grnet/cat/services/IntegrationService.java
+++ b/service/src/main/java/org/grnet/cat/services/IntegrationService.java
@@ -19,7 +19,6 @@ import org.grnet.cat.mappers.SourceMapper;
  * The IntegrationService provides operations for managing integrations.
  */
 @ApplicationScoped
-
 public class IntegrationService {
 
     /**


### PR DESCRIPTION
This pull request addresses the JIRA ticket CAT-117, which aims to create a new API endpoint to retrieve the available assessment types. The implemented changes introduce a new endpoint and its associated functionality to serve the required data.

### Changes Implemented

- Created a new API endpoint: GET /v1/codelist/assessment-types
- Implemented logic to fetch the available assessment types from the database.
