### PR TITLE
CAT-697: Update /registry/tests Endpoints to Include All test and test-definition Fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,7 @@ According to [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) , the `Unr
 - [#399](https://github.com/FC4E-CAT/fc4e-cat-api/pull/399) CAT-687 Publish/Unpublish motivation not to change motivation-actor publish status
 - [#403](https://github.com/FC4E-CAT/fc4e-cat-api/pull/403) CAT-689 Change POST /registry/metrics to insert full metric/metric-definition relation (fix)
 - [#406](https://github.com/FC4E-CAT/fc4e-cat-api/pull/406) CAT-698 Support test-metric relations of a specific metric in a motivation #406
+- [#407](https://github.com/FC4E-CAT/fc4e-cat-api/pull/407) CAT-697: Update /registry/tests Endpoints to Include All test and test-definition Fields
 
 
 

--- a/api/src/main/java/org/grnet/cat/api/endpoints/registry/TestDefinitionEndpoint.java
+++ b/api/src/main/java/org/grnet/cat/api/endpoints/registry/TestDefinitionEndpoint.java
@@ -140,9 +140,9 @@ public class TestDefinitionEndpoint {
     @Produces(MediaType.APPLICATION_JSON)
     @Registration
     public Response createTestDefinition(
-            @Valid @NotNull(message = "The request body is empty.") TestDefinitionRequestDto testRequestDto, @Context UriInfo uriInfo) {
+            @Valid @NotNull(message = "The request body is empty.") TestDefinitionRequestDto request, @Context UriInfo uriInfo) {
 
-        var testDefinition= testDefinitionService.createTestDefinition(utility.getUserUniqueIdentifier(),testRequestDto);
+        var testDefinition= testDefinitionService.createTestDefinition(utility.getUserUniqueIdentifier(), request);
         var serverInfo = new CatServiceUriInfo(serverUrl.concat(uriInfo.getPath()));
 
         return Response.created(serverInfo.getAbsolutePathBuilder().path(String.valueOf(testDefinition.id)).build()).entity(testDefinition).build();

--- a/api/src/main/java/org/grnet/cat/api/endpoints/registry/TestEndpoint.java
+++ b/api/src/main/java/org/grnet/cat/api/endpoints/registry/TestEndpoint.java
@@ -25,9 +25,7 @@ import org.grnet.cat.api.utils.CatServiceUriInfo;
 import org.grnet.cat.constraints.NotFoundEntity;
 import org.grnet.cat.dtos.InformativeResponse;
 import org.grnet.cat.dtos.pagination.PageResource;
-import org.grnet.cat.dtos.registry.test.TestRequestDto;
-import org.grnet.cat.dtos.registry.test.TestResponseDto;
-import org.grnet.cat.dtos.registry.test.TestUpdateDto;
+import org.grnet.cat.dtos.registry.test.*;
 import org.grnet.cat.repositories.registry.TestRepository;
 
 import org.grnet.cat.services.registry.TestService;
@@ -60,7 +58,7 @@ public class TestEndpoint {
             description = "The corresponding Test item.",
             content = @Content(schema = @Schema(
                     type = SchemaType.OBJECT,
-                    implementation = TestResponseDto.class))
+                    implementation = TestAndTestDefinitionResponse.class))
     )
     @APIResponse(
             responseCode = "401",
@@ -100,7 +98,7 @@ public class TestEndpoint {
             @PathParam("id")
             @Valid @NotFoundEntity(repository = TestRepository.class, message = "There is no Test with the following id:") String id) {
 
-        var response = testService.getTestById(id);
+        var response = testService.getTestAndTestDefinitionById(id);
 
         return Response.ok(response).build();
     }
@@ -146,12 +144,12 @@ public class TestEndpoint {
     @Produces(MediaType.APPLICATION_JSON)
     @Registration
     public Response createTest(
-            @Valid @NotNull(message = "The request body is empty.") TestRequestDto testRequestDto, @Context UriInfo uriInfo) {
+            @Valid @NotNull(message = "The request body is empty.") TestAndTestDefinitionRequest request, @Context UriInfo uriInfo) {
 
-        var test = testService.createTest(utility.getUserUniqueIdentifier(), testRequestDto);
+        var test = testService.createTestAndTestDefinition(utility.getUserUniqueIdentifier(), request);
         var serverInfo = new CatServiceUriInfo(serverUrl.concat(uriInfo.getPath()));
 
-        return Response.created(serverInfo.getAbsolutePathBuilder().path(String.valueOf(test.id)).build()).entity(test).build();
+        return Response.created(serverInfo.getAbsolutePathBuilder().path(String.valueOf(test.testResponse.id)).build()).entity(test).build();
     }
 
     @Tag(name = "Test")
@@ -329,7 +327,7 @@ public class TestEndpoint {
             @QueryParam("size") int size,
             @Context UriInfo uriInfo) {
 
-        var tests = testService.getTestlistAll(page - 1, size, uriInfo);
+        var tests = testService.getTestAndTestDefinitionListAll(page - 1, size, uriInfo);
 
         return Response.ok().entity(tests).build();
     }

--- a/api/src/test/java/org/grnet/cat/api/registry/TestEndpointTest.java
+++ b/api/src/test/java/org/grnet/cat/api/registry/TestEndpointTest.java
@@ -8,9 +8,7 @@ import org.grnet.cat.api.endpoints.registry.TestEndpoint;
 import org.grnet.cat.dtos.AutomatedCheckResponse;
 import org.grnet.cat.dtos.InformativeResponse;
 import org.grnet.cat.dtos.AutomatedCheckRequest;
-import org.grnet.cat.dtos.registry.test.TestRequestDto;
-import org.grnet.cat.dtos.registry.test.TestResponseDto;
-import org.grnet.cat.dtos.registry.test.TestUpdateDto;
+import org.grnet.cat.dtos.registry.test.*;
 import org.junit.jupiter.api.Test;
 
 import static io.restassured.RestAssured.given;
@@ -44,25 +42,38 @@ public class TestEndpointTest extends KeycloakTest {
 
         register("admin");
 
-        var request = new TestRequestDto();
-        request.TES = "T12";
-        request.labelTest = "Performance Test";
-        request.descTest = "This Test measures performance.";
+        var createRequest = new TestAndTestDefinitionRequest();
+
+        var testRequest = new TestRequestDto();
+        testRequest.TES = "TCREATE";
+        testRequest.labelTest =  "Performance Test";
+        testRequest.descTest = "This Test measures performance.";
+
+        var testDefinitionRequest = new TestDefinitionRequestDto();
+        testDefinitionRequest.testMethodId = "pid_graph:B733A7D5";
+        testDefinitionRequest.labelTestDefinition = "Performance Test Definition";
+        testDefinitionRequest.paramType = "onscreen";
+        testDefinitionRequest.testParams = "userAuth|evidence";
+        testDefinitionRequest.testQuestion = "\"Does access to Sensitive PID Kernel Metadata require user authentication?\"|\"Provide evidence of this provision via a link to a specification, user guide, or API definition.\"";
+        testDefinitionRequest.toolTip =  "\"Users need to be authenticated and requisite permissions must apply for access to sensitive metadata\"|\"A document, web page, or publication describing provisions\"";
+
+        createRequest.setTestRequest(testRequest);
+        createRequest.setTestDefinitionRequest(testDefinitionRequest);
 
         var response = given()
                 .auth()
                 .oauth2(getAccessToken("admin"))
-                .body(request)
+                .body(createRequest)
                 .contentType(ContentType.JSON)
                 .post("/")
                 .then()
                 .assertThat()
                 .statusCode(201)
                 .extract()
-                .as(TestResponseDto.class);
+                .as(TestAndTestDefinitionResponse.class);
 
-        assertEquals("Performance Test", response.labelTest);
-        assertEquals("This Test measures performance.", response.descTest);
+        assertEquals("Performance Test", response.testResponse.labelTest);
+        assertEquals("This Test measures performance.", response.testResponse.descTest);
     }
 
     @Test
@@ -70,10 +81,23 @@ public class TestEndpointTest extends KeycloakTest {
 
         register("admin");
 
-        var createRequest = new TestRequestDto();
-        createRequest.TES = "T12";
-        createRequest.labelTest = "Performance Test";
-        createRequest.descTest = "This Test measures performance.";
+        var createRequest = new TestAndTestDefinitionRequest();
+
+        var testRequest = new TestRequestDto();
+        testRequest.TES = "TGET";
+        testRequest.labelTest =  "Performance Test";
+        testRequest.descTest = "This Test measures performance.";
+
+        var testDefinitionRequest = new TestDefinitionRequestDto();
+        testDefinitionRequest.testMethodId = "pid_graph:B733A7D5";
+        testDefinitionRequest.labelTestDefinition = "Performance Test Definition";
+        testDefinitionRequest.paramType = "onscreen";
+        testDefinitionRequest.testParams = "userAuth|evidence";
+        testDefinitionRequest.testQuestion = "\"Does access to Sensitive PID Kernel Metadata require user authentication?\"|\"Provide evidence of this provision via a link to a specification, user guide, or API definition.\"";
+        testDefinitionRequest.toolTip =  "\"Users need to be authenticated and requisite permissions must apply for access to sensitive metadata\"|\"A document, web page, or publication describing provisions\"";
+
+        createRequest.setTestRequest(testRequest);
+        createRequest.setTestDefinitionRequest(testDefinitionRequest);
 
         var createdTest = given()
                 .auth()
@@ -85,20 +109,20 @@ public class TestEndpointTest extends KeycloakTest {
                 .assertThat()
                 .statusCode(201)
                 .extract()
-                .as(TestResponseDto.class);
+                .as(TestAndTestDefinitionResponse.class);
 
         var response = given()
                 .auth()
                 .oauth2(getAccessToken("admin"))
                 .contentType(ContentType.JSON)
-                .get("/{id}", createdTest.id)
+                .get("/{id}", createdTest.testResponse.id)
                 .then()
                 .assertThat()
                 .statusCode(200)
                 .extract()
-                .as(TestResponseDto.class);
+                .as(TestAndTestDefinitionResponse.class);
 
-        assertEquals(response.TES, "T12");
+        assertEquals(response.testResponse.TES, "TGET");
     }
 
     @Test
@@ -125,10 +149,23 @@ public class TestEndpointTest extends KeycloakTest {
 
         register("admin");
 
-        var createRequest = new TestRequestDto();
-        createRequest.TES = "T12";
-        createRequest.labelTest = "Performance Test";
-        createRequest.descTest = "This Test measures performance.";
+        var createRequest = new TestAndTestDefinitionRequest();
+
+        var testRequest = new TestRequestDto();
+        testRequest.TES = "TCREATE1";
+        testRequest.labelTest =  "Performance Test";
+        testRequest.descTest = "This Test measures performance.";
+
+        var testDefinitionRequest = new TestDefinitionRequestDto();
+        testDefinitionRequest.testMethodId = "pid_graph:B733A7D5";
+        testDefinitionRequest.labelTestDefinition = "Performance Test Definition";
+        testDefinitionRequest.paramType = "onscreen";
+        testDefinitionRequest.testParams = "userAuth|evidence";
+        testDefinitionRequest.testQuestion = "\"Does access to Sensitive PID Kernel Metadata require user authentication?\"|\"Provide evidence of this provision via a link to a specification, user guide, or API definition.\"";
+        testDefinitionRequest.toolTip =  "\"Users need to be authenticated and requisite permissions must apply for access to sensitive metadata\"|\"A document, web page, or publication describing provisions\"";
+
+        createRequest.setTestRequest(testRequest);
+        createRequest.setTestDefinitionRequest(testDefinitionRequest);
 
         var createdTest = given()
                 .auth()
@@ -140,10 +177,10 @@ public class TestEndpointTest extends KeycloakTest {
                 .assertThat()
                 .statusCode(201)
                 .extract()
-                .as(TestResponseDto.class);
+                .as(TestAndTestDefinitionResponse.class);
 
         var updateRequest = new TestUpdateDto();
-        updateRequest.TES = "T12-Updated";
+        updateRequest.TES = "TCREATE1-Updated";
         updateRequest.labelTest = "Updated Performance Test";
         updateRequest.descTest = "Updated description for performance test.";
 
@@ -152,14 +189,14 @@ public class TestEndpointTest extends KeycloakTest {
                 .oauth2(getAccessToken("admin"))
                 .body(updateRequest)
                 .contentType(ContentType.JSON)
-                .put("/{id}", createdTest.id)
+                .put("/{id}", createdTest.testResponse.id)
                 .then()
                 .assertThat()
                 .statusCode(200)
                 .extract()
                 .as(TestResponseDto.class);
 
-        assertEquals("T12-Updated", updatedResponse.TES);
+        assertEquals("TCREATE1-Updated", updatedResponse.TES);
         assertEquals("Updated Performance Test", updatedResponse.labelTest);
         assertEquals("Updated description for performance test.", updatedResponse.descTest);
     }
@@ -169,10 +206,23 @@ public class TestEndpointTest extends KeycloakTest {
 
         register("admin");
 
-        var createRequest = new TestRequestDto();
-        createRequest.TES = "T12";
-        createRequest.labelTest = "Performance Test";
-        createRequest.descTest = "This Test measures performance.";
+        var createRequest = new TestAndTestDefinitionRequest();
+
+        var testRequest = new TestRequestDto();
+        testRequest.TES = "TDELETE";
+        testRequest.labelTest =  "Performance Test";
+        testRequest.descTest = "This Test measures performance.";
+
+        var testDefinitionRequest = new TestDefinitionRequestDto();
+        testDefinitionRequest.testMethodId = "pid_graph:B733A7D5";
+        testDefinitionRequest.labelTestDefinition = "Performance Test Definition";
+        testDefinitionRequest.paramType = "onscreen";
+        testDefinitionRequest.testParams = "userAuth|evidence";
+        testDefinitionRequest.testQuestion = "\"Does access to Sensitive PID Kernel Metadata require user authentication?\"|\"Provide evidence of this provision via a link to a specification, user guide, or API definition.\"";
+        testDefinitionRequest.toolTip =  "\"Users need to be authenticated and requisite permissions must apply for access to sensitive metadata\"|\"A document, web page, or publication describing provisions\"";
+
+        createRequest.setTestRequest(testRequest);
+        createRequest.setTestDefinitionRequest(testDefinitionRequest);
 
         var createdTest = given()
                 .auth()
@@ -184,13 +234,13 @@ public class TestEndpointTest extends KeycloakTest {
                 .assertThat()
                 .statusCode(201)
                 .extract()
-                .as(TestResponseDto.class);
+                .as(TestAndTestDefinitionResponse.class);
 
         given()
                 .auth()
                 .oauth2(getAccessToken("admin"))
                 .contentType(ContentType.JSON)
-                .delete("/{id}", createdTest.id)
+                .delete("/{id}", createdTest.testResponse.id)
                 .then()
                 .assertThat()
                 .statusCode(200);
@@ -199,7 +249,7 @@ public class TestEndpointTest extends KeycloakTest {
                 .auth()
                 .oauth2(getAccessToken("admin"))
                 .contentType(ContentType.JSON)
-                .get("/{id}", createdTest.id)
+                .get("/{id}", createdTest.testResponse.id)
                 .then()
                 .assertThat()
                 .statusCode(404);

--- a/data-transfer-object/src/main/java/org/grnet/cat/dtos/registry/test/TestAndTestDefinitionRequest.java
+++ b/data-transfer-object/src/main/java/org/grnet/cat/dtos/registry/test/TestAndTestDefinitionRequest.java
@@ -1,0 +1,32 @@
+package org.grnet.cat.dtos.registry.test;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.Setter;
+import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
+
+/**
+ * Request object for creating a Test and its Definition.
+ */
+@Setter
+@Getter
+@Schema(name = "TestAndTestDefinitionRequest", description = "Request object for creating a Test and its Definition.")
+public class TestAndTestDefinitionRequest {
+
+    @Schema(
+            type = SchemaType.OBJECT,
+            implementation = TestRequestDto.class,
+            description = "Details of the Test."
+    )
+    @JsonProperty("test")
+    private TestRequestDto testRequest;
+
+    @Schema(
+            type = SchemaType.OBJECT,
+            implementation = TestDefinitionRequestDto.class,
+            description = "Details of the Test Definition."
+    )
+    @JsonProperty("test_definition")
+    private TestDefinitionRequestDto testDefinitionRequest;
+}

--- a/data-transfer-object/src/main/java/org/grnet/cat/dtos/registry/test/TestAndTestDefinitionResponse.java
+++ b/data-transfer-object/src/main/java/org/grnet/cat/dtos/registry/test/TestAndTestDefinitionResponse.java
@@ -1,0 +1,24 @@
+package org.grnet.cat.dtos.registry.test;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
+
+public class TestAndTestDefinitionResponse {
+    @Schema(
+            type = SchemaType.OBJECT,
+            implementation = Object.class,
+            description = "The unique identifier of the test method"
+    )
+    @JsonProperty("test")
+    public TestResponseDto testResponse;
+    @Schema(
+            type = SchemaType.OBJECT,
+            implementation = Object.class,
+            description = "The unique identifier for the Test Definition"
+    )
+    @JsonProperty("test_definition")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public TestDefinitionResponseDto testDefinitionResponse;
+}

--- a/mapper/src/main/java/org/grnet/cat/mappers/registry/TestDefinitionMapper.java
+++ b/mapper/src/main/java/org/grnet/cat/mappers/registry/TestDefinitionMapper.java
@@ -16,25 +16,30 @@ public interface TestDefinitionMapper {
 
     TestDefinitionMapper INSTANCE = Mappers.getMapper(TestDefinitionMapper.class);
 
-    @IterableMapping(qualifiedByName="map")
+    @IterableMapping(qualifiedByName="mapTestDefinition")
     List<TestDefinitionResponseDto> testDefinitionToDtos(List<TestDefinition> entities);
 
-    @Named("map")
+    @Named("mapTestDefinition")
     @Mapping(target = "testMethodId", expression = "java(testDefinition.getTestMethod().getId())")
     @Mapping(target = "lodTESV", ignore = true)
     @Mapping(target = "testParams", expression = "java(TestParamsTransformer.transformTestParams(testDefinition.getTestParams()))")
     TestDefinitionResponseDto testDefinitionToDto(TestDefinition testDefinition);
 
     @Named("mapWithExpression")
-    @Mapping(target = "id", ignore = true)
-    @Mapping(target = "populatedBy", ignore = true)
+//    @Mapping(target = "id", ignore = true)
+//    @Mapping(target = "labelTestDefinition", ignore = true)
+//    @Mapping(target = "populatedBy", ignore = true)
     @Mapping(target = "lastTouch", expression = "java(Timestamp.from(Instant.now()))")
-    @Mapping(target = "testMethod", ignore = true)
-    @Mapping(target = "lodMTV", ignore = true)
-    @Mapping(target = "lodTES", ignore = true)
-    @Mapping(target = "lodDFV", ignore = true)
-    @Mapping(target = "upload", ignore = true)
-    @Mapping(target = "dataType", ignore = true)
+//    @Mapping(target = "testMethod", ignore = true)
+//    @Mapping(target = "lodMTV", ignore = true)
+//    @Mapping(target = "lodTES", ignore = true)
+//    @Mapping(target = "lodDFV", ignore = true)
+//    @Mapping(target = "upload", ignore = true)
+//    @Mapping(target = "dataType", ignore = true)
+//    @Mapping(target = "toolTip", ignore = true)
+//    @Mapping(target = "testQuestion", ignore = true)
+//    @Mapping(target = "testParams", ignore = true)
+//    @Mapping(target = "paramType", ignore = true)
     TestDefinition testDefinitionToEntity(TestDefinitionRequestDto request);
 
     @Mapping(target = "labelTestDefinition", expression = "java(StringUtils.isNotEmpty(request.labelTestDefinition) ? request.labelTestDefinition : testDefinition.getLabelTestDefinition())")

--- a/mapper/src/main/java/org/grnet/cat/mappers/registry/TestMapper.java
+++ b/mapper/src/main/java/org/grnet/cat/mappers/registry/TestMapper.java
@@ -1,10 +1,9 @@
 package org.grnet.cat.mappers.registry;
 
 import org.apache.commons.lang3.StringUtils;
-import org.grnet.cat.dtos.registry.test.TestRequestDto;
-import org.grnet.cat.dtos.registry.test.TestResponseDto;
-import org.grnet.cat.dtos.registry.test.TestUpdateDto;
+import org.grnet.cat.dtos.registry.test.*;
 import org.grnet.cat.entities.registry.Test;
+import org.grnet.cat.entities.registry.TestDefinition;
 import org.mapstruct.*;
 import org.mapstruct.factory.Mappers;
 
@@ -12,25 +11,18 @@ import java.sql.Timestamp;
 import java.time.Instant;
 import java.util.List;
 
-@Mapper(imports = {StringUtils.class, Timestamp.class, Instant.class})
+@Mapper(imports = {StringUtils.class, Timestamp.class, Instant.class}, uses = {TestDefinitionMapper.class})
 public interface TestMapper {
 
     TestMapper INSTANCE = Mappers.getMapper(TestMapper.class);
 
-    @IterableMapping(qualifiedByName="map")
+    @IterableMapping(qualifiedByName="mapTest")
     List<TestResponseDto> testToDtos(List<Test> entities);
 
-    @Named("map")
+    @Named("mapTest")
     TestResponseDto testToDto(Test test);
 
-    @Named("mapWithExpression")
-    @Mapping(target = "id", ignore = true)
-    @Mapping(target = "populatedBy", ignore = true)
     @Mapping(target = "lastTouch", expression = "java(Timestamp.from(Instant.now()))")
-    @Mapping(target = "lodMTV", ignore = true)
-    @Mapping(target = "lodTES_V", ignore = true)
-    @Mapping(target = "upload", ignore = true)
-    @Mapping(target = "dataType", ignore = true)
     Test testToEntity(TestRequestDto request);
 
     @Mapping(target = "TES", expression = "java(StringUtils.isNotEmpty(request.TES) ? request.TES : test.getTES())")
@@ -44,5 +36,11 @@ public interface TestMapper {
     @Mapping(target = "upload", ignore = true)
     @Mapping(target = "dataType", ignore = true)
     void updateTestFromDto(TestUpdateDto request, @MappingTarget Test test);
+
+    @Named("mapTestAndTestDefinition")
+    @Mapping(source = "test", target = "testResponse", qualifiedByName = "mapTest")
+    @Mapping(source = "testDefinition", target = "testDefinitionResponse", qualifiedByName = "mapTestDefinition")
+    TestAndTestDefinitionResponse testAndTestDefinitionToDto(Test test, TestDefinition testDefinition);
+
 
 }

--- a/repository/src/main/java/org/grnet/cat/repositories/registry/TestDefinitionRepository.java
+++ b/repository/src/main/java/org/grnet/cat/repositories/registry/TestDefinitionRepository.java
@@ -1,5 +1,6 @@
 package org.grnet.cat.repositories.registry;
 
+import io.quarkus.panache.common.Parameters;
 import io.quarkus.panache.common.Sort;
 import jakarta.enterprise.context.ApplicationScoped;
 import org.grnet.cat.entities.Page;
@@ -8,6 +9,8 @@ import org.grnet.cat.entities.PageQueryImpl;
 import org.grnet.cat.entities.registry.MetricTestJunction;
 import org.grnet.cat.entities.registry.TestDefinition;
 import org.grnet.cat.repositories.Repository;
+
+import java.util.List;
 
 import java.util.Optional;
 
@@ -39,5 +42,22 @@ public class TestDefinitionRepository implements Repository<TestDefinition, Stri
             return find("FROM TestDefinition t WHERE t.lodTES = ?1",testId)
                     .firstResultOptional();
         }
+
+
+    public TestDefinition fetchTestDefinitionByTestId(String testId){
+
+        return find("from TestDefinition td where td.lodTES = ?1", testId).firstResult();
     }
+
+    /**
+     * Fetches all TestDefinition entities associated with the provided Test IDs.
+     *
+     * @param testIds The list of Test IDs.
+     * @return A list of TestDefinition entities.
+     */
+    public List<TestDefinition> fetchTestDefinitionsByTestIds(List<String> testIds){
+        return list("from TestDefinition td where td.lodTES in :testIds", Parameters.with("testIds", testIds));
+    }
+}
+
 

--- a/repository/src/main/java/org/grnet/cat/repositories/registry/TestRepository.java
+++ b/repository/src/main/java/org/grnet/cat/repositories/registry/TestRepository.java
@@ -8,6 +8,8 @@ import org.grnet.cat.entities.PageQueryImpl;
 import org.grnet.cat.entities.registry.Test;
 import org.grnet.cat.repositories.Repository;
 
+import static io.quarkus.hibernate.orm.panache.Panache.getEntityManager;
+
 @ApplicationScoped
 public class TestRepository implements Repository<Test, String> {
 
@@ -30,5 +32,13 @@ public class TestRepository implements Repository<Test, String> {
         pageable.page = Page.of(page, size);
 
         return pageable;
+    }
+
+    public boolean notUnique(String fieldName, String value) {
+        String query = "select count(c) from Test c where lower(c." + fieldName + ") = lower(?1)";
+        long count = getEntityManager().createQuery(query, Long.class)
+                .setParameter(1, value)
+                .getSingleResult();
+        return count > 0;
     }
 }

--- a/service/src/main/java/org/grnet/cat/services/registry/TestDefinitionService.java
+++ b/service/src/main/java/org/grnet/cat/services/registry/TestDefinitionService.java
@@ -8,9 +8,8 @@ import jakarta.ws.rs.ForbiddenException;
 import jakarta.ws.rs.NotFoundException;
 import jakarta.ws.rs.core.UriInfo;
 import org.grnet.cat.dtos.pagination.PageResource;
-import org.grnet.cat.dtos.registry.test.TestDefinitionRequestDto;
-import org.grnet.cat.dtos.registry.test.TestDefinitionResponseDto;
-import org.grnet.cat.dtos.registry.test.TestDefinitionUpdateDto;
+import org.grnet.cat.dtos.registry.test.*;
+import org.grnet.cat.entities.registry.TestDefinition;
 import org.grnet.cat.entities.registry.TestMethod;
 import org.grnet.cat.mappers.registry.TestDefinitionMapper;
 import org.grnet.cat.repositories.registry.MetricTestRepository;
@@ -49,21 +48,42 @@ public class TestDefinitionService {
     /**
      * Creates a new TestDefinition item.
      *
-     * @param userId The user creating the TestDefinition.
-     * @param testDefinitionRequestDto The TestDefinition request data.
+     * @param userId The user creating the TestAndTestDefinitionRequest.
+     * @param request The TestAndTestDefinitionRequest request data.
      * @return The created TestDefinition DTO.
      */
     @Transactional
-    public TestDefinitionResponseDto createTestDefinition(String userId, TestDefinitionRequestDto testDefinitionRequestDto) {
+    public TestDefinitionResponseDto createTestDefinition(String userId, TestDefinitionRequestDto request) {
 
-        var testDefinition = TestDefinitionMapper.INSTANCE.testDefinitionToEntity(testDefinitionRequestDto);
+        var testDefinition = TestDefinitionMapper.INSTANCE.testDefinitionToEntity(request);
 
         testDefinition.setPopulatedBy(userId);
-        testDefinition.setTestMethod(Panache.getEntityManager().getReference(TestMethod.class, testDefinitionRequestDto.testMethodId));
+        testDefinition.setTestMethod(Panache.getEntityManager().getReference(TestMethod.class, request.testMethodId));
 
         testDefinitionRepository.persist(testDefinition);
 
-        return TestDefinitionMapper.INSTANCE.testDefinitionToDto(testDefinition);
+        return TestDefinitionMapper.INSTANCE.testDefinitionToDto(testDefinition);    }
+
+
+    /**
+     * Creates a new TestDefinition item.
+     *
+     * @param userId The user creating the TestAndTestDefinitionRequest.
+     * @param request The TestAndTestDefinitionRequest request data.
+     * @return The created TestDefinition DTO.
+     */
+    @Transactional
+    public TestDefinition createTestDefinition(String userId, TestDefinitionRequestDto request, String lodTest) {
+
+        var testDefinition = TestDefinitionMapper.INSTANCE.testDefinitionToEntity(request);
+
+        testDefinition.setPopulatedBy(userId);
+        testDefinition.setLodTES(lodTest);
+        testDefinition.setTestMethod(Panache.getEntityManager().getReference(TestMethod.class, request.testMethodId));
+
+        testDefinitionRepository.persist(testDefinition);
+
+        return testDefinition;
     }
 
     /**


### PR DESCRIPTION
### POST /tests (request)

```
{
  "test": {
    "tes": "adsasdasdasd",
    "label": "PID Persistence - Service - Evidence",
    "description": "Evidence is provided by the service that PIDs cannot be deleted."
  },
  "test_definition": {
    "test_method_id": "pid_graph:B733A7D5",
    "label": "Manual confirmation of user authentication required for access to sensitive metadata.",
    "param_type": "onscreen",
    "test_params": "userAuth\"|\"evidence",
    "test_question": "\"Does access to Sensitive PID Kernel Metadata require user authentication?\"|\"Provide evidence of this provision via a link to a specification, user guide, or API definition.\"",
    "tool_tip": "\"Users need to be authenticated and requisite permissions must apply for access to sensitive metadata\"|\"A document, web page, or publication describing provisions\""
  }
}
```

### POST /tests (responce)
```
{
  "test": {
    "id": "pid_graph:87764CCF",
    "tes": "adsasdasdasd",
    "label": "PID Persistence - Service - Evidence",
    "description": "Evidence is provided by the service that PIDs cannot be deleted.",
    "motivation_id": null,
    "populated_by": "admin_voperson_id",
    "last_touch": "2024-12-20T11:59:18.430+00:00",
    "version": null
  },
  "test_definition": {
    "id": "pid_graph:A9539D0A",
    "test_method_id": "pid_graph:B733A7D5",
    "label": "Manual confirmation of user authentication required for access to sensitive metadata.",
    "param_type": "onscreen",
    "test_params": "user_authentication|evidence",
    "test_question": "\"Does access to Sensitive PID Kernel Metadata require user authentication?\"|\"Provide evidence of this provision via a link to a specification, user guide, or API definition.\"",
    "tool_tip": "\"Users need to be authenticated and requisite permissions must apply for access to sensitive metadata\"|\"A document, web page, or publication describing provisions\"",
    "motivation_id": null,
    "test_id": "pid_graph:87764CCF",
    "populated_by": "admin_voperson_id",
    "last_touch": "2024-12-20T11:59:18.432+00:00",
    "version": null
  }
}
```

### GET /tests/{id} (response)
```
{
  "test": {
    "id": "pid_graph:87764CCF",
    "tes": "adsasdasdasd",
    "label": "PID Persistence - Service - Evidence",
    "description": "Evidence is provided by the service that PIDs cannot be deleted.",
    "motivation_id": null,
    "populated_by": "admin_voperson_id",
    "last_touch": "2024-12-20T11:59:18.430+00:00",
    "version": null
  },
  "test_definition": {
    "id": "pid_graph:A9539D0A",
    "test_method_id": "pid_graph:B733A7D5",
    "label": "Manual confirmation of user authentication required for access to sensitive metadata.",
    "param_type": "onscreen",
    "test_params": "user_authentication|evidence",
    "test_question": "\"Does access to Sensitive PID Kernel Metadata require user authentication?\"|\"Provide evidence of this provision via a link to a specification, user guide, or API definition.\"",
    "tool_tip": "\"Users need to be authenticated and requisite permissions must apply for access to sensitive metadata\"|\"A document, web page, or publication describing provisions\"",
    "motivation_id": null,
    "test_id": "pid_graph:87764CCF",
    "populated_by": "admin_voperson_id",
    "last_touch": "2024-12-20T11:59:18.432+00:00",
    "version": null
  }
}

```