### PR TITLE
CAT-726 CAT-725 CAT-724 Quote typos in MD1 related tests - Auto MD1 related tests inform about wrong parameters-Auto MD1 related test return 500 when metadata not valid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,7 +88,7 @@ According to [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) , the `Unr
 - [#412](https://github.com/FC4E-CAT/fc4e-cat-api/pull/412) CAT-706 Give the ability to update tests with the same info as CREATE.
 - [#413](https://github.com/FC4E-CAT/fc4e-cat-api/pull/413) CAT-618 Change metadata xml validation automated checks 
 - [#416](https://github.com/FC4E-CAT/fc4e-cat-api/pull/416) Update /registry/metric Endpoints to Include All metric and metric-definition Fields
-
+- [#419](https://github.com/FC4E-CAT/fc4e-cat-api/pull/419) CAT-726 CAT-725 CAT-724 Quote typos in MD1 related tests - Auto MD1 related tests inform about wrong parameters-Auto MD1 related test return 500 when metadata not valid.
 
 ### Removed
 

--- a/api/src/main/java/org/grnet/cat/api/endpoints/AutomatedCheckEndpoint.java
+++ b/api/src/main/java/org/grnet/cat/api/endpoints/AutomatedCheckEndpoint.java
@@ -126,7 +126,7 @@ public class AutomatedCheckEndpoint {
             @Valid @NotNull(message = "The request body is empty.") ArccValidationRequest request) {
 
         if (type != null && !ArccTestType.getTypes().contains(type)) {
-            throw new BadRequestException("The value " + type + " is not a valid test type. Valid type values are: " + Arrays.toString(ArccTestType.values()));
+            throw new BadRequestException("The value " + type + " is not a valid test type. Valid type values are: " + ArccTestType.getTypes().toString());
         }
         var response = arccValidationService.validateMetadataByTestType(type,request);
 

--- a/entity/src/main/resources/db/migration/tables/registry/V1.149__update_Arcc_Tests.sql
+++ b/entity/src/main/resources/db/migration/tables/registry/V1.149__update_Arcc_Tests.sql
@@ -1,0 +1,8 @@
+UPDATE p_Test_Definition set testParams='xmlUrlValidation',testQuestion='Url of metadata xml  to check if it validates with MD-1a schema requirements',
+ toolTip='Please provide a valid metadata xml url to be compared with the schema' where lodTDF='pid_graph:C4CF813A';
+
+UPDATE p_Test_Definition set testParams='xmlUrlValidation',testQuestion='Url of metadata xml  to check if it validates with MD-1b1 schema requirements',
+ toolTip='Please provide a valid metadata xml url to be compared with the schema' where lodTDF='pid_graph:23GF813A';
+
+UPDATE p_Test_Definition set testParams='xmlUrlValidation',testQuestion='Url of metadata xml  to check if it validates with MD-1b2 schema requirements',
+ toolTip='Please provide a valid metadata xml url to be compared with the schema' where lodTDF='pid_graph:23GF848A';

--- a/enum/src/main/java/org/grnet/cat/enums/ArccTestType.java
+++ b/enum/src/main/java/org/grnet/cat/enums/ArccTestType.java
@@ -8,19 +8,21 @@ public enum ArccTestType {
     MD1a("MD-1a"),
     MD1b1("MD-1b1"),
     MD1b2("MD-1b2");
-  //  MD1c("MD-1c");
+    // MD1c("MD-1c");
+
     private String type;
 
     ArccTestType(String type) {
         this.type = type;
     }
+
     public String getType() {
         return type;
     }
+
     public static List<String> getTypes() {
         return Arrays.stream(ArccTestType.values())
                 .map(ArccTestType::getType)
                 .collect(Collectors.toList());
     }
-
 }


### PR DESCRIPTION
Minor fixes in issues spotted on automated checks