### PR TITLE
[CAT-91] Create an API endpoint that allows to view list of assessments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,8 +30,10 @@ According to [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) , the `Unr
 -   [#52](https://github.com/FC4E-CAT/fc4e-cat-api/pull/52)    -  Create API endpoint to view an assessment.
 -   [#53](https://github.com/FC4E-CAT/fc4e-cat-api/pull/53)    -  Create an endpoint that retrieves the available assessment types.
 -   [#50](https://github.com/FC4E-CAT/fc4e-cat-api/pull/50)    -  CAT-90 Create API endpoint to allow user to update an existing assessment (PUT).
--   [#51](https://github.com/FC4E-CAT/fc4e-cat-api/pull/51)    -  CAT-75 Investigate to enrich ROR search organisation on acronym
--   [#54](https://github.com/FC4E-CAT/fc4e-cat-api/pull/54)    -  CAT-111 Create API endpoint to get the list of templates for an actor
+-   [#51](https://github.com/FC4E-CAT/fc4e-cat-api/pull/51)    -  CAT-75 Investigate to enrich ROR search organisation on acronym.
+-   [#54](https://github.com/FC4E-CAT/fc4e-cat-api/pull/54)    -  CAT-111 Create API endpoint to get the list of templates for an actor.
+-   [#54](https://github.com/FC4E-CAT/fc4e-cat-api/pull/54)    -  CAT-111 Create API endpoint to get the list of templates for an actor.
+-   [#55](https://github.com/FC4E-CAT/fc4e-cat-api/pull/55)    -  CAT-91 Create an API endpoint that allows to view list of assessments.
 
 ## 1.0.0 - 2023-07-18
 

--- a/api/src/main/java/org/grnet/cat/api/endpoints/IntegrationsEndpoint.java
+++ b/api/src/main/java/org/grnet/cat/api/endpoints/IntegrationsEndpoint.java
@@ -16,7 +16,6 @@ import jakarta.ws.rs.core.Context;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.UriInfo;
-import java.io.IOException;
 import org.eclipse.microprofile.openapi.annotations.Operation;
 import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
 import org.eclipse.microprofile.openapi.annotations.media.Content;
@@ -208,18 +207,19 @@ public class IntegrationsEndpoint {
     @Produces(MediaType.APPLICATION_JSON)
     @Registration
     public Response searchRorByName(
-            @Valid @NotNull(message = "The parameter is empty.")
+            @Valid
+            @Size(min=2, message = "Value must be at least 2 characters.")
             @Parameter(
                     description = "The query param to search organisation by name. Name size must be >=2 chars",
                     required = true,
                     example = "Keimyung University",
                     schema = @Schema(type = SchemaType.STRING))
-            @QueryParam("name") @Size(min=2) String name,
+            @QueryParam("name") String name,
             @Parameter(name = "page", in = QUERY,
             description = "Indicates the page number. Page number must be >= 1.") @DefaultValue("1") @Min(value = 1, message = "Page number must be >= 1.") @QueryParam("page") int page,
              @Context UriInfo uriInfo)  {
 
-        var integrations = integrationService.searchOrganisationsByNameAndPage(name,page,uriInfo);
+        var integrations = integrationService.searchOrganisationsByNameAndPage(name, page, uriInfo);
 
         return Response.ok().entity(integrations).build();
     }

--- a/api/src/test/java/org/grnet/cat/api/IntegrationsEndpointTest.java
+++ b/api/src/test/java/org/grnet/cat/api/IntegrationsEndpointTest.java
@@ -2,15 +2,15 @@ package org.grnet.cat.api;
 
 import io.quarkus.test.common.http.TestHTTPEndpoint;
 import io.quarkus.test.junit.QuarkusTest;
-import static io.restassured.RestAssured.given;
 import org.grnet.cat.api.endpoints.IntegrationsEndpoint;
 import org.grnet.cat.dtos.InformativeResponse;
 import org.grnet.cat.dtos.OrganisationResponseDto;
 import org.grnet.cat.dtos.SourceResponseDto;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-
 import org.grnet.cat.dtos.pagination.PageResource;
 import org.junit.jupiter.api.Test;
+
+import static io.restassured.RestAssured.given;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @QuarkusTest
 @TestHTTPEndpoint(IntegrationsEndpoint.class)
@@ -109,7 +109,7 @@ public class IntegrationsEndpointTest extends KeycloakTest {
         var response = given()
                 .auth()
                 .oauth2(getAccessToken("alice"))
-                .queryParam("name","Keimyung University")
+                .queryParam("name", "Keimyung University")
                 .get("/organisations/ROR/search")
                 .thenReturn();
 
@@ -117,6 +117,8 @@ public class IntegrationsEndpointTest extends KeycloakTest {
         assertEquals(3, response.body().as(PageResource.class).getTotalElements());
 
     }
+
+    @Test
     public void fetchRorOrganisationByNameEmpty() {
 
         register("alice");
@@ -124,7 +126,7 @@ public class IntegrationsEndpointTest extends KeycloakTest {
         var response = given()
                 .auth()
                 .oauth2(getAccessToken("alice"))
-                .queryParam("name","")
+                .queryParam("name", "")
                 .get("/organisations/ROR/search")
                 .then()
                 .assertThat()
@@ -132,17 +134,18 @@ public class IntegrationsEndpointTest extends KeycloakTest {
                 .extract()
                 .as(InformativeResponse.class);
 
-        assertEquals("The parameter is empty.", response.message);
-
+        assertEquals("Value must be at least 2 characters.", response.message);
     }
-      public void fetchRorOrganisationByNameLessThan2Chars() {
+
+    @Test
+    public void fetchRorOrganisationByNameLessThan2Chars() {
 
         register("alice");
 
         var response = given()
                 .auth()
                 .oauth2(getAccessToken("alice"))
-                .queryParam("name","K")
+                .queryParam("name", "K")
                 .get("/organisations/ROR/search")
                 .then()
                 .assertThat()
@@ -150,7 +153,6 @@ public class IntegrationsEndpointTest extends KeycloakTest {
                 .extract()
                 .as(InformativeResponse.class);
 
-        assertEquals("Value must be at least 2 characters", response.message);
-
+        assertEquals("Value must be at least 2 characters.", response.message);
     }
 }

--- a/entity/src/main/java/org/grnet/cat/entities/Validation.java
+++ b/entity/src/main/java/org/grnet/cat/entities/Validation.java
@@ -12,6 +12,7 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToOne;
 import jakarta.validation.constraints.NotNull;
+import lombok.EqualsAndHashCode;
 import org.grnet.cat.enums.Source;
 import org.grnet.cat.enums.ValidationStatus;
 
@@ -21,10 +22,12 @@ import java.sql.Timestamp;
  * This entity represents an application that an identified user can request to be promoted to a validated user.
  */
 @Entity
+@EqualsAndHashCode(onlyExplicitlyIncluded = true)
 public class Validation {
 
     @Id
     @GeneratedValue(strategy= GenerationType.IDENTITY)
+    @EqualsAndHashCode.Include
     private Long id;
 
     @ManyToOne(fetch = FetchType.EAGER)

--- a/mapper/src/main/java/org/grnet/cat/mappers/AssessmentMapper.java
+++ b/mapper/src/main/java/org/grnet/cat/mappers/AssessmentMapper.java
@@ -8,8 +8,10 @@ import org.grnet.cat.entities.Template;
 import org.json.simple.JSONObject;
 import org.json.simple.parser.JSONParser;
 import org.json.simple.parser.ParseException;
+import org.mapstruct.IterableMapping;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
+import org.mapstruct.Named;
 import org.mapstruct.factory.Mappers;
 
 import java.sql.Timestamp;
@@ -25,6 +27,10 @@ public interface AssessmentMapper {
 
     AssessmentMapper INSTANCE = Mappers.getMapper(AssessmentMapper.class);
 
+    @IterableMapping(qualifiedByName="mapWithExpression")
+    List<AssessmentResponseDto> assessmentsToDto(List<Assessment> assessments);
+
+    @Named("mapWithExpression")
     @Mapping(target = "assessmentDoc", expression = "java(convertToJson(assessment.getAssessmentDoc()))")
     @Mapping(target = "templateId", expression = "java(assessment.getTemplate().getId())")
     @Mapping(target = "validationId", expression = "java(assessment.getValidation().getId())")

--- a/repository/src/main/java/org/grnet/cat/repositories/ActorRepository.java
+++ b/repository/src/main/java/org/grnet/cat/repositories/ActorRepository.java
@@ -1,20 +1,17 @@
 package org.grnet.cat.repositories;
 
-import io.quarkus.hibernate.orm.panache.PanacheRepositoryBase;
 import jakarta.enterprise.context.ApplicationScoped;
 import org.grnet.cat.entities.Actor;
 import org.grnet.cat.entities.Page;
 import org.grnet.cat.entities.PageQuery;
 import org.grnet.cat.entities.PageQueryImpl;
 
-import java.util.Optional;
-
 
 /**
  * The ActorRepository interface provides data access methods for the Actor entity.
  */
 @ApplicationScoped
-public class ActorRepository implements PanacheRepositoryBase<Actor, Long>, Repository<Actor, Long> {
+public class ActorRepository implements Repository<Actor, Long> {
 
     /**
      * Retrieves a page of from the database.
@@ -35,10 +32,5 @@ public class ActorRepository implements PanacheRepositoryBase<Actor, Long>, Repo
         pageable.page = Page.of(page, size);
 
         return pageable;
-    }
-
-    @Override
-    public Optional<Actor> searchByIdOptional(Long id) {
-        return findByIdOptional(id);
     }
 }

--- a/repository/src/main/java/org/grnet/cat/repositories/AssessmentRepository.java
+++ b/repository/src/main/java/org/grnet/cat/repositories/AssessmentRepository.java
@@ -1,21 +1,34 @@
 package org.grnet.cat.repositories;
 
-import io.quarkus.hibernate.orm.panache.PanacheRepositoryBase;
 import jakarta.enterprise.context.ApplicationScoped;
-import jakarta.transaction.Transactional;
 import org.grnet.cat.entities.Assessment;
-
-import java.sql.Timestamp;
-import java.time.Instant;
-import java.util.Optional;
+import org.grnet.cat.entities.Page;
+import org.grnet.cat.entities.PageQuery;
+import org.grnet.cat.entities.PageQueryImpl;
 
 @ApplicationScoped
 
-public class AssessmentRepository  implements PanacheRepositoryBase<Assessment, Long>, Repository<Assessment, Long> {
+public class AssessmentRepository implements Repository<Assessment, Long> {
 
-        @Override
-        public Optional<Assessment> searchByIdOptional(Long id) {
-            return findByIdOptional(id);
-        }
+    /**
+     * Retrieves a page of assessments submitted by the specified user.
+     *
+     * @param page The index of the page to retrieve (starting from 0).
+     * @param size The maximum number of assessments to include in a page.
+     * @param userID The ID of the user.
+     * @return A list of Assessment objects representing the assessments in the requested page.
+     */
+    public PageQuery<Assessment> fetchAssessmentsByUserAndPage(int page, int size, String userID){
 
+        var panache = find("from Assessment a where a.validation.user.id = ?1", userID).page(page, size);
+
+        var pageable = new PageQueryImpl<Assessment>();
+        pageable.list = panache.list();
+        pageable.index = page;
+        pageable.size = size;
+        pageable.count = panache.count();
+        pageable.page = Page.of(page, size);
+
+        return pageable;
+    }
 }

--- a/repository/src/main/java/org/grnet/cat/repositories/AssessmentTypeRepository.java
+++ b/repository/src/main/java/org/grnet/cat/repositories/AssessmentTypeRepository.java
@@ -1,21 +1,13 @@
 package org.grnet.cat.repositories;
 
-import io.quarkus.hibernate.orm.panache.PanacheRepositoryBase;
 import jakarta.enterprise.context.ApplicationScoped;
 import org.grnet.cat.entities.AssessmentType;
 import org.grnet.cat.entities.Page;
 import org.grnet.cat.entities.PageQuery;
 import org.grnet.cat.entities.PageQueryImpl;
 
-import java.util.Optional;
-
 @ApplicationScoped
-public class AssessmentTypeRepository implements PanacheRepositoryBase<AssessmentType, Long>, Repository<AssessmentType, Long> {
-
-    @Override
-    public Optional<AssessmentType> searchByIdOptional(Long id) {
-        return findByIdOptional(id);
-    }
+public class AssessmentTypeRepository implements Repository<AssessmentType, Long> {
 
     /**
      * Retrieves from the database a page of assessment types.

--- a/repository/src/main/java/org/grnet/cat/repositories/Repository.java
+++ b/repository/src/main/java/org/grnet/cat/repositories/Repository.java
@@ -1,8 +1,12 @@
 package org.grnet.cat.repositories;
 
+import io.quarkus.hibernate.orm.panache.PanacheRepositoryBase;
+
 import java.util.Optional;
 
-public interface Repository <E, ID>{
+public interface Repository <E, ID> extends PanacheRepositoryBase<E, ID> {
 
-    Optional<E> searchByIdOptional(ID id);
+    default Optional<E> searchByIdOptional(ID id){
+        return findByIdOptional(id);
+    }
 }

--- a/repository/src/main/java/org/grnet/cat/repositories/TemplateRepository.java
+++ b/repository/src/main/java/org/grnet/cat/repositories/TemplateRepository.java
@@ -1,6 +1,5 @@
 package org.grnet.cat.repositories;
 
-import io.quarkus.hibernate.orm.panache.PanacheRepositoryBase;
 import jakarta.enterprise.context.ApplicationScoped;
 import org.grnet.cat.entities.Page;
 import org.grnet.cat.entities.PageQuery;
@@ -10,12 +9,7 @@ import org.grnet.cat.entities.Template;
 import java.util.Optional;
 
 @ApplicationScoped
-public class TemplateRepository implements PanacheRepositoryBase<Template, Long>, Repository<Template, Long> {
-
-    @Override
-    public Optional<Template> searchByIdOptional(Long id) {
-        return findByIdOptional(id);
-    }
+public class TemplateRepository implements Repository<Template, Long> {
 
     public Optional<Template> fetchTemplateByActorAndType(Long actorId, Long typeId){
 

--- a/repository/src/main/java/org/grnet/cat/repositories/UserRepository.java
+++ b/repository/src/main/java/org/grnet/cat/repositories/UserRepository.java
@@ -1,7 +1,5 @@
 package org.grnet.cat.repositories;
 
-import io.quarkus.hibernate.orm.panache.PanacheRepositoryBase;
-
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import jakarta.inject.Named;
@@ -18,14 +16,13 @@ import org.grnet.cat.enums.UserType;
 import java.sql.Timestamp;
 import java.time.Instant;
 import java.util.List;
-import java.util.Optional;
 import java.util.stream.Collectors;
 
 /**
  * The IdentifiedRepository interface provides data access methods for the User entity.
  */
 @ApplicationScoped
-public class UserRepository implements UserRepositoryI<User, String>, PanacheRepositoryBase<User, String> {
+public class UserRepository implements UserRepositoryI<User, String> {
 
     @Inject
     @Named("keycloak-repository")
@@ -109,11 +106,6 @@ public class UserRepository implements UserRepositoryI<User, String>, PanacheRep
         user.setUpdatedOn(Timestamp.from(Instant.now()));
 
         return user;
-    }
-
-    @Override
-    public Optional<User> searchByIdOptional(String id) {
-        return findByIdOptional(id);
     }
 
     private UserType findUserType(List<Role> roles){

--- a/repository/src/main/java/org/grnet/cat/repositories/ValidationRepository.java
+++ b/repository/src/main/java/org/grnet/cat/repositories/ValidationRepository.java
@@ -1,7 +1,5 @@
 package org.grnet.cat.repositories;
 
-import io.quarkus.hibernate.orm.panache.PanacheQuery;
-import io.quarkus.hibernate.orm.panache.PanacheRepositoryBase;
 import jakarta.enterprise.context.ApplicationScoped;
 import org.grnet.cat.entities.*;
 import org.grnet.cat.enums.Source;
@@ -9,14 +7,12 @@ import org.grnet.cat.enums.ValidationStatus;
 
 import java.util.Arrays;
 import java.util.List;
-import java.util.Optional;
-
 
 /**
  * The ValidationRepository interface provides data access methods for the Validation entity.
  */
 @ApplicationScoped
-public class ValidationRepository implements PanacheRepositoryBase<Validation, Long>, Repository<Validation, Long> {
+public class ValidationRepository implements Repository<Validation, Long> {
 
     /**
      * It executes a query in database to check if there is a promotion request for a specific user and organisation.
@@ -121,10 +117,4 @@ public class ValidationRepository implements PanacheRepositoryBase<Validation, L
 
         return pageable;
     }
-
-    @Override
-    public Optional<Validation> searchByIdOptional(Long id) {
-        return findByIdOptional(id);
-    }
-
 }


### PR DESCRIPTION
This commit addresses the JIRA ticket CAT-91, which aims to create a new API endpoint to view list of assessments. The implemented changes introduce a new endpoint and its associated functionality to serve the required data.