### PR TITLE
use INTEGER insteadof TINYINT

### DIFF
--- a/entity/src/main/resources/db/migration/V1.12__update_validation_status.sql
+++ b/entity/src/main/resources/db/migration/V1.12__update_validation_status.sql
@@ -13,4 +13,4 @@ SET status = CASE
                  ELSE '1'
                  END;
 
-ALTER TABLE Validation MODIFY status tinyint NOT NULL;
+ALTER TABLE Validation MODIFY status INTEGER NOT NULL;

--- a/entity/src/main/resources/db/migration/V1.34__update_validation_status.sql
+++ b/entity/src/main/resources/db/migration/V1.34__update_validation_status.sql
@@ -1,0 +1,7 @@
+-- ------------------------------------------------
+-- Version: v1.34
+--
+-- Description: Migration that updates the validation status column in the Validation table
+-- -------------------------------------------------
+
+ALTER TABLE Validation MODIFY status INTEGER NOT NULL;


### PR DESCRIPTION
When running from scratch (first-time),
Hibernate is expecting an INTER: found [tinyint (Types#TINYINT)], but expecting [integer (Types#INTEGER)
So, either change SQL, or change Hibernate. I dont know which you prefer, I changed SQL.