### PR TITLE
CAT-653 Delete & Update Principle in a motivation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,10 +40,10 @@ According to [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) , the `Unr
 - [#361](https://github.com/FC4E-CAT/fc4e-cat-api/pull/361) CAT-628 Assessment Update.
 - [#360](https://github.com/FC4E-CAT/fc4e-cat-api/pull/360) CAT-622 Create an endpoint to check if a url is a valid https
 - [#396](https://github.com/FC4E-CAT/fc4e-cat-api/pull/396) CAT-680 Create an API endpoint to establish a relationship between a criterion and a metric
-- [#400](https://github.com/FC4E-CAT/fc4e-cat-api/pull/400) 
-
+- [#400](https://github.com/FC4E-CAT/fc4e-cat-api/pull/400) CAT-689: Change POST /registry/metrics to insert full metric/metric-definition relation
 - [#401](https://github.com/FC4E-CAT/fc4e-cat-api/pull/401) CAT-693 Create POST and PUT Endpoints for Metric-Test Relationship
 - [#405](https://github.com/FC4E-CAT/fc4e-cat-api/pull/405) CAT-695: Implement GET and PUT /metric - definition by Motivation API Endpoint
+- [#398](https://github.com/FC4E-CAT/fc4e-cat-api/pull/398) CAT-653 Delete & Update Principle in a motivation
 
 ### Fix
 

--- a/api/src/main/java/org/grnet/cat/api/endpoints/registry/MotivationEndpoint.java
+++ b/api/src/main/java/org/grnet/cat/api/endpoints/registry/MotivationEndpoint.java
@@ -44,9 +44,11 @@ import org.grnet.cat.dtos.registry.motivation.*;
 import org.grnet.cat.dtos.registry.principle.MotivationPrincipleExtendedRequestDto;
 import org.grnet.cat.dtos.registry.principle.MotivationPrincipleRequest;
 import org.grnet.cat.dtos.registry.principle.PrincipleResponseDto;
+import org.grnet.cat.dtos.registry.principle.PrincipleUpdateDto;
 import org.grnet.cat.dtos.registry.template.RegistryTemplateDto;
 import org.grnet.cat.repositories.registry.CriterionRepository;
 import org.grnet.cat.repositories.registry.MotivationRepository;
+import org.grnet.cat.repositories.registry.PrincipleRepository;
 import org.grnet.cat.repositories.registry.RegistryActorRepository;
 import org.grnet.cat.services.TemplateService;
 import org.grnet.cat.services.registry.*;
@@ -241,7 +243,7 @@ public class MotivationEndpoint {
     @Produces(MediaType.APPLICATION_JSON)
     @Registration
     public Response getMotivations(@Parameter(name = "page", in = QUERY,
-            description = "Indicates the page number. Page number must be >= 1.") @DefaultValue("1") @Min(value = 1, message = "Page number must be >= 1.") @QueryParam("page") int page,
+                                           description = "Indicates the page number. Page number must be >= 1.") @DefaultValue("1") @Min(value = 1, message = "Page number must be >= 1.") @QueryParam("page") int page,
                                    @Parameter(name = "size", in = QUERY,
                                            description = "The page size.") @DefaultValue("10") @Min(value = 1, message = "Page size must be between 1 and 100.")
                                    @Max(value = 100, message = "Page size must be between 1 and 100.") @QueryParam("size") int size,
@@ -327,13 +329,13 @@ public class MotivationEndpoint {
     @Produces(MediaType.APPLICATION_JSON)
     @Registration
     public Response updateMotivation(@Parameter(
-            description = "The ID of the Subject to update.",
-            required = true,
-            example = "1",
-            schema = @Schema(type = SchemaType.STRING))
+                                             description = "The ID of the Subject to update.",
+                                             required = true,
+                                             example = "1",
+                                             schema = @Schema(type = SchemaType.STRING))
                                      @PathParam("id")
                                      @Valid @NotFoundEntity(repository = MotivationRepository.class, message = "There is no Motivation with the following id:")
-                                         @CheckPublished(repository = MotivationRepository.class, message = "No action permitted for published Motivation with the following id:", isPublishedPermitted = false) String id,
+                                     @CheckPublished(repository = MotivationRepository.class, message = "No action permitted for published Motivation with the following id:", isPublishedPermitted = false) String id,
                                      @Valid @NotNull(message = "The request body is empty.") UpdateMotivationRequest request) {
 
         var motivation = motivationService.update(id, request, utility.getUserUniqueIdentifier());
@@ -376,13 +378,13 @@ public class MotivationEndpoint {
     @Produces(MediaType.APPLICATION_JSON)
     @Registration
     public Response getActorsByMotivation(@Parameter(
-            description = "The ID of the Motivation to retrieve.",
-            required = true,
-            example = "pid_graph:3E109BBA",
-            schema = @Schema(type = SchemaType.STRING))
+                                                  description = "The ID of the Motivation to retrieve.",
+                                                  required = true,
+                                                  example = "pid_graph:3E109BBA",
+                                                  schema = @Schema(type = SchemaType.STRING))
                                           @PathParam("id")
                                           @Valid @NotFoundEntity(repository = MotivationRepository.class, message = "There is no Motivation with the following id:") String id, @Parameter(name = "page", in = QUERY,
-            description = "Indicates the page number. Page number must be >= 1.") @DefaultValue("1") @Min(value = 1, message = "Page number must be >= 1.") @QueryParam("page") int page,
+                                                  description = "Indicates the page number. Page number must be >= 1.") @DefaultValue("1") @Min(value = 1, message = "Page number must be >= 1.") @QueryParam("page") int page,
                                           @Parameter(name = "size", in = QUERY,
                                                   description = "The page size.") @DefaultValue("10") @Min(value = 1, message = "Page size must be between 1 and 100.")
                                           @Max(value = 100, message = "Page size must be between 1 and 100.") @QueryParam("size") int size,
@@ -432,14 +434,14 @@ public class MotivationEndpoint {
     @Path("/{id}/actors")
     @Produces(MediaType.APPLICATION_JSON)
     public Response assignActorToMotivation(@Parameter(
-            description = "The ID of the Motivation to update.",
-            required = true,
-            example = "1",
-            schema = @Schema(type = SchemaType.STRING))
+                                                    description = "The ID of the Motivation to update.",
+                                                    required = true,
+                                                    example = "1",
+                                                    schema = @Schema(type = SchemaType.STRING))
                                             @PathParam("id")
                                             @Valid
                                             @NotFoundEntity(repository = MotivationRepository.class, message = "There is no Motivation with the following id:")
-                                                @CheckPublished(repository = MotivationRepository.class, message = "No action permitted for published Motivation with the following id:", isPublishedPermitted = false) String id,
+                                            @CheckPublished(repository = MotivationRepository.class, message = "No action permitted for published Motivation with the following id:", isPublishedPermitted = false) String id,
                                             @NotEmpty(message = "Actors list can not be empty.") Set<@Valid MotivationActorRequest> request) {
 
         var messages = motivationService.assignActors(id, request, utility.getUserUniqueIdentifier());
@@ -498,15 +500,15 @@ public class MotivationEndpoint {
     @Produces(MediaType.APPLICATION_JSON)
     @Registration
     public Response removeActorFromMotivation(@Parameter(
-            description = "The ID of the Motivation to update.",
-            required = true,
-            example = "1",
-            schema = @Schema(type = SchemaType.STRING))
+                                                      description = "The ID of the Motivation to update.",
+                                                      required = true,
+                                                      example = "1",
+                                                      schema = @Schema(type = SchemaType.STRING))
                                               @PathParam("id")
                                               @Valid
                                               @NotFoundEntity(repository = MotivationRepository.class, message = "There is no Motivation with the following id:")
                                               @CheckPublished(repository = MotivationRepository.class, message = "No action permitted for published Motivation with the following id:", isPublishedPermitted = false) String id,
-                                             @Parameter(
+                                              @Parameter(
                                                       description = "The actor to be deleted.",
                                                       required = true,
                                                       example = "pid_graph:0E00C332",
@@ -573,10 +575,10 @@ public class MotivationEndpoint {
     @Produces(MediaType.APPLICATION_JSON)
     public Response createPrinciple(
             @Parameter(
-            description = "The ID of the Motivation to create a principle for.",
-            required = true,
-            example = "pid_graph:3E109BBA",
-            schema = @Schema(type = SchemaType.STRING))
+                    description = "The ID of the Motivation to create a principle for.",
+                    required = true,
+                    example = "pid_graph:3E109BBA",
+                    schema = @Schema(type = SchemaType.STRING))
             @PathParam("id")
             @Valid
             @NotFoundEntity(repository = MotivationRepository.class, message = "There is no Motivation with the following id:")
@@ -589,8 +591,6 @@ public class MotivationEndpoint {
         return Response.status(response.code).entity(response).build();
 
     }
-
-
 
 
     @Tag(name = "Motivation")
@@ -632,10 +632,10 @@ public class MotivationEndpoint {
     @Path("/{id}/principles")
     @Produces(MediaType.APPLICATION_JSON)
     public Response assignPrinciplesToMotivation(@Parameter(
-            description = "The ID of the Motivation to update.",
-            required = true,
-            example = "1",
-            schema = @Schema(type = SchemaType.STRING))
+                                                         description = "The ID of the Motivation to update.",
+                                                         required = true,
+                                                         example = "1",
+                                                         schema = @Schema(type = SchemaType.STRING))
                                                  @PathParam("id")
                                                  @Valid
                                                  @NotFoundEntity(repository = MotivationRepository.class, message = "There is no Motivation with the following id:")
@@ -783,10 +783,10 @@ public class MotivationEndpoint {
     @Path("/{id}/actors/{actor-id}/criteria")
     @Produces(MediaType.APPLICATION_JSON)
     public Response addCriterionToMotivationActor(@Parameter(
-            description = "The ID of the Motivation to update.",
-            required = true,
-            example = "1",
-            schema = @Schema(type = SchemaType.STRING))
+                                                          description = "The ID of the Motivation to update.",
+                                                          required = true,
+                                                          example = "1",
+                                                          schema = @Schema(type = SchemaType.STRING))
                                                   @PathParam("id")
                                                   @Valid
                                                   @NotFoundEntity(repository = MotivationRepository.class, message = "There is no Motivation with the following id:")
@@ -847,10 +847,10 @@ public class MotivationEndpoint {
     @Produces(MediaType.APPLICATION_JSON)
     @Registration
     public Response getCriteriaByMotivationActor(@Parameter(
-            description = "The ID of the Motivation to add criteria.",
-            required = true,
-            example = "pid_graph:3E109BBA",
-            schema = @Schema(type = SchemaType.STRING))
+                                                         description = "The ID of the Motivation to add criteria.",
+                                                         required = true,
+                                                         example = "pid_graph:3E109BBA",
+                                                         schema = @Schema(type = SchemaType.STRING))
                                                  @PathParam("id")
                                                  @Valid @NotFoundEntity(repository = MotivationRepository.class, message = "There is no Motivation with the following id:") String id,
                                                  @Parameter(
@@ -860,7 +860,7 @@ public class MotivationEndpoint {
                                                          schema = @Schema(type = SchemaType.STRING))
                                                  @PathParam("actor-id")
                                                  @Valid @NotFoundEntity(repository = RegistryActorRepository.class, message = "There is no Actor with the following id:") String actorId, @Parameter(name = "page", in = QUERY,
-            description = "Indicates the page number. Page number must be >= 1.") @DefaultValue("1") @Min(value = 1, message = "Page number must be >= 1.") @QueryParam("page") int page,
+                    description = "Indicates the page number. Page number must be >= 1.") @DefaultValue("1") @Min(value = 1, message = "Page number must be >= 1.") @QueryParam("page") int page,
                                                  @Parameter(name = "size", in = QUERY,
                                                          description = "The page size.") @DefaultValue("10") @Min(value = 1, message = "Page size must be between 1 and 100.")
                                                  @Max(value = 100, message = "Page size must be between 1 and 100.") @QueryParam("size") int size,
@@ -1040,10 +1040,10 @@ public class MotivationEndpoint {
     @Path("/{id}/actors/{actor-id}/criteria")
     @Produces(MediaType.APPLICATION_JSON)
     public Response updateCriterionToMotivationActor(@Parameter(
-            description = "The ID of the Motivation to update.",
-            required = true,
-            example = "pid_graph:3E109BBA",
-            schema = @Schema(type = SchemaType.STRING))
+                                                             description = "The ID of the Motivation to update.",
+                                                             required = true,
+                                                             example = "pid_graph:3E109BBA",
+                                                             schema = @Schema(type = SchemaType.STRING))
                                                      @PathParam("id")
                                                      @Valid
                                                      @NotFoundEntity(repository = MotivationRepository.class, message = "There is no Motivation with the following id:")
@@ -1110,10 +1110,10 @@ public class MotivationEndpoint {
     @Path("/{id}/principles-criteria")
     @Produces(MediaType.APPLICATION_JSON)
     public Response createNewPrinciplesCriteriaRelationship(@Parameter(
-            description = "The ID of the Motivation to update.",
-            required = true,
-            example = "pid_graph:3E109BBA",
-            schema = @Schema(type = SchemaType.STRING))
+                                                                    description = "The ID of the Motivation to update.",
+                                                                    required = true,
+                                                                    example = "pid_graph:3E109BBA",
+                                                                    schema = @Schema(type = SchemaType.STRING))
                                                             @PathParam("id")
                                                             @Valid
                                                             @NotFoundEntity(repository = MotivationRepository.class, message = "There is no Motivation with the following id:")
@@ -1169,10 +1169,10 @@ public class MotivationEndpoint {
     @Path("/{id}/principles-criteria")
     @Produces(MediaType.APPLICATION_JSON)
     public Response updatePrinciplesCriteriaRelationship(@Parameter(
-            description = "The ID of the Motivation to update.",
-            required = true,
-            example = "pid_graph:3E109BBA",
-            schema = @Schema(type = SchemaType.STRING))
+                                                                 description = "The ID of the Motivation to update.",
+                                                                 required = true,
+                                                                 example = "pid_graph:3E109BBA",
+                                                                 schema = @Schema(type = SchemaType.STRING))
                                                          @PathParam("id")
                                                          @Valid
                                                          @NotFoundEntity(repository = MotivationRepository.class, message = "There is no Motivation with the following id:")
@@ -1235,10 +1235,10 @@ public class MotivationEndpoint {
     @Produces(MediaType.APPLICATION_JSON)
     @Registration
     public Response getRegistryTemplate(@Parameter(
-            description = "The Motivation to retrieve template.",
-            required = true,
-            example = "pid_graph:3E109BBA",
-            schema = @Schema(type = SchemaType.STRING))
+                                                description = "The Motivation to retrieve template.",
+                                                required = true,
+                                                example = "pid_graph:3E109BBA",
+                                                schema = @Schema(type = SchemaType.STRING))
                                         @PathParam("id") @Valid @NotFoundEntity(repository = MotivationRepository.class, message = "There is no Motivation with the following id:")
                                         String id,
 
@@ -1288,10 +1288,10 @@ public class MotivationEndpoint {
     @Path("/{id}/principles-criteria")
     @Produces(MediaType.APPLICATION_JSON)
     public Response getPrinciplesCriteriaRelationship(@Parameter(
-            description = "The ID of the Motivation to assign Principles.",
-            required = true,
-            example = "pid_graph:3E109BBA",
-            schema = @Schema(type = SchemaType.STRING))
+                                                              description = "The ID of the Motivation to assign Principles.",
+                                                              required = true,
+                                                              example = "pid_graph:3E109BBA",
+                                                              schema = @Schema(type = SchemaType.STRING))
                                                       @PathParam("id")
                                                       @Valid @NotFoundEntity(repository = MotivationRepository.class, message = "There is no Motivation with the following id:") String id,
                                                       @Parameter(name = "page", in = QUERY,
@@ -1422,7 +1422,7 @@ public class MotivationEndpoint {
             @PathParam("id")
             @Valid @NotFoundEntity(repository = MotivationRepository.class, message = "There is no Motivation with the following id:")
             @CheckPublished(repository = MotivationRepository.class, message = "No action permitted for published Motivation with the following id:", isPublishedPermitted = false) String id
-            ) {
+    ) {
 
         motivationService.publish(id);
 
@@ -1549,10 +1549,10 @@ public class MotivationEndpoint {
             @PathParam("id")
             @Valid @NotFoundEntity(repository = MotivationRepository.class, message = "There is no Motivation with the following id:")
             String id, @Parameter(
-            description = "The ID of the Actor to publish.",
-            required = true,
-            example = "pid_graph:234B60D8",
-            schema = @Schema(type = SchemaType.STRING))
+                    description = "The ID of the Actor to publish.",
+                    required = true,
+                    example = "pid_graph:234B60D8",
+                    schema = @Schema(type = SchemaType.STRING))
             @PathParam("actor-id")
 
             @Valid @NotFoundEntity(repository = RegistryActorRepository.class, message = "There is no Actor with the following id:")
@@ -1620,10 +1620,10 @@ public class MotivationEndpoint {
             @PathParam("id")
             @Valid @NotFoundEntity(repository = MotivationRepository.class, message = "There is no Motivation with the following id:")
             String id, @Parameter(
-            description = "The ID of the Actor to publish.",
-            required = true,
-            example = "pid_graph:234B60D8",
-            schema = @Schema(type = SchemaType.STRING))
+                    description = "The ID of the Actor to publish.",
+                    required = true,
+                    example = "pid_graph:234B60D8",
+                    schema = @Schema(type = SchemaType.STRING))
             @PathParam("actor-id")
             @Valid @NotFoundEntity(repository = RegistryActorRepository.class, message = "There is no Actor with the following id:") String actorId) {
 
@@ -1675,15 +1675,15 @@ public class MotivationEndpoint {
     @Path("/{id}/criteria-metrics")
     @Produces(MediaType.APPLICATION_JSON)
     public Response createNewCriteriaMetricsRelationship(@Parameter(
-            description = "The ID of the Motivation to create a relationship.",
-            required = true,
-            example = "pid_graph:3E109BBA",
-            schema = @Schema(type = SchemaType.STRING))
-                                                            @PathParam("id")
-                                                            @Valid
-                                                            @NotFoundEntity(repository = MotivationRepository.class, message = "There is no Motivation with the following id:")
-                                                            @CheckPublished(repository = MotivationRepository.class, message = "No action permitted for published Motivation with the following id:", isPublishedPermitted = false) String id,
-                                                            @NotEmpty(message = "Criteria-Metrics list can not be empty.") Set<@Valid CriterionMetricRequest> request) {
+                                                                 description = "The ID of the Motivation to create a relationship.",
+                                                                 required = true,
+                                                                 example = "pid_graph:3E109BBA",
+                                                                 schema = @Schema(type = SchemaType.STRING))
+                                                         @PathParam("id")
+                                                         @Valid
+                                                         @NotFoundEntity(repository = MotivationRepository.class, message = "There is no Motivation with the following id:")
+                                                         @CheckPublished(repository = MotivationRepository.class, message = "No action permitted for published Motivation with the following id:", isPublishedPermitted = false) String id,
+                                                         @NotEmpty(message = "Criteria-Metrics list can not be empty.") Set<@Valid CriterionMetricRequest> request) {
 
         var messages = criterionMetricService.createNewCriteriaMetricsRelationship(id, request, utility.getUserUniqueIdentifier());
         String result = String.join(StringUtils.LF, messages);
@@ -1734,15 +1734,15 @@ public class MotivationEndpoint {
     @Path("/{id}/criteria-metrics")
     @Produces(MediaType.APPLICATION_JSON)
     public Response updateCriteriaMetricsRelationship(@Parameter(
-            description = "The ID of the Motivation to update a relationship.",
-            required = true,
-            example = "pid_graph:3E109BBA",
-            schema = @Schema(type = SchemaType.STRING))
-                                                         @PathParam("id")
-                                                         @Valid
-                                                         @NotFoundEntity(repository = MotivationRepository.class, message = "There is no Motivation with the following id:")
-                                                         @CheckPublished(repository = MotivationRepository.class, message = "No action permitted for published Motivation with the following id:", isPublishedPermitted = false) String id,
-                                                         Set<@Valid CriterionMetricRequest> request) {
+                                                              description = "The ID of the Motivation to update a relationship.",
+                                                              required = true,
+                                                              example = "pid_graph:3E109BBA",
+                                                              schema = @Schema(type = SchemaType.STRING))
+                                                      @PathParam("id")
+                                                      @Valid
+                                                      @NotFoundEntity(repository = MotivationRepository.class, message = "There is no Motivation with the following id:")
+                                                      @CheckPublished(repository = MotivationRepository.class, message = "No action permitted for published Motivation with the following id:", isPublishedPermitted = false) String id,
+                                                      Set<@Valid CriterionMetricRequest> request) {
 
         if (Objects.isNull(request)) {
 
@@ -1793,23 +1793,23 @@ public class MotivationEndpoint {
     @Path("/{id}/criteria-metrics")
     @Produces(MediaType.APPLICATION_JSON)
     public Response getCriteriaMetricsRelationship(@Parameter(
-            description = "The ID of the Motivation to assign Principles.",
-            required = true,
-            example = "pid_graph:3E109BBA",
-            schema = @Schema(type = SchemaType.STRING))
-                                                      @PathParam("id")
-                                                      @Valid @NotFoundEntity(repository = MotivationRepository.class, message = "There is no Motivation with the following id:") String id,
-                                                      @Parameter(name = "page", in = QUERY,
-                                                              description = "Indicates the page number. Page number must be >= 1.")
-                                                      @DefaultValue("1") @Min(value = 1, message = "Page number must be >= 1.")
-                                                      @QueryParam("page") int page,
-                                                      @Parameter(name = "size", in = QUERY,
-                                                              description = "The page size.")
-                                                      @DefaultValue("10")
-                                                      @Min(value = 1, message = "Page size must be between 1 and 100.")
-                                                      @Max(value = 100, message = "Page size must be between 1 and 100.")
-                                                      @QueryParam("size") int size,
-                                                      @Context UriInfo uriInfo) {
+                                                           description = "The ID of the Motivation to assign Principles.",
+                                                           required = true,
+                                                           example = "pid_graph:3E109BBA",
+                                                           schema = @Schema(type = SchemaType.STRING))
+                                                   @PathParam("id")
+                                                   @Valid @NotFoundEntity(repository = MotivationRepository.class, message = "There is no Motivation with the following id:") String id,
+                                                   @Parameter(name = "page", in = QUERY,
+                                                           description = "Indicates the page number. Page number must be >= 1.")
+                                                   @DefaultValue("1") @Min(value = 1, message = "Page number must be >= 1.")
+                                                   @QueryParam("page") int page,
+                                                   @Parameter(name = "size", in = QUERY,
+                                                           description = "The page size.")
+                                                   @DefaultValue("10")
+                                                   @Min(value = 1, message = "Page size must be between 1 and 100.")
+                                                   @Max(value = 100, message = "Page size must be between 1 and 100.")
+                                                   @QueryParam("size") int size,
+                                                   @Context UriInfo uriInfo) {
 
 
         var response = criterionMetricService.getCriteriaMetricsRelationship(id, page - 1, size, uriInfo);
@@ -2325,5 +2325,152 @@ public class MotivationEndpoint {
             this.content = content;
         }
     }
-}
 
+    @Tag(name = "Motivation")
+    @Operation(
+            summary = "Remove a Principle from a Motivation.",
+            description = "Removes  a principle from a specific Motivation and its associated relations.")
+    @APIResponse(
+            responseCode = "200",
+            description = "Principle successfully deleted from the motivation.",
+            content = @Content(schema = @Schema(
+                    type = SchemaType.OBJECT,
+                    implementation = InformativeResponse.class)))
+    @APIResponse(
+            responseCode = "400",
+            description = "Invalid request payload.",
+            content = @Content(schema = @Schema(
+                    type = SchemaType.OBJECT,
+                    implementation = InformativeResponse.class)))
+    @APIResponse(
+            responseCode = "401",
+            description = "User has not been authenticated.",
+            content = @Content(schema = @Schema(
+                    type = SchemaType.OBJECT,
+                    implementation = InformativeResponse.class)))
+    @APIResponse(
+            responseCode = "403",
+            description = "Not permitted.",
+            content = @Content(schema = @Schema(
+                    type = SchemaType.OBJECT,
+                    implementation = InformativeResponse.class)))
+    @APIResponse(
+            responseCode = "404",
+            description = "Motivation or Principle not found.",
+            content = @Content(schema = @Schema(
+                    type = SchemaType.OBJECT,
+                    implementation = InformativeResponse.class)))
+    @APIResponse(
+            responseCode = "500",
+            description = "Internal Server Error.",
+            content = @Content(schema = @Schema(
+                    type = SchemaType.OBJECT,
+                    implementation = InformativeResponse.class)))
+    @SecurityRequirement(name = "Authentication")
+    @DELETE
+    @Path("/{id}/principles/{principle-id}")
+    @Produces(MediaType.APPLICATION_JSON)
+    @Registration
+    public Response removePrincipleFromMotivation(@Parameter(
+                                                          description = "The ID of the Motivation to update.",
+                                                          required = true,
+                                                          example = "1",
+                                                          schema = @Schema(type = SchemaType.STRING))
+                                                  @PathParam("id")
+                                                  @Valid
+                                                  @NotFoundEntity(repository = MotivationRepository.class, message = "There is no Motivation with the following id:")
+                                                  @CheckPublished(repository = MotivationRepository.class, message = "No action permitted for published Motivation with the following id:", isPublishedPermitted = false) String id,
+                                                  @Parameter(
+                                                          description = "The principle to be deleted.",
+                                                          required = true,
+                                                          example = "pid_graph:0E00C332",
+                                                          schema = @Schema(type = SchemaType.STRING))
+                                                  @PathParam("principle-id")
+                                                  @Valid @NotFoundEntity(
+                                                          repository = PrincipleRepository.class,
+                                                          message = "There is no Principle with the following id: ")
+                                                  String principleId) {
+
+        var messages = motivationService.deletePrincipleFromMotivation(id, principleId);
+        String result = String.join("\n", messages);
+
+        var informativeResponse = new InformativeResponse();
+        informativeResponse.code = 200;
+        informativeResponse.message = result;
+
+        return Response.ok().entity(informativeResponse).build();
+    }
+
+
+    @Tag(name = "Motivation")
+    @Operation(
+            summary = "Update a Principle from a Motivation.",
+            description = "Update  a principle from a specific Motivation and its associated relations.")
+    @APIResponse(
+            responseCode = "200",
+            description = "Principle successfully updated from the motivation.",
+            content = @Content(schema = @Schema(
+                    type = SchemaType.OBJECT,
+                    implementation = InformativeResponse.class)))
+    @APIResponse(
+            responseCode = "400",
+            description = "Invalid request payload.",
+            content = @Content(schema = @Schema(
+                    type = SchemaType.OBJECT,
+                    implementation = InformativeResponse.class)))
+    @APIResponse(
+            responseCode = "401",
+            description = "User has not been authenticated.",
+            content = @Content(schema = @Schema(
+                    type = SchemaType.OBJECT,
+                    implementation = InformativeResponse.class)))
+    @APIResponse(
+            responseCode = "403",
+            description = "Not permitted.",
+            content = @Content(schema = @Schema(
+                    type = SchemaType.OBJECT,
+                    implementation = InformativeResponse.class)))
+    @APIResponse(
+            responseCode = "404",
+            description = "Motivation or Principle not found.",
+            content = @Content(schema = @Schema(
+                    type = SchemaType.OBJECT,
+                    implementation = InformativeResponse.class)))
+    @APIResponse(
+            responseCode = "500",
+            description = "Internal Server Error.",
+            content = @Content(schema = @Schema(
+                    type = SchemaType.OBJECT,
+                    implementation = InformativeResponse.class)))
+    @SecurityRequirement(name = "Authentication")
+    @PUT
+    @Path("/{id}/principles/{principle-id}")
+    @Produces(MediaType.APPLICATION_JSON)
+    @Registration
+    public Response updatePrincipleFromMotivation(@Parameter(
+                                                          description = "The ID of the Motivation to update.",
+                                                          required = true,
+                                                          example = "1",
+                                                          schema = @Schema(type = SchemaType.STRING))
+                                                  @PathParam("id")
+                                                  @Valid
+                                                  @NotFoundEntity(repository = MotivationRepository.class, message = "There is no Motivation with the following id:")
+                                                  @CheckPublished(repository = MotivationRepository.class, message = "No action permitted for published Motivation with the following id:", isPublishedPermitted = false) String id,
+                                                  @Parameter(
+                                                          description = "The principle to be deleted.",
+                                                          required = true,
+                                                          example = "pid_graph:0E00C332",
+                                                          schema = @Schema(type = SchemaType.STRING))
+                                                  @PathParam("principle-id")
+                                                  @Valid @NotFoundEntity(
+                                                          repository = PrincipleRepository.class,
+                                                          message = "There is no Principle with the following id: ")
+                                                  String principleId, @Valid @NotNull(message = "The request body is empty.") PrincipleUpdateDto principleRequestDto
+    ) {
+
+        var principle = motivationService.updatePrincipleFromMotivation(id, principleId, principleRequestDto);
+
+
+        return Response.ok().entity(principle).build();
+    }
+}

--- a/api/src/test/java/org/grnet/cat/api/KeycloakTest.java
+++ b/api/src/test/java/org/grnet/cat/api/KeycloakTest.java
@@ -18,8 +18,6 @@ import org.grnet.cat.services.UserService;
 import org.grnet.cat.services.ValidationService;
 import org.grnet.cat.services.assessment.JsonAssessmentService;
 import org.grnet.cat.services.registry.CriterionService;
-import org.grnet.cat.services.registry.metric.MetricService;
-import org.intellij.lang.annotations.JdkConstants;
 import org.junit.jupiter.api.BeforeEach;
 import org.mockito.Mockito;
 

--- a/api/src/test/java/org/grnet/cat/api/registry/MotivationEndpointTest.java
+++ b/api/src/test/java/org/grnet/cat/api/registry/MotivationEndpointTest.java
@@ -40,7 +40,7 @@ public class MotivationEndpointTest extends KeycloakTest {
         var error = given()
                 .auth()
                 .oauth2(getAccessToken("alice"))
-                 .contentType(ContentType.JSON)
+                .contentType(ContentType.JSON)
                 .get("/{id}", "pid_graph:3E109BBA")
                 .then()
                 .assertThat()
@@ -1146,7 +1146,7 @@ public class MotivationEndpointTest extends KeycloakTest {
     private void testPublishMotivation(String motivationId) {
 
         /******* Test UnAuthorized **********/
-     var   response = given()
+        var   response = given()
                 .auth().oauth2("alice")
                 .contentType(ContentType.JSON)
                 .put("/{id}/publish", motivationId)

--- a/data-transfer-object/src/main/java/org/grnet/cat/dtos/registry/motivation/DeletePrincipleCriterionRequest.java
+++ b/data-transfer-object/src/main/java/org/grnet/cat/dtos/registry/motivation/DeletePrincipleCriterionRequest.java
@@ -1,0 +1,44 @@
+package org.grnet.cat.dtos.registry.motivation;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.constraints.NotEmpty;
+import lombok.EqualsAndHashCode;
+import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
+import org.grnet.cat.constraints.NotFoundEntity;
+import org.grnet.cat.repositories.registry.CriterionRepository;
+import org.grnet.cat.repositories.registry.PrincipleRepository;
+import org.grnet.cat.repositories.registry.RelationRepository;
+
+@Schema(name="DeletePrincipleCriterionRequest", description="This object represents a request for creating a new relationship between principle and criterion.")
+@EqualsAndHashCode(onlyExplicitlyIncluded = true)
+public class DeletePrincipleCriterionRequest {
+
+    @Schema(
+            type = SchemaType.STRING,
+            implementation = String.class,
+            description = "The Criterion.",
+            required = true,
+            example = "pid_graph:A5A41F03"
+    )
+
+    @NotEmpty(message = "criterion_id may not be empty.")
+    @NotFoundEntity(repository = CriterionRepository.class, message = "There is no Criterion with the following id:")
+    @JsonProperty(value = "criterion_id")
+    @EqualsAndHashCode.Include
+    public String criterionId;
+
+    @Schema(
+            type = SchemaType.STRING,
+            implementation = String.class,
+            description = "The Principle.",
+            required = true,
+            example = "pid_graph:0C11BA29"
+    )
+    @NotEmpty(message = "principle_id may not be empty.")
+    @NotFoundEntity(repository = PrincipleRepository.class, message = "There is no Principle with the following id:")
+    @JsonProperty(value = "principle_id")
+    @EqualsAndHashCode.Include
+    public String principleId;
+}
+

--- a/repository/src/main/java/org/grnet/cat/repositories/registry/MotivationPrincipleRepository.java
+++ b/repository/src/main/java/org/grnet/cat/repositories/registry/MotivationPrincipleRepository.java
@@ -14,7 +14,11 @@ public class MotivationPrincipleRepository implements Repository<MotivationPrinc
                 .firstResultOptional()
                 .isPresent();
     }
-
+    public boolean isUsedInOtherMotivation(String motivationId, String principleId, Integer lodMpV) {
+        return find("SELECT 1 FROM MotivationPrincipleJunction m WHERE m.id.motivationId != ?1 AND m.id.principleId = ?2 AND m.id.lodMpV = ?3", motivationId, principleId, lodMpV)
+                .firstResultOptional()
+                .isPresent();
+    }
 
     public boolean existsByPrinciple(String principleId) {
         return find("SELECT 1 FROM MotivationPrincipleJunction pc WHERE pc.id.principleId = ?1", principleId)
@@ -33,5 +37,9 @@ public class MotivationPrincipleRepository implements Repository<MotivationPrinc
     @Transactional
     public long removeAll(){
         return deleteAll();
+    }
+
+    public void deleteByPrincipleId(String motivationId, String principleId,Integer lodMpV) {
+        delete("FROM MotivationPrincipleJunction p WHERE p.id.motivationId =?1 AND p.id.principleId = ?2 AND p.id.lodMpV = ?3", motivationId, principleId,lodMpV);
     }
 }

--- a/repository/src/main/java/org/grnet/cat/repositories/registry/MotivationRepository.java
+++ b/repository/src/main/java/org/grnet/cat/repositories/registry/MotivationRepository.java
@@ -123,4 +123,5 @@ public class MotivationRepository implements Repository<Motivation, String> {
     public Motivation fetchById(String id) {
         return find("from Motivation m left join fetch m.motivationType mt left join fetch m.actors act left join fetch act.actor left join fetch m.principles pri left join fetch pri.principle where m.id = ?1", id).firstResult();
     }
+
 }

--- a/repository/src/main/java/org/grnet/cat/repositories/registry/PrincipleCriterionRepository.java
+++ b/repository/src/main/java/org/grnet/cat/repositories/registry/PrincipleCriterionRepository.java
@@ -158,7 +158,25 @@ public class PrincipleCriterionRepository  implements Repository<PrincipleCriter
                 .isPresent();
     }
 
+    public boolean existsByMotivationAndPrincipleAndVersion(String motivationId, String principleId, Integer lodMpV) {
+        return find("SELECT 1 FROM PrincipleCriterionJunction p WHERE p.id.motivationId = ?1 AND p.id.principleId = ?2 AND p.id.lodPcV = ?3", motivationId, principleId, lodMpV)
+                .firstResultOptional()
+                .isPresent();
+    }
 
+    public void deleteByMotivationPrincipleId(String motivationId, String principleId) {
+        delete("FROM PrincipleCriterionJunction p WHERE p.id.motivationId =?1 AND p.id.principleId = ?2", motivationId, principleId);
+    }
+
+    public boolean isUsedWithCriterionInOtherMotivation(String motivationId, String principleId, Integer lodPcV) {
+        return find("SELECT 1 FROM PrincipleCriterionJunction m WHERE m.id.motivationId != ?1 AND m.id.principleId = ?2 AND m.id.lodPcV = ?3", motivationId, principleId, lodPcV)
+                .firstResultOptional()
+                .isPresent();
+    }
+
+    public void deletePrincipleCriterionMotivationRelation(String motivationId, String principleId,String criterionId) {
+        delete("FROM PrincipleCriterionJunction p WHERE p.motivation.id =?1 AND p.id.principleId = ?2 AND p.id.criterionId = ?3" , motivationId, principleId,criterionId);
+    }
 }
 
 

--- a/repository/src/main/java/org/grnet/cat/repositories/registry/PrincipleRepository.java
+++ b/repository/src/main/java/org/grnet/cat/repositories/registry/PrincipleRepository.java
@@ -94,5 +94,6 @@ public class PrincipleRepository implements Repository<Principle, String> {
                 .getSingleResult();
         return count > 0;
     }
+
 }
 


### PR DESCRIPTION
Delete a principle inside a motivation: this will remove the principle-motivation relation as well as the principle-criterion-motivation relation. principle will be deleted from registry only in the case the principle has no relations principle-motivation, principle-criterion-motivation with any other motivation except the one trying to update
Update a principle inside a motivation : this will update the principle fileds. only in the case there does not exist any other relations principle-motivation, principle-criterion-motivation with any other motivation except the one trying to update