### PR TITLE
[CAT-178] Delete private assessment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,10 @@ According to [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) , the `Unr
 
 ---
 
+### Added
+
+-   [#76](https://github.com/FC4E-CAT/fc4e-cat-api/pull/76)    -  CAT-178 Delete private assessment.
+
 ### Changed
 
 -   [#73](https://github.com/FC4E-CAT/fc4e-cat-api/pull/73)    -  CAT-159 Change assessment id from bigint to uuid.

--- a/api/config/quarkus-realm.json
+++ b/api/config/quarkus-realm.json
@@ -342,6 +342,14 @@
           "attributes": {}
         },
         {
+          "id": "df147a31-5da2-5bbc-866c-f20cf99b2637",
+          "name": "evald",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "0ac5df91-e044-4051-bd03-106a3a5fb9cc",
+          "attributes": {}
+        },
+        {
           "id": "df147a91-4da7-5bbc-266c-f70cf99b2637",
           "name": "identified",
           "composite": false,
@@ -2891,6 +2899,25 @@
       "clientRoles": {
         "backend-service": [
           "identified"
+        ]
+      }
+    },
+    {
+      "username": "evald",
+      "enabled": true,
+      "attributes": {
+        "voperson_id": ["evald_voperson_id"]
+      },
+      "credentials": [
+        {
+          "type": "password",
+          "value": "evald"
+        }
+      ],
+      "clientRoles": {
+        "backend-service": [
+          "identified",
+          "validated"
         ]
       }
     },

--- a/api/src/main/java/org/grnet/cat/api/endpoints/AssessmentsEndpoint.java
+++ b/api/src/main/java/org/grnet/cat/api/endpoints/AssessmentsEndpoint.java
@@ -6,6 +6,7 @@ import jakarta.validation.Valid;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
+import jakarta.ws.rs.DELETE;
 import jakarta.ws.rs.DefaultValue;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.POST;
@@ -147,6 +148,12 @@ public class AssessmentsEndpoint {
                     type = SchemaType.OBJECT,
                     implementation = InformativeResponse.class)))
     @APIResponse(
+            responseCode = "404",
+            description = "Entity Not Found.",
+            content = @Content(schema = @Schema(
+                    type = SchemaType.OBJECT,
+                    implementation = InformativeResponse.class)))
+    @APIResponse(
             responseCode = "500",
             description = "Internal Server Error.",
             content = @Content(schema = @Schema(
@@ -194,6 +201,12 @@ public class AssessmentsEndpoint {
     @APIResponse(
             responseCode = "403",
             description = "Not permitted.",
+            content = @Content(schema = @Schema(
+                    type = SchemaType.OBJECT,
+                    implementation = InformativeResponse.class)))
+    @APIResponse(
+            responseCode = "404",
+            description = "Entity Not Found.",
             content = @Content(schema = @Schema(
                     type = SchemaType.OBJECT,
                     implementation = InformativeResponse.class)))
@@ -291,6 +304,12 @@ public class AssessmentsEndpoint {
                     type = SchemaType.OBJECT,
                     implementation = InformativeResponse.class)))
     @APIResponse(
+            responseCode = "404",
+            description = "Entity Not Found.",
+            content = @Content(schema = @Schema(
+                    type = SchemaType.OBJECT,
+                    implementation = InformativeResponse.class)))
+    @APIResponse(
             responseCode = "500",
             description = "Internal Server Error.",
             content = @Content(schema = @Schema(
@@ -321,6 +340,61 @@ public class AssessmentsEndpoint {
         var assessments = assessmentService.getPublishedAssessmentsByTypeAndActorAndPage(page - 1, size, typeId, actorId, uriInfo);
 
         return Response.ok().entity(assessments).build();
+    }
+
+    @Tag(name = "Assessment")
+    @Operation(
+            summary = "Delete private Assessment.",
+            description = "Deletes a private assessment if it is not published and belongs to the authenticated user.")
+    @APIResponse(
+            responseCode = "200",
+            description = "The corresponding assessment.",
+            content = @Content(schema = @Schema(
+                    type = SchemaType.OBJECT,
+                    implementation = InformativeResponse.class)))
+    @APIResponse(
+            responseCode = "401",
+            description = "User has not been authenticated.",
+            content = @Content(schema = @Schema(
+                    type = SchemaType.OBJECT,
+                    implementation = InformativeResponse.class)))
+    @APIResponse(
+            responseCode = "403",
+            description = "Not permitted.",
+            content = @Content(schema = @Schema(
+                    type = SchemaType.OBJECT,
+                    implementation = InformativeResponse.class)))
+    @APIResponse(
+            responseCode = "404",
+            description = "Entity Not Found.",
+            content = @Content(schema = @Schema(
+                    type = SchemaType.OBJECT,
+                    implementation = InformativeResponse.class)))
+    @APIResponse(
+            responseCode = "500",
+            description = "Internal Server Error.",
+            content = @Content(schema = @Schema(
+                    type = SchemaType.OBJECT,
+                    implementation = InformativeResponse.class)))
+    @SecurityRequirement(name = "Authentication")
+    @DELETE
+    @Path("/{id}")
+    @Produces(MediaType.APPLICATION_JSON)
+    @Registration
+    public Response deleteAssessment(@Parameter(
+            description = "The ID of the assessment to be deleted.",
+            required = true,
+            example = "c242e43f-9869-4fb0-b881-631bc5746ec0",
+            schema = @Schema(type = SchemaType.STRING)) @PathParam("id")
+                                  @Valid @NotFoundEntity(repository = AssessmentRepository.class, message = "There is no Assessment with the following id:") String id) {
+
+        assessmentService.deletePrivateAssessment(utility.getUserUniqueIdentifier(), id);
+
+        var informativeResponse = new InformativeResponse();
+        informativeResponse.code = 200;
+        informativeResponse.message = "Assessment has been successfully deleted.";
+
+        return Response.ok().entity(informativeResponse).build();
     }
 
     public static class PageablePartialAssessmentResponse extends PageResource<PartialJsonAssessmentResponse> {

--- a/api/src/main/java/org/grnet/cat/api/endpoints/TemplatesEndpoint.java
+++ b/api/src/main/java/org/grnet/cat/api/endpoints/TemplatesEndpoint.java
@@ -75,6 +75,12 @@ public class TemplatesEndpoint {
                     type = SchemaType.OBJECT,
                     implementation = InformativeResponse.class)))
     @APIResponse(
+            responseCode = "404",
+            description = "Entity Not Found.",
+            content = @Content(schema = @Schema(
+                    type = SchemaType.OBJECT,
+                    implementation = InformativeResponse.class)))
+    @APIResponse(
             responseCode = "500",
             description = "Internal Server Error.",
             content = @Content(schema = @Schema(
@@ -130,6 +136,12 @@ public class TemplatesEndpoint {
                     type = SchemaType.OBJECT,
                     implementation = InformativeResponse.class)))
     @APIResponse(
+            responseCode = "404",
+            description = "Entity Not Found.",
+            content = @Content(schema = @Schema(
+                    type = SchemaType.OBJECT,
+                    implementation = InformativeResponse.class)))
+    @APIResponse(
             responseCode = "500",
             description = "Internal Server Error.",
             content = @Content(schema = @Schema(
@@ -166,6 +178,12 @@ public class TemplatesEndpoint {
     @APIResponse(
             responseCode = "403",
             description = "Not permitted.",
+            content = @Content(schema = @Schema(
+                    type = SchemaType.OBJECT,
+                    implementation = InformativeResponse.class)))
+    @APIResponse(
+            responseCode = "404",
+            description = "Entity Not Found.",
             content = @Content(schema = @Schema(
                     type = SchemaType.OBJECT,
                     implementation = InformativeResponse.class)))
@@ -213,6 +231,12 @@ public class TemplatesEndpoint {
     @APIResponse(
             responseCode = "403",
             description = "Not permitted.",
+            content = @Content(schema = @Schema(
+                    type = SchemaType.OBJECT,
+                    implementation = InformativeResponse.class)))
+    @APIResponse(
+            responseCode = "404",
+            description = "Entity Not Found.",
             content = @Content(schema = @Schema(
                     type = SchemaType.OBJECT,
                     implementation = InformativeResponse.class)))
@@ -314,6 +338,12 @@ public class TemplatesEndpoint {
                     type = SchemaType.OBJECT,
                     implementation = InformativeResponse.class)))
     @APIResponse(
+            responseCode = "404",
+            description = "Entity Not Found.",
+            content = @Content(schema = @Schema(
+                    type = SchemaType.OBJECT,
+                    implementation = InformativeResponse.class)))
+    @APIResponse(
             responseCode = "500",
             description = "Internal Server Error.",
             content = @Content(schema = @Schema(
@@ -342,7 +372,7 @@ public class TemplatesEndpoint {
         return Response.ok().entity(templates).build();
     }
 
-    public class PageableTemplate extends PageResource<TemplateResponse> {
+    public static class PageableTemplate extends PageResource<TemplateResponse> {
 
         private List<TemplateResponse> content;
 

--- a/service/src/main/java/org/grnet/cat/services/assessment/AssessmentService.java
+++ b/service/src/main/java/org/grnet/cat/services/assessment/AssessmentService.java
@@ -18,4 +18,6 @@ public interface AssessmentService <Request extends AssessmentRequest, Update, R
     PageResource<? extends Response> getAssessmentsByUserAndPage(int page, int size, UriInfo uriInfo, String userID);
 
     PageResource<? extends Response> getPublishedAssessmentsByTypeAndActorAndPage(int page, int size, Long typeId, Long actorId, UriInfo uriInfo);
+
+    void deletePrivateAssessment(String userID, String assessmentId);
 }


### PR DESCRIPTION
We have generated a new endpoint that deletes an assessment if it is not published and belongs to the authenticated user.