### PR TITLE
CAT-590 Fix CriterionActorJunction key to keep Motivation id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ According to [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) , the `Unr
 - [#326](https://github.com/FC4E-CAT/fc4e-cat-api/pull/326) CAT-584 Resolve Unique Constraint Violation When Updating Principle with Existing PRI.
 - [#331](https://github.com/FC4E-CAT/fc4e-cat-api/pull/331) CAT-589 Change copy Motivation to insert value on db field lodMTV_P
 - [#329](https://github.com/FC4E-CAT/fc4e-cat-api/pull/329) CAT-573 Jenkins warnings
+- [#332](https://github.com/FC4E-CAT/fc4e-cat-api/pull/332) CAT-590 Fix CriterionActorJunction key to keep Motivation id
 
 ### Removed
 

--- a/entity/src/main/java/org/grnet/cat/entities/registry/CriterionActorId.java
+++ b/entity/src/main/java/org/grnet/cat/entities/registry/CriterionActorId.java
@@ -20,10 +20,13 @@ public class CriterionActorId {
 
     @Column(name = "lodC_A_V")
     private Integer lodCAV;
+    @Column(name = "motivation_lodMTV")
+    private String motivationId;
 
-    public CriterionActorId( String criterionId, String actorId, Integer lodCAV) {
+    public CriterionActorId( String criterionId, String actorId, String motivationId,Integer lodCAV) {
         this.criterionId = criterionId;
         this.actorId = actorId;
+        this.motivationId=motivationId;
         this.lodCAV = lodCAV;
     }
 
@@ -40,12 +43,13 @@ public class CriterionActorId {
         CriterionActorId that = (CriterionActorId) o;
         return Objects.equals(criterionId, that.criterionId) &&
                 Objects.equals(actorId, that.actorId) &&
+                Objects.equals(motivationId, that.motivationId) &&
                 Objects.equals(lodCAV, that.lodCAV)  ;
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(criterionId, actorId, lodCAV );
+        return Objects.hash(criterionId, actorId,motivationId, lodCAV );
     }
 
     public String getCriterionId() {
@@ -70,6 +74,14 @@ public class CriterionActorId {
 
     public void setLodCAV(Integer lodCAV) {
         this.lodCAV = lodCAV;
+    }
+
+    public String getMotivationId() {
+        return motivationId;
+    }
+
+    public void setMotivationId(String motivationId) {
+        this.motivationId = motivationId;
     }
 }
 

--- a/entity/src/main/java/org/grnet/cat/entities/registry/CriterionActorJunction.java
+++ b/entity/src/main/java/org/grnet/cat/entities/registry/CriterionActorJunction.java
@@ -20,7 +20,7 @@ public class CriterionActorJunction extends Registry {
     private CriterionActorId id;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name="motivation_lodMTV")
+    @MapsId("motivationId")
     private Motivation motivation;
 
     @ManyToOne(fetch = FetchType.LAZY)
@@ -40,6 +40,7 @@ public class CriterionActorJunction extends Registry {
     @NotNull
     private String motivationX;
 
+
     public CriterionActorJunction(Motivation motivation, Criterion criterion, RegistryActor actor, Imperative imperative, String motivationX, Timestamp lastTouch, String populatedBy, Integer lodCAV) {
         this.motivation = motivation;
         this.criterion = criterion;
@@ -48,7 +49,7 @@ public class CriterionActorJunction extends Registry {
         this.motivationX = motivationX;
         this.setLastTouch(lastTouch);
         this.setPopulatedBy(populatedBy);
-        this.id = new CriterionActorId( criterion.getId(), actor.getId(), lodCAV);
+        this.id = new CriterionActorId( criterion.getId(), actor.getId(), motivation.getId(),lodCAV);
     }
 
     public CriterionActorJunction() {
@@ -65,12 +66,12 @@ public class CriterionActorJunction extends Registry {
         CriterionActorJunction that = (CriterionActorJunction) o;
         return Objects.equals(motivation, that.motivation) &&
                 Objects.equals(id.getCriterionId(), that.id.getCriterionId()) &&
-                Objects.equals(id.getActorId(), that.id.getActorId()) && Objects.equals(id.getLodCAV(), that.id.getLodCAV());
+                Objects.equals(id.getActorId(), that.id.getActorId()) &&  Objects.equals(id.getMotivationId(), that.id.getMotivationId()) && Objects.equals(id.getLodCAV(), that.id.getLodCAV());
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(motivation,id.getCriterionId(), id.getActorId(), id.getLodCAV());
+        return Objects.hash(id.getMotivationId(),id.getCriterionId(), id.getActorId(), id.getLodCAV());
     }
 
     public CriterionActorId getId() {

--- a/entity/src/main/resources/db/migration/tables/registry/V1.135__exists_foreign_key_stored_procedure.sql
+++ b/entity/src/main/resources/db/migration/tables/registry/V1.135__exists_foreign_key_stored_procedure.sql
@@ -1,0 +1,30 @@
+DELIMITER //
+
+DROP PROCEDURE IF EXISTS DropForeignKeyIfExists; //
+
+CREATE PROCEDURE DropForeignKeyIfExists(IN fk_name VARCHAR(255))
+BEGIN
+    DECLARE fk_exists INT DEFAULT 0;
+    DECLARE current_db VARCHAR(255);
+
+    -- Retrieve the current database name
+    SET current_db = DATABASE();
+
+    -- Check if the foreign key exists
+    SELECT COUNT(*)
+    INTO fk_exists
+    FROM information_schema.REFERENTIAL_CONSTRAINTS
+    WHERE CONSTRAINT_SCHEMA = current_db
+      AND TABLE_NAME = 'p_Criterion_Actor'
+      AND CONSTRAINT_NAME = fk_name;
+
+    -- If the foreign key exists, drop it
+    IF fk_exists > 0 THEN
+        SET @sql = CONCAT('ALTER TABLE `', current_db, '`.p_Criterion_Actor DROP FOREIGN KEY `', fk_name, '`');
+        PREPARE stmt FROM @sql;
+        EXECUTE stmt;
+        DEALLOCATE PREPARE stmt;
+    END IF;
+END //
+
+DELIMITER ;

--- a/entity/src/main/resources/db/migration/tables/registry/V1.136__exists_primary_key_stored_procedure.sql
+++ b/entity/src/main/resources/db/migration/tables/registry/V1.136__exists_primary_key_stored_procedure.sql
@@ -1,0 +1,32 @@
+DELIMITER //
+
+DROP PROCEDURE IF EXISTS DropPrimaryKeyIfExists; //
+
+CREATE PROCEDURE DropPrimaryKeyIfExists(IN table_name VARCHAR(255))
+BEGIN
+    DECLARE pk_exists INT DEFAULT 0;
+    DECLARE current_db VARCHAR(255);
+    -- Get the current database name
+    SET current_db = DATABASE();
+
+    -- Check if the primary key exists for the given table
+    SELECT COUNT(*)
+    INTO pk_exists
+    FROM information_schema.TABLE_CONSTRAINTS
+    WHERE TABLE_SCHEMA = current_db
+      AND TABLE_NAME = table_name
+      AND CONSTRAINT_TYPE = 'PRIMARY KEY';
+-- Print the value of pk_exists for debugging
+    SELECT pk_exists AS primary_key_exists;
+    -- If it exists, drop the primary key
+    IF pk_exists > 0 THEN
+     SET @sql =  CONCAT('ALTER TABLE `', current_db, '`.`', table_name, '` DROP PRIMARY KEY');
+     SELECT @sql AS sql_statement;  -- This will show you the generated SQL
+
+     PREPARE stmt FROM @sql;
+     EXECUTE stmt;
+     DEALLOCATE PREPARE stmt;
+     END IF;
+END //
+
+DELIMITER ;

--- a/entity/src/main/resources/db/migration/tables/registry/V1.137__update_criterion_actor.sql
+++ b/entity/src/main/resources/db/migration/tables/registry/V1.137__update_criterion_actor.sql
@@ -1,0 +1,23 @@
+-- update p_Criteron_Actor to add motivation_lodMTV as part of the primary key
+
+UPDATE p_Criterion_Actor
+SET motivation_lodMTV = 'pid_graph:3E109BBA'
+WHERE motivation_lodMTV IS NULL AND populatedBy IS NULL;
+
+ALTER TABLE p_Criterion_Actor
+MODIFY motivation_lodMTV VARCHAR(255) NOT NULL;
+
+
+CALL DropForeignKeyIfExists('p_Criterion_Actor_ibfk_1');
+CALL DropForeignKeyIfExists('p_Criterion_Actor_ibfk_2');
+CALL DropPrimaryKeyIfExists('p_Criterion_Actor');
+
+
+ALTER TABLE p_Criterion_Actor
+ADD   FOREIGN KEY (actor_lodActor) REFERENCES t_Actor(lodActor) ON DELETE CASCADE;
+
+ALTER TABLE p_Criterion_Actor
+ADD FOREIGN KEY (criterion_lodCRI) REFERENCES p_Criterion(lodCRI) ON DELETE CASCADE;
+
+ALTER TABLE p_Criterion_Actor
+ADD PRIMARY KEY (actor_lodActor, criterion_lodCRI, lodC_A_V, motivation_lodMTV);


### PR DESCRIPTION
changes to scripts to set motivation_id as part of primary key of p_Criterion_Actor.
NULL values in motivation_lodMTV are updated to keep the EOSC PID Policy id.
also scripts to update the primary key 
and changes in implementation to support this. 