### PR TITLE
[CAT-295] Assign identified role to user during registration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,7 +43,7 @@ According to [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) , the `Unr
 -   [#113](https://github.com/FC4E-CAT/fc4e-cat-api/pull/113)  -  CAT-279 API Endpoint for assigning deny_access role.
 -   [#114](https://github.com/FC4E-CAT/fc4e-cat-api/pull/114)  -  CAT-280 API Endpoint for removing deny_access role.
 -   [#116](https://github.com/FC4E-CAT/fc4e-cat-api/pull/116)  -  CAT-289 As an admin i want to see some statistics in CAT
-
+-   [#121](https://github.com/FC4E-CAT/fc4e-cat-api/pull/121)  -  CAT-295 Assign identified role to user during registration through Keycloak API.
 ### Changed
 
 -   [#73](https://github.com/FC4E-CAT/fc4e-cat-api/pull/73)    -  CAT-159 Change assessment id from bigint to uuid.

--- a/api/config/quarkus-realm.json
+++ b/api/config/quarkus-realm.json
@@ -909,7 +909,7 @@
       ],
       "authorizationSettings":{
         "allowRemoteResourceManagement": true,
-        "policyEnforcementMode": "ENFORCING",
+        "policyEnforcementMode": "PERMISSIVE",
         "resources": [
           {
             "name": "Codelist Resource",
@@ -1050,17 +1050,6 @@
             "uris": [
               "/v1/users/*"
             ],
-            "scopes": [
-              {
-                "name": "read"
-              },
-              {
-                "name": "update"
-              },
-              {
-                "name": "create"
-              }
-            ],
             "icon_uri": ""
           },
           {
@@ -1153,17 +1142,6 @@
             }
           },
           {
-            "id": "7bf886c7-74a3-48b7-b181-ded3dfd91629",
-            "name": "Any Identified Policy",
-            "description": "",
-            "type": "role",
-            "logic": "POSITIVE",
-            "decisionStrategy": "UNANIMOUS",
-            "config": {
-              "roles": "[{\"id\":\"backend-service/identified\",\"required\":false}]"
-            }
-          },
-          {
             "id": "fcef30b2-68b2-4b78-9f3d-9162c6cdf5cb",
             "name": "Only Administrators",
             "description": "Only administrators can access",
@@ -1210,18 +1188,6 @@
               "resources": "[\"Read Template By Actor\"]",
               "scopes": "[\"read\"]",
               "applyPolicies": "[\"Any Validated Policy\",\"Only Administrators\"]"
-            }
-          },
-          {
-            "id": "8019f0a4-687a-4f3b-92f3-d479b266921b",
-            "name": "Identified Permission",
-            "description": "",
-            "type": "resource",
-            "logic": "POSITIVE",
-            "decisionStrategy": "AFFIRMATIVE",
-            "config": {
-              "resources": "[\"User Resource\",\"Integration Resource\",\"Validation Resource\",\"Codelist Resource\"]",
-              "applyPolicies": "[\"Any Identified Policy\"]"
             }
           },
           {
@@ -2960,7 +2926,8 @@
       ],
       "clientRoles": {
         "backend-service": [
-          "identified"
+          "identified",
+          "validated"
         ]
       }
     },
@@ -2975,13 +2942,7 @@
           "type": "password",
           "value": "evald"
         }
-      ],
-      "clientRoles": {
-        "backend-service": [
-          "identified",
-          "validated"
-        ]
-      }
+      ]
     },
     {
       "username": "validated",

--- a/api/src/test/java/org/grnet/cat/api/AssessmentsEndpointTest.java
+++ b/api/src/test/java/org/grnet/cat/api/AssessmentsEndpointTest.java
@@ -216,7 +216,7 @@ public class AssessmentsEndpointTest extends KeycloakTest {
 
         var error = given()
                 .auth()
-                .oauth2(getAccessToken("bob"))
+                .oauth2(getAccessToken("evald"))
                 .get("/{id}", assessment.id)
                 .then()
                 .assertThat()
@@ -571,7 +571,7 @@ public class AssessmentsEndpointTest extends KeycloakTest {
 
         register("validated");
         register("admin");
-        register("evald");
+        register("bob");
 
         makeValidation("validated", 6L);
         fetchTemplateByActorAndType();
@@ -593,7 +593,7 @@ public class AssessmentsEndpointTest extends KeycloakTest {
 
         var informativeResponse = given()
                 .auth()
-                .oauth2(getAccessToken("evald"))
+                .oauth2(getAccessToken("bob"))
                 .contentType(ContentType.JSON)
                 .delete("/{id}", assessment.id)
                 .then()

--- a/service/src/main/java/org/grnet/cat/services/UserService.java
+++ b/service/src/main/java/org/grnet/cat/services/UserService.java
@@ -9,7 +9,6 @@ import org.grnet.cat.dtos.UserProfileDto;
 import org.grnet.cat.dtos.ValidationRequest;
 import org.grnet.cat.dtos.ValidationResponse;
 import org.grnet.cat.dtos.pagination.PageResource;
-import org.grnet.cat.dtos.statistics.UserStatisticsResponse;
 import org.grnet.cat.entities.User;
 import org.grnet.cat.entities.Validation;
 import org.grnet.cat.entities.history.History;
@@ -128,6 +127,8 @@ public class UserService {
         identified.setRegisteredOn(Timestamp.from(Instant.now()));
 
         userRepository.persist(identified);
+
+        roleRepository.assignRoles(id, List.of("identified"));
 
         return UserMapper.INSTANCE.userToProfileDto(identified);
     }


### PR DESCRIPTION
During user registration, it is necessary to assign the identified role to the user by communicating with the Keycloak API. This process involves integrating with Keycloak to set the appropriate role for the newly registered user.