### PR TITLE
[CAT-279] Deny access to the CAT Service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ According to [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) , the `Unr
 -   [#107](https://github.com/FC4E-CAT/fc4e-cat-api/pull/107)  -  CAT-262 Update a Subject.
 -   [#109](https://github.com/FC4E-CAT/fc4e-cat-api/pull/109)  -  CAT-276 Implement Flexible Logic for Saving Assessments in the Database.
 -   [#112](https://github.com/FC4E-CAT/fc4e-cat-api/pull/112)  -  CAT-264 Update api calls to objects used for filters.
+-   [#113](https://github.com/FC4E-CAT/fc4e-cat-api/pull/113)  -  CAT-279 API Endpoint for assigning deny_access role.
 
 ### Changed
 

--- a/api/src/main/java/org/grnet/cat/api/endpoints/AdminEndpoint.java
+++ b/api/src/main/java/org/grnet/cat/api/endpoints/AdminEndpoint.java
@@ -34,6 +34,7 @@ import org.grnet.cat.dtos.InformativeResponse;
 import org.grnet.cat.dtos.UpdateValidationStatus;
 import org.grnet.cat.dtos.ValidationRequest;
 import org.grnet.cat.dtos.ValidationResponse;
+import org.grnet.cat.dtos.access.DenyAccess;
 import org.grnet.cat.enums.ValidationStatus;
 import org.grnet.cat.repositories.AssessmentRepository;
 import org.grnet.cat.repositories.ValidationRepository;
@@ -378,5 +379,49 @@ public class AdminEndpoint {
         var userProfile = userService.getUsersByPage(page-1, size, uriInfo);
 
         return Response.ok().entity(userProfile).build();
+    }
+
+    @Tag(name = "Admin")
+    @Operation(
+            summary = "Restrict a user's access.",
+            description = "Calling this endpoint results in the specified user being denied access to the API.")
+    @APIResponse(
+            responseCode = "200",
+            description = "Successful operation.",
+            content = @Content(schema = @Schema(
+                    type = SchemaType.OBJECT,
+                    implementation = InformativeResponse.class)))
+    @APIResponse(
+            responseCode = "401",
+            description = "User has not been authenticated.",
+            content = @Content(schema = @Schema(
+                    type = SchemaType.OBJECT,
+                    implementation = InformativeResponse.class)))
+    @APIResponse(
+            responseCode = "403",
+            description = "Not permitted.",
+            content = @Content(schema = @Schema(
+                    type = SchemaType.OBJECT,
+                    implementation = InformativeResponse.class)))
+    @APIResponse(
+            responseCode = "500",
+            description = "Internal Server Error.",
+            content = @Content(schema = @Schema(
+                    type = SchemaType.OBJECT,
+                    implementation = InformativeResponse.class)))
+    @SecurityRequirement(name = "Authentication")
+    @PUT
+    @Path("/users/deny-access")
+    @Produces(MediaType.APPLICATION_JSON)
+    @Registration
+    public Response denyAccess( @Valid @NotNull(message = "The request body is empty.") DenyAccess denyAccess) {
+
+        userService.addDenyAccessRole(utility.getUserUniqueIdentifier(), denyAccess.userId, denyAccess.reason);
+
+        var informativeResponse = new InformativeResponse();
+        informativeResponse.code = 200;
+        informativeResponse.message = "deny_access role added successfully to the user. User now denied access to the API.";
+
+        return Response.ok().entity(informativeResponse).build();
     }
 }

--- a/data-transfer-object/src/main/java/org/grnet/cat/dtos/UserProfileDto.java
+++ b/data-transfer-object/src/main/java/org/grnet/cat/dtos/UserProfileDto.java
@@ -32,7 +32,7 @@ public class UserProfileDto {
             type = SchemaType.STRING,
             implementation = UserType.class,
             description = "Type of user (e.g., Identified, Validated, Admin).",
-            example = " Identified"
+            example = "Identified"
     )
     @JsonProperty("user_type")
     public String type;
@@ -106,4 +106,13 @@ public class UserProfileDto {
     @JsonProperty("roles")
     @JsonInclude(JsonInclude.Include.NON_NULL)
     public List<String> roles;
+
+    @Schema(
+            type = SchemaType.BOOLEAN,
+            implementation = Boolean.class,
+            description = "If a User is banned.",
+            example = "false"
+    )
+    @JsonProperty("banned")
+    public Boolean banned;
 }

--- a/data-transfer-object/src/main/java/org/grnet/cat/dtos/access/DenyAccess.java
+++ b/data-transfer-object/src/main/java/org/grnet/cat/dtos/access/DenyAccess.java
@@ -1,0 +1,35 @@
+package org.grnet.cat.dtos.access;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.constraints.NotEmpty;
+import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
+import org.grnet.cat.constraints.NotFoundEntity;
+import org.grnet.cat.repositories.UserRepository;
+
+@Schema(name="DenyAccess", description="This object represents the denial of access to the CAT Service.")
+public class DenyAccess {
+
+    @Schema(
+            type = SchemaType.STRING,
+            implementation = String.class,
+            required = true,
+            description = "The unique identifier of the user to whom the access will be restricted.",
+            example = "7827fbb605a23b0cbd5cb4db292fe6dd6c7734a27057eb163d616a6ecd02d2ec@einfra.grnet.gr"
+    )
+    @JsonProperty("user_id")
+    @NotEmpty(message = "user_id may not be empty.")
+    @NotFoundEntity(repository = UserRepository.class, message = "There is no User with the following id:")
+    public String userId;
+
+    @Schema(
+            type = SchemaType.STRING,
+            implementation = String.class,
+            required = true,
+            description = "The reason for denying access to the user.",
+            example = "User's account under investigation."
+    )
+    @JsonProperty("reason")
+    @NotEmpty(message = "reason may not be empty.")
+    public String reason;
+}

--- a/entity/src/main/java/org/grnet/cat/entities/User.java
+++ b/entity/src/main/java/org/grnet/cat/entities/User.java
@@ -67,6 +67,9 @@ public class User {
     @Column(name = "validated_on")
     private Timestamp validatedOn;
 
+    @Column
+    private Boolean banned;
+
     @Transient
     private List<Role> roles;
 
@@ -148,5 +151,13 @@ public class User {
 
     public void setOrcidId(String orcidId) {
         this.orcidId = orcidId;
+    }
+
+    public Boolean isBanned() {
+        return banned;
+    }
+
+    public void setBanned(Boolean banned) {
+        this.banned = banned;
     }
 }

--- a/entity/src/main/java/org/grnet/cat/entities/history/AccessToCatService.java
+++ b/entity/src/main/java/org/grnet/cat/entities/history/AccessToCatService.java
@@ -1,0 +1,28 @@
+package org.grnet.cat.entities.history;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.DiscriminatorValue;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import jakarta.validation.constraints.NotEmpty;
+
+@Entity
+@Table(name = "AccessToCatServiceHistory")
+@DiscriminatorValue("access_to_cat_service")
+public class AccessToCatService extends History{
+
+    /**
+     * The action the user performs.
+     */
+    @Column(name = "action")
+    @NotEmpty
+    private String action;
+
+    public String getAction() {
+        return action;
+    }
+
+    public void setAction(String action) {
+        this.action = action;
+    }
+}

--- a/entity/src/main/java/org/grnet/cat/entities/history/History.java
+++ b/entity/src/main/java/org/grnet/cat/entities/history/History.java
@@ -1,0 +1,67 @@
+package org.grnet.cat.entities.history;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.validation.constraints.NotEmpty;
+
+import java.sql.Timestamp;
+
+@Entity
+public class History {
+
+    @Id
+    @GeneratedValue(strategy= GenerationType.IDENTITY)
+    private Long id;
+
+    @Column
+    @NotEmpty
+    private String action;
+
+    /**
+     * The use who performs the action.
+     */
+    @Column(name = "user_id")
+    @NotEmpty
+    private String userId;
+
+    /**
+     * The date and time the action is performed.
+     */
+    @Column(name = "performed_on")
+    private Timestamp performedOn;
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getUserId() {
+        return userId;
+    }
+
+    public void setUserId(String userId) {
+        this.userId = userId;
+    }
+
+    public Timestamp getPerformedOn() {
+        return performedOn;
+    }
+
+    public void setPerformedOn(Timestamp performedOn) {
+        this.performedOn = performedOn;
+    }
+
+    public String getAction() {
+        return action;
+    }
+
+    public void setAction(String action) {
+        this.action = action;
+    }
+}

--- a/entity/src/main/resources/db/migration/tables/history/V1.51__history.sql
+++ b/entity/src/main/resources/db/migration/tables/history/V1.51__history.sql
@@ -1,0 +1,12 @@
+-- ------------------------------------------------
+-- Version: v1.51
+--
+-- Description: Migration that introduces the History table
+-- -------------------------------------------------
+
+CREATE TABLE History (
+   id BIGINT AUTO_INCREMENT PRIMARY KEY,
+   user_id varchar(255) NOT NULL,
+   action varchar(10000) NOT NULL,
+   performed_on datetime(6) NOT NULL
+);

--- a/entity/src/main/resources/db/migration/tables/user/V1.52__banned.sql
+++ b/entity/src/main/resources/db/migration/tables/user/V1.52__banned.sql
@@ -1,0 +1,5 @@
+-- ------------------------------------------------
+-- Version: v1.52
+-- -------------------------------------------------
+
+ALTER TABLE User ADD COLUMN banned BOOLEAN DEFAULT false;

--- a/repository/src/main/java/org/grnet/cat/repositories/HistoryRepository.java
+++ b/repository/src/main/java/org/grnet/cat/repositories/HistoryRepository.java
@@ -1,0 +1,8 @@
+package org.grnet.cat.repositories;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import org.grnet.cat.entities.history.History;
+
+@ApplicationScoped
+public class HistoryRepository implements Repository<History, Long> {
+}


### PR DESCRIPTION
This Pull Request introduces a new API endpoint for adding the deny_access role to a user in Keycloak. The endpoint is designed to be used by administrators and serves the purpose of denying access to the API for the specified user.