### PR TITLE
[CAT-276] Implement Flexible Logic for Saving Assessments in the Database

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,19 +33,22 @@ According to [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) , the `Unr
 -   [#104](https://github.com/FC4E-CAT/fc4e-cat-api/pull/104)  -  CAT-261 Create a new Subject.
 -   [#105](https://github.com/FC4E-CAT/fc4e-cat-api/pull/105)  -  CAT-263 Delete a Subject.
 -   [#106](https://github.com/FC4E-CAT/fc4e-cat-api/pull/106)  -  CAT-274 Fetch the created Subjects.
+-   [#107](https://github.com/FC4E-CAT/fc4e-cat-api/pull/107)  -  CAT-262 Update a Subject.
+-   [#109](https://github.com/FC4E-CAT/fc4e-cat-api/pull/109)  -  CAT-276 Implement Flexible Logic for Saving Assessments in the Database.
 
 ### Changed
 
 -   [#73](https://github.com/FC4E-CAT/fc4e-cat-api/pull/73)    -  CAT-159 Change assessment id from bigint to uuid.
--   [#79](https://github.com/FC4E-CAT/fc4e-cat-api/pull/79)    -  CAT-169 Create template for actor: Scheme.
--   [#80](https://github.com/FC4E-CAT/fc4e-cat-api/pull/80)    -  CAT-167 Create template for actor: Manager.
+-   [#79](https://github.com/FC4E-CAT/fc4e-cat-api/pull/79)    -  CAT-169 Create a template for the actor: Scheme.
+-   [#80](https://github.com/FC4E-CAT/fc4e-cat-api/pull/80)    -  CAT-167 Create a template for the actor: Manager.
 -   [#81](https://github.com/FC4E-CAT/fc4e-cat-api/pull/81)    -  CAT-181 Generate JSON Schema for PID Owner Template.
 -   [#82](https://github.com/FC4E-CAT/fc4e-cat-api/pull/82)    -  fix json of scheme template.
--   [#83](https://github.com/FC4E-CAT/fc4e-cat-api/pull/83)    -  CAT-168 Create template for actor: Service.
+-   [#83](https://github.com/FC4E-CAT/fc4e-cat-api/pull/83)    -  CAT-168 Create a template for the actor: Service.
 -   [#95](https://github.com/FC4E-CAT/fc4e-cat-api/pull/95)    -  CAT-218 API move /users list under /admin path.
 -   [#96](https://github.com/FC4E-CAT/fc4e-cat-api/pull/96)    -  CAT-220 Remove unnecessary properties from the assessment creation request.
 -   [#99](https://github.com/FC4E-CAT/fc4e-cat-api/pull/99)    -  CAT-231 Sort the validation requests by creation date.
--   [#100](https://github.com/FC4E-CAT/fc4e-cat-api/pull/100)  -  CAT-229 Required fields on assesment metadata.
+-   [#100](https://github.com/FC4E-CAT/fc4e-cat-api/pull/100)  -  CAT-229 Required fields on assessment metadata.
+-   [#108](https://github.com/FC4E-CAT/fc4e-cat-api/pull/108)  -  CAT-275 Refactor the template json to handle subject db_id property .
 
 
 ## 1.1.0 - 2023-09-01

--- a/api/src/main/java/org/grnet/cat/api/endpoints/AssessmentsEndpoint.java
+++ b/api/src/main/java/org/grnet/cat/api/endpoints/AssessmentsEndpoint.java
@@ -66,7 +66,9 @@ public class AssessmentsEndpoint {
     @Operation(
             summary = "Request to create an assessment.",
             description = "This endpoint allows a validated user to create an assessment for a validation request." +
-                    " The validated user should provide the necessary information to support their request.")
+                    " The validated user should provide the necessary information to support their request. " +
+                    "The API provides flexibility for clients to either use an existing Subject by specifying its id in the subject.db_id property " +
+                    "or create a new one by leaving subject.db_id empty and filling in the other three properties (subject.name, subject.type and subject.id)")
     @APIResponse(
             responseCode = "201",
             description = "Assessment creation successful.",
@@ -235,7 +237,7 @@ public class AssessmentsEndpoint {
             schema = @Schema(type = SchemaType.STRING))
                                      @PathParam("id")
                                      @Valid @NotFoundEntity(repository = AssessmentRepository.class, message = "There is no assessment with the following id:") String id,
-                                     @Valid @NotNull(message = "The request body is empty.") UpdateJsonAssessmentRequest updateJsonAssessmentRequest) {
+                                     @Valid @NotNull(message = "The request body is empty.") JsonAssessmentRequest updateJsonAssessmentRequest) {
 
         var assessment = assessmentService.updatePrivateAssessmentBelongsToUser(id, utility.getUserUniqueIdentifier(), updateJsonAssessmentRequest);
 

--- a/api/src/main/java/org/grnet/cat/api/endpoints/SubjectsEndpoint.java
+++ b/api/src/main/java/org/grnet/cat/api/endpoints/SubjectsEndpoint.java
@@ -266,7 +266,7 @@ public class SubjectsEndpoint {
                                           @PathParam("id")
                                           @Valid @NotFoundEntity(repository = SubjectRepository.class, message = "There is no Subject with the following id:") Long id) {
 
-        var subject = subjectService.getSubject(id, utility.getUserUniqueIdentifier());
+        var subject = subjectService.getSubjectByUserAndId(id, utility.getUserUniqueIdentifier());
 
         return Response.ok().entity(subject).build();
     }

--- a/data-transfer-object/src/main/java/org/grnet/cat/dtos/assessment/JsonAssessmentRequest.java
+++ b/data-transfer-object/src/main/java/org/grnet/cat/dtos/assessment/JsonAssessmentRequest.java
@@ -1,7 +1,6 @@
 package org.grnet.cat.dtos.assessment;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
 import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
@@ -17,7 +16,6 @@ public class JsonAssessmentRequest{
             description = "The assessment doc."
     )
     @JsonProperty("assessment_doc")
-    @NotNull(message = "assessment doc may not be empty")
-    @Valid
+    @NotNull(message = "assessment doc may not be empty.")
     public TemplateDto assessmentDoc;
 }

--- a/service/src/main/java/org/grnet/cat/services/SubjectService.java
+++ b/service/src/main/java/org/grnet/cat/services/SubjectService.java
@@ -4,6 +4,7 @@ import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import jakarta.transaction.Transactional;
 import jakarta.ws.rs.ForbiddenException;
+import jakarta.ws.rs.NotFoundException;
 import jakarta.ws.rs.core.UriInfo;
 import org.grnet.cat.dtos.pagination.PageResource;
 import org.grnet.cat.dtos.subject.SubjectRequest;
@@ -17,6 +18,7 @@ import org.grnet.cat.repositories.SubjectRepository;
 
 import java.sql.Timestamp;
 import java.time.Instant;
+import java.util.Optional;
 
 /**
  * The SubjectService provides operations for managing Subject entities.
@@ -42,8 +44,7 @@ public class SubjectService {
         subject.setCreatedBy(userId);
         subject.setCreatedOn(Timestamp.from(Instant.now()));
 
-        var optional = subjectRepository
-                .fetchSubjectByNameAndTypeAndSubjectId(request.name, request.type, request.id, userId);
+        var optional = subjectRepository.fetchSubjectByNameAndTypeAndSubjectId(request.name, request.type, request.id, userId);
 
         if(optional.isPresent()){
 
@@ -53,6 +54,11 @@ public class SubjectService {
         subjectRepository.persist(subject);
 
         return SubjectMapper.INSTANCE.subjectToDto(subject);
+    }
+
+    public Optional<Subject> getSubjectByNameAndTypeAndSubjectId(String name, String type, String subjectId, String userID){
+
+        return subjectRepository.fetchSubjectByNameAndTypeAndSubjectId(name, type, subjectId, userID);
     }
 
     /**
@@ -97,7 +103,7 @@ public class SubjectService {
      * @param userID The ID of the user who requests the subject.
      * @return The corresponding Subject.
      */
-    public SubjectResponse getSubject(Long id, String userID){
+    public SubjectResponse getSubjectByUserAndId(Long id, String userID){
 
         var subject = subjectRepository.findById(id);
 
@@ -106,6 +112,19 @@ public class SubjectService {
         }
 
         return SubjectMapper.INSTANCE.subjectToDto(subject);
+    }
+
+    /**
+     * Retrieves a specific Subject.
+     *
+     * @param id The ID of the Subject to retrieve.
+     * @return The corresponding Subject.
+     */
+    public Subject getSubjectById(Long id){
+
+        var subject = subjectRepository.findByIdOptional(id);
+
+        return subject.orElseThrow(()-> new NotFoundException("There is no Subject with the following id: "+id));
     }
 
     /**

--- a/service/src/main/java/org/grnet/cat/services/assessment/AssessmentService.java
+++ b/service/src/main/java/org/grnet/cat/services/assessment/AssessmentService.java
@@ -14,7 +14,7 @@ public interface AssessmentService <Request, Update, Response extends Assessment
 
     void deleteAll();
 
-    Response update(String id, Update request);
+    Response update(String id, String userId, Update request);
 
     PageResource<? extends Response> getDtoAssessmentsByUserAndPage(int page, int size, UriInfo uriInfo, String userID, String subjectName, String subjectType, Long actorId);
 

--- a/service/src/main/java/org/grnet/cat/services/assessment/JsonAbstractAssessmentService.java
+++ b/service/src/main/java/org/grnet/cat/services/assessment/JsonAbstractAssessmentService.java
@@ -30,7 +30,7 @@ public abstract class JsonAbstractAssessmentService<Request, Update, Response ex
     public Response updatePrivateAssessmentBelongsToUser(String id, String userId, Update request) {
 
         assessmentBelongsToUser(userId, id);
-        return updatePrivateAssessment(id, request);
+        return updatePrivateAssessment(id, userId, request);
     }
 
     /**
@@ -50,13 +50,14 @@ public abstract class JsonAbstractAssessmentService<Request, Update, Response ex
      * Updates a private assessment if it is not published.
      *
      * @param id The ID of the assessment whose is being updated.
+     * @param userId The ID of the user who requests to update a specific assessment.
      * @param request The update request.
      * @throws ForbiddenException If the user does not have permission to delete this assessment (e.g., it's published).
      */
-    public Response updatePrivateAssessment(String id, Update request){
+    public Response updatePrivateAssessment(String id, String userId, Update request){
 
         var assessment = getAssessment(id);
         forbidActionsToPublicAssessment(assessment);
-        return update(id, request);
+        return update(id, userId, request);
     }
 }

--- a/service/src/main/java/org/grnet/cat/services/assessment/JsonAssessmentService.java
+++ b/service/src/main/java/org/grnet/cat/services/assessment/JsonAssessmentService.java
@@ -20,6 +20,7 @@ import org.grnet.cat.dtos.assessment.JsonAssessmentResponse;
 import org.grnet.cat.dtos.assessment.PartialJsonAssessmentResponse;
 import org.grnet.cat.dtos.assessment.UpdateJsonAssessmentRequest;
 import org.grnet.cat.dtos.pagination.PageResource;
+import org.grnet.cat.dtos.subject.SubjectRequest;
 import org.grnet.cat.dtos.template.TemplateSubjectDto;
 import org.grnet.cat.entities.Assessment;
 import org.grnet.cat.exceptions.InternalServerErrorException;
@@ -28,12 +29,14 @@ import org.grnet.cat.mappers.TemplateMapper;
 import org.grnet.cat.repositories.AssessmentRepository;
 import org.grnet.cat.repositories.TemplateRepository;
 import org.grnet.cat.repositories.ValidationRepository;
+import org.grnet.cat.services.SubjectService;
 
 import java.sql.Timestamp;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.Map;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 /**
@@ -41,7 +44,7 @@ import java.util.stream.Collectors;
  */
 @ApplicationScoped
 @Named("json-assessment-service")
-public class JsonAssessmentService extends JsonAbstractAssessmentService<JsonAssessmentRequest, UpdateJsonAssessmentRequest, AssessmentResponse, Assessment> {
+public class JsonAssessmentService extends JsonAbstractAssessmentService<JsonAssessmentRequest, JsonAssessmentRequest, AssessmentResponse, Assessment> {
 
     @Inject
     AssessmentRepository assessmentRepository;
@@ -55,11 +58,15 @@ public class JsonAssessmentService extends JsonAbstractAssessmentService<JsonAss
     @Inject
     ObjectMapper objectMapper;
 
+    @Inject
+    SubjectService subjectService;
+
     @Override
     @Transactional
     @SneakyThrows
     public JsonAssessmentResponse createAssessment(String userId, JsonAssessmentRequest request) {
 
+        handleSubjectDatabaseId(userId, request);
         var validation = validationRepository.fetchValidationByUserAndActorAndOrganisation(userId, request.assessmentDoc.actor.id, request.assessmentDoc.organisation.id);
         var template = templateRepository.fetchTemplateByActor(request.assessmentDoc.actor.id);
 
@@ -85,6 +92,48 @@ public class JsonAssessmentService extends JsonAbstractAssessmentService<JsonAss
         storedAssessment.setAssessmentDoc(objectMapper.writeValueAsString(assessmentDoc));
 
         return AssessmentMapper.INSTANCE.assessmentToJsonAssessment(storedAssessment);
+    }
+
+    /**
+     *The API should provide flexibility for clients to either use an existing Subject by specifying its id in the db_id property
+     * or create a new one by leaving db_id empty and filling in the other three properties (name, type and id).
+     *The API should also give precedence to the properties stored in the database. If a valid db_id is provided,
+     * its associated Subject should be retrieved, and the values of name, type, and id in the Assessment should be overwritten
+     * with the corresponding values from the existing  database Subject.
+     *
+     */
+    private void handleSubjectDatabaseId(String userId, JsonAssessmentRequest request){
+
+        if(Objects.isNull(request.assessmentDoc.subject.dbId)){
+
+            var optional = subjectService
+                    .getSubjectByNameAndTypeAndSubjectId(request.assessmentDoc.subject.name, request.assessmentDoc.subject.type, request.assessmentDoc.subject.id, userId);
+
+            if(optional.isEmpty()){
+
+                var newSubject = new SubjectRequest();
+                newSubject.name = request.assessmentDoc.subject.name;
+                newSubject.type = request.assessmentDoc.subject.type;
+                newSubject.id = request.assessmentDoc.subject.id;
+
+                var response = subjectService.createSubject(newSubject, userId);
+                request.assessmentDoc.subject.dbId = response.id;
+            } else {
+
+                request.assessmentDoc.subject.dbId = optional.get().getId();
+            }
+        } else{
+
+            var subject = subjectService.getSubjectById(request.assessmentDoc.subject.dbId);
+
+            if (!subject.getCreatedBy().equals(userId)) {
+                throw new ForbiddenException("User not authorized to manage subject with ID " + request.assessmentDoc.subject.dbId);
+            }
+
+            request.assessmentDoc.subject.name = subject.getName();
+            request.assessmentDoc.subject.type = subject.getType();
+            request.assessmentDoc.subject.id = subject.getSubjectId();
+        }
     }
 
     private void validateAssessmentAgainstTemplate(String request, String template){
@@ -257,12 +306,15 @@ public class JsonAssessmentService extends JsonAbstractAssessmentService<JsonAss
      * Updates the Assessment's json document.
      *
      * @param id The ID of the assessment whose json doc is being updated.
+     * @param userId The ID of the user who requests to update a specific assessment.
      * @param request The update request.
      * @return The updated assessment
      */
     @Override
     @SneakyThrows
-    public JsonAssessmentResponse update(String id, UpdateJsonAssessmentRequest request) {
+    public JsonAssessmentResponse update(String id, String userId, JsonAssessmentRequest request) {
+
+        handleSubjectDatabaseId(userId, request);
 
         var assessmentDoc = AssessmentMapper.INSTANCE.templateDocToAssessmentDoc(request.assessmentDoc);
 


### PR DESCRIPTION
The API should provide flexibility for clients to either use an existing Subject by specifying its id in the subject.db_id property or create a new one by leaving subject.db_id empty and filling in the other three properties (subject.name, subject.type and subject.id).

Finally, the API should give precedence to the properties stored in the database. If a valid subject.db_id is provided, its associated Subject should be retrieved, and the values of name, type, and id in the Assessment should be overwritten with the corresponding values from the existing database Subject.