### PR TITLE
Bumped version number to 1.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,10 +24,13 @@ According to [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) , the `Unr
 
 ---
 
+## 1.5.0 - 2024-06-18
+
+---
+
 ### Changed
 
-- [#207](https://github.com/FC4E-CAT/fc4e-cat-api/pull/207) CAT-395 Public assessment not updated.
-
+- [#208](https://github.com/FC4E-CAT/fc4e-cat-api/pull/208) CAT-395 Public assessment not updated.
 - [#209](https://github.com/FC4E-CAT/fc4e-cat-api/pull/209) CAT-398 Update PID Service Provider template to remove default thresholds.
 
 ## 1.5.0 - 2024-06-17

--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
     <apache.common3.version>3.12.0</apache.common3.version>
     <vavr.version>0.10.4</vavr.version>
     <pivovarit.version>1.5.1</pivovarit.version>
-    <revision>1.5.0</revision>
+    <revision>1.5.1</revision>
     <json.simple.version>1.1.1</json.simple.version>
     <json.schema.validator>1.0.72</json.schema.validator>
   </properties>


### PR DESCRIPTION
### Changed

- [#208](https://github.com/FC4E-CAT/fc4e-cat-api/pull/208) CAT-395 Public assessment not updated.
- [#209](https://github.com/FC4E-CAT/fc4e-cat-api/pull/209) CAT-398 Update PID Service Provider 