### PR TITLE
CAT-516 Criteria items under motivation are represented with a bit different schema under two different GET calls - Missing criterion id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ According to [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) , the `Unr
 - [#282](https://github.com/FC4E-CAT/fc4e-cat-api/pull/282) CAT-506 lodMTV missing column from t_Actor.
 - [#286](https://github.com/FC4E-CAT/fc4e-cat-api/pull/286) CAT-509 Weird Principles local pagination issue when page size=5.
 - [#288](https://github.com/FC4E-CAT/fc4e-cat-api/pull/288) CAT-518 Pagination issues in Motivation > Actor > Criteria.
+- [#289](https://github.com/FC4E-CAT/fc4e-cat-api/pull/289) CAT-516 Criteria items under motivation are represented with a bit different schema under two different GET calls - Missing criterion id
 
 
 ## 1.7.0 - 2024-09-10

--- a/data-transfer-object/src/main/java/org/grnet/cat/dtos/registry/criterion/PrincipleCriterionResponse.java
+++ b/data-transfer-object/src/main/java/org/grnet/cat/dtos/registry/criterion/PrincipleCriterionResponse.java
@@ -18,6 +18,15 @@ public class PrincipleCriterionResponse {
             description = "The Criterion's code identifier.",
             example = "C1"
     )
+    @JsonProperty("id")
+    public String id;
+
+    @Schema(
+            type = SchemaType.STRING,
+            implementation = String.class,
+            description = "The Criterion's code identifier.",
+            example = "C1"
+    )
     @JsonProperty("cri")
     public String cri;
 

--- a/entity/src/main/java/org/grnet/cat/entities/registry/Criterion.java
+++ b/entity/src/main/java/org/grnet/cat/entities/registry/Criterion.java
@@ -110,4 +110,8 @@ public class Criterion extends Registry {
     public Set<PrincipleCriterionJunction> getPrinciples() {
         return principles;
     }
+
+    public @NotNull String getCri() {
+        return cri;
+    }
 }

--- a/entity/src/main/java/org/grnet/cat/entities/registry/PrincipleCriterionJunction.java
+++ b/entity/src/main/java/org/grnet/cat/entities/registry/PrincipleCriterionJunction.java
@@ -1,13 +1,6 @@
 package org.grnet.cat.entities.registry;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.EmbeddedId;
-import jakarta.persistence.Entity;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.MapsId;
-import jakarta.persistence.Table;
+import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 import lombok.Setter;
@@ -80,5 +73,9 @@ public class PrincipleCriterionJunction extends Registry{
     @Override
     public int hashCode() {
         return Objects.hash(id);
+    }
+
+    public Criterion getCriterion() {
+        return criterion;
     }
 }

--- a/mapper/src/main/java/org/grnet/cat/mappers/registry/CriterionActorMapper.java
+++ b/mapper/src/main/java/org/grnet/cat/mappers/registry/CriterionActorMapper.java
@@ -4,9 +4,9 @@ import org.apache.commons.lang3.StringUtils;
 import org.grnet.cat.dtos.registry.actor.MotivationActorResponse;
 import org.grnet.cat.dtos.registry.criterion.CriterionActorResponse;
 import org.grnet.cat.dtos.registry.criterion.CriterionRequest;
-import org.grnet.cat.entities.registry.Criterion;
-import org.grnet.cat.entities.registry.CriterionActorJunction;
-import org.grnet.cat.entities.registry.MotivationActorJunction;
+import org.grnet.cat.dtos.registry.criterion.PrincipleCriterionResponse;
+import org.grnet.cat.dtos.registry.principle.PrinciplePartialResponse;
+import org.grnet.cat.entities.registry.*;
 import org.mapstruct.IterableMapping;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
@@ -14,6 +14,9 @@ import org.mapstruct.Named;
 import org.mapstruct.factory.Mappers;
 
 import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
  * The CriterionActorMapper is responsible for mapping CriterionActor entities to DTOs and vice versa.
@@ -22,19 +25,35 @@ import java.util.List;
 public interface CriterionActorMapper {
 
     CriterionActorMapper INSTANCE = Mappers.getMapper(CriterionActorMapper.class);
+    @Mapping(source = "criterion.id", target = "id")
+    @Mapping(source = "criterion.cri", target = "cri")
+    @Mapping(source = "criterion.label", target = "label")
+    @Mapping(source = "criterion.description", target = "description")
+    @Mapping(source = "criterion.imperative.id", target = "imperative")
+    @Mapping(source = "criterion.typeCriterion.id", target = "typeCriterion")
+    @Mapping(source = "criterion.url", target = "url")
+    @Mapping(source = "criterion.lodCriP", target = "lodCriP")
+    @Mapping(source = "populatedBy", target = "populatedBy")
+    @Mapping(source = "lastTouch", target = "lastTouch")
+    @Mapping(target = "principles", source = "criterion.principles", qualifiedByName = "mapPrinciples")
+    PrincipleCriterionResponse toPrincipleCriterionResponse(CriterionActorJunction junction);
 
-    @Named("map")
+    List<PrincipleCriterionResponse> toPrincipleCriterionResponseList(List<CriterionActorJunction> junctions);
 
-    @Mapping(target = "lodCAV", expression = "java(criterionActor.getId().getLodCAV())")
-    @Mapping(target = "criterion", expression = "java(criterionActor.getCriterion().getId())")
-    @Mapping(target = "imperative", expression = "java(criterionActor.getImperative().getId())")
-    @Mapping(target = "motivation", expression = "java(criterionActor.getMotivation().getId())")
-    @Mapping(target = "motivationX", expression = "java(criterionActor.getMotivationX())")
-    CriterionActorResponse criterionActorActorToDto(CriterionActorJunction criterionActor);
+    @Named("mapPrinciples")
+    default List<PrinciplePartialResponse> mapPrinciples(Set<PrincipleCriterionJunction> principles) {
+        return principles.stream()
+                .map(this::mapPrinciple)
+                .collect(Collectors.toList());
+    }
 
-    @IterableMapping(qualifiedByName = "map")
-    List<CriterionActorResponse> criterionActorToDtos(List<CriterionActorJunction> criterionActorList);
+    @Named("mapPrinciple")
+    @Mapping(target = "id",  expression = "java(principleJunction.getPrinciple().getId())")  // Ignore the id field here as well
+    @Mapping(target = "pri", expression = "java(principleJunction.getPrinciple().getPri())")
+    @Mapping(target = "label", expression = "java(principleJunction.getPrinciple().getLabel())")
+        //@Mapping(target = "motivation_id", expression = "java(principleJunction.getLodMTV())")
 
+    PrinciplePartialResponse mapPrinciple(PrincipleCriterionJunction principleJunction);
 
 }
 

--- a/mapper/src/main/java/org/grnet/cat/mappers/registry/PrincipleCriterionMapper.java
+++ b/mapper/src/main/java/org/grnet/cat/mappers/registry/PrincipleCriterionMapper.java
@@ -26,6 +26,7 @@ public interface PrincipleCriterionMapper {
     List<PrincipleCriterionResponse> criteriaToDtos(List<Criterion> criteria);
 
     @Named("mapWithExpression")
+    @Mapping(target = "id", expression = "java(criterion.getId())")
     @Mapping(target = "imperative", expression = "java(criterion.getImperative().getId())")
     @Mapping(target = "typeCriterion", expression = "java(criterion.getTypeCriterion().getId())")
     @Mapping(source = "principles", target = "principles", qualifiedByName = "mapPrinciples")
@@ -42,7 +43,6 @@ public interface PrincipleCriterionMapper {
     @Mapping(target = "id",  expression = "java(principleJunction.getPrinciple().getId())")  // Ignore the id field here as well
     @Mapping(target = "pri", expression = "java(principleJunction.getPrinciple().getPri())")
     @Mapping(target = "label", expression = "java(principleJunction.getPrinciple().getLabel())")
-    //@Mapping(target = "motivation_id", expression = "java(principleJunction.getLodMTV())")
 
     PrinciplePartialResponse mapPrinciple(PrincipleCriterionJunction principleJunction);
 

--- a/repository/src/main/java/org/grnet/cat/repositories/registry/CriterionActorRepository.java
+++ b/repository/src/main/java/org/grnet/cat/repositories/registry/CriterionActorRepository.java
@@ -10,6 +10,9 @@ import org.grnet.cat.entities.registry.CriterionActorJunction;
 import org.grnet.cat.entities.registry.MotivationActorJunction;
 import org.grnet.cat.repositories.Repository;
 
+import java.util.Comparator;
+import java.util.stream.Collectors;
+
 @ApplicationScoped
 public class CriterionActorRepository  implements Repository<CriterionActorJunction, String> {
 
@@ -22,10 +25,15 @@ public class CriterionActorRepository  implements Repository<CriterionActorJunct
      */
     public PageQuery<CriterionActorJunction> fetchCriteriaByMotivationAndActorAndPage(String motivationId, String actorId, int page, int size) {
 
-        var panache = find("SELECT c FROM CriterionActorJunction c WHERE c.motivation.id = ?1 AND c.id.actorId = ?2", Sort.by("lastTouch", Sort.Direction.Descending), motivationId, actorId).page(page, size);
+        var panache = find("SELECT DISTINCT c FROM CriterionActorJunction c WHERE c.motivation.id = ?1 AND c.id.actorId = ?2 ", motivationId, actorId).page(page, size);
+
+        var sortedResults = panache.list()
+                .stream()
+                .sorted(Comparator.comparing(c -> c.getCriterion().getCri())) // Adjust 'getCri()' to the actual method
+                .collect(Collectors.toList());
 
         var pageable = new PageQueryImpl<CriterionActorJunction>();
-        pageable.list = panache.list();
+        pageable.list = sortedResults;
         pageable.index = page;
         pageable.size = size;
         pageable.count = panache.count();

--- a/repository/src/main/java/org/grnet/cat/repositories/registry/CriterionRepository.java
+++ b/repository/src/main/java/org/grnet/cat/repositories/registry/CriterionRepository.java
@@ -49,8 +49,9 @@ public class CriterionRepository implements Repository<Criterion, String> {
      * @return A list of Motivations objects representing the Criteria in the requested page.
      */
     public PageQuery<Criterion> fetchCriteriaByMotivationAndPage(String motivationId, int page, int size) {
-
-        var panache = find("SELECT pri.criterion FROM PrincipleCriterionJunction pri WHERE pri.motivation.id = ?1 ", Sort.by("pri.lastTouch", Sort.Direction.Descending), motivationId).page(page, size);
+        var panache = find("SELECT DISTINCT pri.criterion FROM PrincipleCriterionJunction pri WHERE pri.motivation.id = ?1",
+               Sort.ascending("pri.criterion.cri"), motivationId)
+                .page(page, size);
 
         var pageable = new PageQueryImpl<Criterion>();
         pageable.list = panache.list();

--- a/repository/src/main/java/org/grnet/cat/repositories/registry/PrincipleCriterionRepository.java
+++ b/repository/src/main/java/org/grnet/cat/repositories/registry/PrincipleCriterionRepository.java
@@ -1,0 +1,16 @@
+package org.grnet.cat.repositories.registry;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import org.grnet.cat.entities.registry.PrincipleCriterionJunction;
+import org.grnet.cat.repositories.Repository;
+
+import java.util.Optional;
+
+@ApplicationScoped
+public class PrincipleCriterionRepository  implements Repository<PrincipleCriterionJunction, String> {
+
+    public Optional<PrincipleCriterionJunction> findCriterion(String criterionId, String motivationId) {
+
+       return find("FROM PrincipleCriterionJunction pri WHERE pri.criterion.id = ?1 and pri.motivation.id =?2 ",criterionId,motivationId).firstResultOptional();
+   }
+}


### PR DESCRIPTION
added id to responses to get the criterion id
return the principlecriterionjunctionresponse in the get /motivations/{id}/actors/{id}/criteria
fixed some issues with pagination and sorting 