### PR TITLE
CAT-695: Implement GET and PUT /metric - definition by Motivation API Endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ According to [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) , the `Unr
 - [#400](https://github.com/FC4E-CAT/fc4e-cat-api/pull/400) 
 
 - [#401](https://github.com/FC4E-CAT/fc4e-cat-api/pull/401) CAT-693 Create POST and PUT Endpoints for Metric-Test Relationship
+- [#405](https://github.com/FC4E-CAT/fc4e-cat-api/pull/405) CAT-695: Implement GET and PUT /metric - definition by Motivation API Endpoint
 
 ### Fix
 

--- a/data-transfer-object/src/main/java/org/grnet/cat/dtos/registry/MetricDefinitionExtendedResponse.java
+++ b/data-transfer-object/src/main/java/org/grnet/cat/dtos/registry/MetricDefinitionExtendedResponse.java
@@ -1,0 +1,118 @@
+package org.grnet.cat.dtos.registry;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
+
+@Schema(name="MetricDefinitionResponse", description="This object represents a response for a Metric Definition.")
+public class MetricDefinitionExtendedResponse {
+
+    @Schema(
+            type = SchemaType.STRING,
+            implementation = String.class,
+            description = "The Metric Object.",
+            example = "pid_graph:97ECCC27"
+    )
+    @JsonProperty("metric_id")
+    public String metricId;
+
+    @Schema(
+            type = SchemaType.STRING,
+            implementation = String.class,
+            description = "The Metric Label.",
+            example = "Versioning Supported"
+    )
+    @JsonProperty("metric_label")
+    public String metricLabel;
+
+    @Schema(
+            type = SchemaType.STRING,
+            implementation = String.class,
+            description = "The description of the metric.",
+            example = "Evidence is available that one or more versioning approaches can be implemented"
+    )
+    @JsonProperty("metric_description")
+    public String metricDescription;
+
+    @Schema(
+            type = SchemaType.STRING,
+            implementation = String.class,
+            description = "The Type Algorithm Id.",
+            example = "pid_graph:EBCEBED1"
+    )
+    @JsonProperty("type_algorithm_id")
+    public String typeAlgorithmId;
+
+    @Schema(
+            type = SchemaType.STRING,
+            implementation = String.class,
+            description = "The Type Algorithm Label.",
+            example = "Test = Metric"
+    )
+    @JsonProperty("type_algorithm_label")
+    public String typeAlgorithmLabel;
+
+    @Schema(
+            type = SchemaType.STRING,
+            implementation = String.class,
+            description = "The Metric Type Label.",
+            example = "pid_graph:EBCEBED1"
+    )
+    @JsonProperty("type_metric_id")
+    public String typeMetricId;
+
+    @Schema(
+            type = SchemaType.STRING,
+            implementation = String.class,
+            description = "The Metric Type Label.",
+            example = "pid_graph:EBCEBED1"
+    )
+    @JsonProperty("type_metric_label")
+    public String typeMetricLabel;
+
+
+    @Schema(
+            type = SchemaType.STRING,
+            implementation = String.class,
+            description = "The Type Benchmark Id.",
+            example = "pid_graph:EBCEBED1"
+    )
+    @JsonProperty("type_benchmark_id")
+    public String typeBenchmarkId;
+
+    @Schema(
+            type = SchemaType.STRING,
+            implementation = String.class,
+            description = "The Type Benchmark label.",
+            example = "Binary-Binary"
+    )
+    @JsonProperty("type_benchmark_label")
+    public String typeBenchmarkLabel;
+
+    @Schema(
+            type = SchemaType.STRING,
+            implementation = String.class,
+            description = "The Type Benchmark description.",
+            example = "The benchmark maps a binary metric value to binary assessment outcome (Pass/ Fail). The inverse can also be done."
+    )
+    @JsonProperty("type_benchmark_description")
+    public String typeBenchmarkDescription;
+
+    @Schema(
+            type = SchemaType.STRING,
+            implementation = String.class,
+            description = "The Type Benchmark pattern.",
+            example = "M[0,1] → [Fail, Pass]"
+    )
+    @JsonProperty("type_benchmark_patter")
+    public String typeBenchmarkPatter;
+
+    @Schema(
+            type = SchemaType.STRING,
+            implementation = String.class,
+            description = "The Motivation Id.",
+            example = "pid_graph:3E109BBA"
+    )@JsonProperty("motivation_id")
+    public String motivationId;
+
+}

--- a/data-transfer-object/src/main/java/org/grnet/cat/dtos/registry/MetricDefinitionRequest.java
+++ b/data-transfer-object/src/main/java/org/grnet/cat/dtos/registry/MetricDefinitionRequest.java
@@ -1,0 +1,45 @@
+package org.grnet.cat.dtos.registry;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
+
+@Schema(name="MetricDefinitionRequest", description="This object represents a request for a Metric Definition Update.")
+public class MetricDefinitionRequest {
+
+    @Schema(
+            type = SchemaType.STRING,
+            implementation = String.class,
+            description = "The Metric ID.",
+            example = "pid_graph:EBCEBED1"
+    )
+    @JsonProperty("metric_id")
+    public String metricId;
+
+    @Schema(
+            type = SchemaType.STRING,
+            implementation = String.class,
+            description = "The Benchmark Type ID.",
+            example = "pid_graph:0917EC0D"
+    )
+    @JsonProperty("type_benchmark_id")
+    public String typeBenchmarkId;
+
+    @Schema(
+            type = SchemaType.STRING,
+            implementation = String.class,
+            description = "The Benchmark Value.",
+            example = "3"
+    )
+    @JsonProperty("value_benchmark")
+    public String valueBenchmark;
+
+    @Schema(
+            type = SchemaType.STRING,
+            implementation = String.class,
+            description = "The Motivation ID.",
+            example = "pid_graph:EBCEBED1"
+    )
+    @JsonProperty("motivation_id")
+    public String motivationId;
+}

--- a/mapper/src/main/java/org/grnet/cat/mappers/registry/MetricDefinitionMapper.java
+++ b/mapper/src/main/java/org/grnet/cat/mappers/registry/MetricDefinitionMapper.java
@@ -1,8 +1,10 @@
 package org.grnet.cat.mappers.registry;
 
 import org.apache.commons.lang3.StringUtils;
+import org.grnet.cat.dtos.registry.MetricDefinitionExtendedResponse;
 import org.grnet.cat.dtos.registry.MetricDefinitionResponseDto;
 import org.grnet.cat.entities.registry.MetricDefinitionJunction;
+import org.grnet.cat.mappers.registry.metric.MetricMapper;
 import org.mapstruct.IterableMapping;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
@@ -11,7 +13,7 @@ import org.mapstruct.factory.Mappers;
 
 import java.util.List;
 
-@Mapper(imports = {StringUtils.class, java.sql.Timestamp.class, java.time.Instant.class})
+@Mapper(imports = {StringUtils.class, java.sql.Timestamp.class, java.time.Instant.class}, uses = {MetricMapper.class, TypeBenchmarkMapper.class})
 public interface MetricDefinitionMapper {
 
     MetricDefinitionMapper INSTANCE = Mappers.getMapper(MetricDefinitionMapper.class);
@@ -24,5 +26,25 @@ public interface MetricDefinitionMapper {
     @Mapping(target = "typeBenchmarkId",  expression = "java(metricDefinitionJunction.getTypeBenchmark().getId())")
     @Mapping(target = "motivationId", expression = "java(metricDefinitionJunction.getMotivation().getId())")
     MetricDefinitionResponseDto metricDefinitionToResponseDto(MetricDefinitionJunction metricDefinitionJunction);
+
+    @IterableMapping(qualifiedByName = "mapToExtendedResponse")
+    List<MetricDefinitionExtendedResponse> metricDefinitionToExtendedResponses(List<MetricDefinitionJunction> metricDefinitionJunctions);
+
+    @Named("mapToExtendedResponse")
+    @Mapping(target = "metricId", expression = "java(metricDefinitionJunction.getMetric().getId())")
+    @Mapping(target = "metricLabel", expression = "java(metricDefinitionJunction.getMetric().getLabelMetric())")
+    @Mapping(target = "metricDescription", expression = "java(metricDefinitionJunction.getMetric().getDescrMetric())")
+    @Mapping(target = "typeAlgorithmId", expression = "java(metricDefinitionJunction.getMetric().getTypeAlgorithm().getId())")
+    @Mapping(target = "typeAlgorithmLabel", expression = "java(metricDefinitionJunction.getMetric().getTypeAlgorithm().getLabelAlgorithmType())")
+    @Mapping(target = "typeMetricId", expression = "java(metricDefinitionJunction.getMetric().getTypeMetric().getId())")
+    @Mapping(target = "typeMetricLabel", expression = "java(metricDefinitionJunction.getMetric().getTypeMetric().getLabelTypeMetric())")
+    @Mapping(target = "typeBenchmarkId", expression = "java(metricDefinitionJunction.getTypeBenchmark().getId())")
+    @Mapping(target = "typeBenchmarkLabel", expression = "java(metricDefinitionJunction.getTypeBenchmark().getLabelBenchmarkType())")
+    @Mapping(target = "typeBenchmarkDescription", expression = "java(metricDefinitionJunction.getTypeBenchmark().getDescBenchmarkType())")
+    @Mapping(target = "typeBenchmarkPatter", expression = "java(metricDefinitionJunction.getTypeBenchmark().getPattern())")
+    @Mapping(target = "motivationId", expression = "java(metricDefinitionJunction.getMotivation().getId())")
+    MetricDefinitionExtendedResponse metricDefinitionToExtendedResponse(MetricDefinitionJunction metricDefinitionJunction);
+
+
 
 }

--- a/repository/src/main/java/org/grnet/cat/repositories/registry/MetricDefinitionRepository.java
+++ b/repository/src/main/java/org/grnet/cat/repositories/registry/MetricDefinitionRepository.java
@@ -7,9 +7,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.grnet.cat.entities.Page;
 import org.grnet.cat.entities.PageQuery;
 import org.grnet.cat.entities.PageQueryImpl;
-import org.grnet.cat.entities.registry.CriterionMetricJunction;
 import org.grnet.cat.entities.registry.MetricDefinitionJunction;
-import org.grnet.cat.entities.registry.MetricTestJunction;
 import org.grnet.cat.repositories.Repository;
 
 import java.util.HashMap;


### PR DESCRIPTION
### GET /metric-definition (response):
> {
>   "size_of_page": 1,
>   "number_of_page": 1,
>   "total_elements": 1,
>   "total_pages": 1,
>   "content": [
>     {
>       "metric_id": "pid_graph:6805DC1D",
>       "metric_label": "Performance Metric",
>       "metric_description": "This metric measures performance.",
>       "type_algorithm_id": "pid_graph:2050775C",
>       "type_algorithm_label": "Weighted Sum",
>       "type_metric_id": "pid_graph:35966E2B",
>       "type_metric_label": "Open Review",
>       "type_benchmark_id": "pid_graph:0917EC0D",
>       "type_benchmark_label": "Integer-Binary-AND",
>       "type_benchmark_description": "The benchmark maps the aggregate of a number of binary tests, expressed as an integer, to a binary assessment and all tests must pass. The benchmark equals the number of tests.",
>       "type_benchmark_patter": "M → [Fail, Pass]",
>       "motivation_id": "pid_graph:169E9666"
>     }
>   ],
>   "links": []

### PUT /metric-definition (request):
> [
>   {
>     "metric_id": "pid_graph:EBCEBED1",
>     "type_benchmark_id": "pid_graph:0917EC0D",
>     "value_benchmark": "3",
>     "motivation_id": "pid_graph:EBCEBED1"
>   }
> ]