### PR TITLE
CAT-741 Motivation preview displays wrong json when add/remove elements in motivation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,6 +94,7 @@ According to [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) , the `Unr
 - [#419](https://github.com/FC4E-CAT/fc4e-cat-api/pull/419) CAT-726 CAT-725 CAT-724 Quote typos in MD1 related tests - Auto MD1 related tests inform about wrong parameters-Auto MD1 related test return 500 when metadata not valid.
 - [#417](https://github.com/FC4E-CAT/fc4e-cat-api/pull/417) CAT-728 Extend Search Functionality for Principles and Criteria
 - [#424](https://github.com/FC4E-CAT/fc4e-cat-api/pull/424) CAT-734 Change assessment_doc to include published.
+- [#428](https://github.com/FC4E-CAT/fc4e-cat-api/pull/428) CAT-741 Motivation preview displays wrong json when add/remove elements in motivation
 
 
 

--- a/entity/src/main/java/org/grnet/cat/entities/registry/RegistryTemplate.java
+++ b/entity/src/main/java/org/grnet/cat/entities/registry/RegistryTemplate.java
@@ -54,4 +54,8 @@ public class RegistryTemplate {
     private String testParams;
 
     private String toolTip;
+    private String md_mtv;
+
+    private String mt_mtv;
+    private String cm_mtv;
 }

--- a/entity/src/main/resources/db/migration/tables/registry/V1.52__update_registry_template.sql
+++ b/entity/src/main/resources/db/migration/tables/registry/V1.52__update_registry_template.sql
@@ -1,0 +1,51 @@
+-- ------------------------------------------------
+-- Version: v1.44
+--
+-- Description: Migration that creates a View for registry templates
+-- -------------------------------------------------
+
+CREATE OR REPLACE VIEW registry_templates AS
+SELECT
+        p.PRI,
+        p.labelPrinciple,
+        p.descPrinciple,
+        c.CRI,
+        c.labelCriterion,
+        c.descCriterion,
+        m.lodMTR,
+        m.MTR,
+        m.labelMetric,
+        ta.labelAlgorithmType,
+        ttm.labelTypeMetric,
+        t.TES,
+        t.labelTest,
+        t.descTest,
+        md.valueBenchmark,
+        pc.motivation_lodMTV as principle_criterion_motivation_id,
+        tb.labelBenchmarkType,
+        ca.actor_lodActor AS lodActor,
+        i.labelImperative,
+        tm.labelTestMethod,
+        td.testQuestion,
+        td.testParams,
+        td.toolTip,
+        md.motivation_lodMTV as md_mtv,
+        mt.motivation_lodMTV as mt_mtv,
+        cm.motivation_lodMTV as cm_mtv
+
+    FROM
+        t_Type_Benchmark tb
+        INNER JOIN p_Metric_Definition md ON tb.lodTBN = md.type_benchmark_lodTBN
+        INNER JOIN p_Metric m ON md.metric_lodMTR = m.lodMTR
+        INNER JOIN p_Metric_Test mt ON m.lodMTR = mt.metric_lodMTR
+        INNER JOIN t_Type_Algorithm ta ON m.lodTAL = ta.lodTAL
+        INNER JOIN t_Type_Metric ttm ON m.lodTMT = ttm.lodTMT
+        INNER JOIN p_Test_Definition td ON mt.test_definition_lodTDF = td.lodTDF
+        INNER JOIN t_TestMethod tm ON td.lodTME = tm.lodTME
+        INNER JOIN p_Test t ON mt.test_lodTES = t.lodTES
+        INNER JOIN p_Criterion_Metric cm ON m.lodMTR = cm.metric_lodMTR
+        INNER JOIN p_Criterion c ON cm.criterion_lodCRI = c.lodCRI
+        INNER JOIN p_Criterion_Actor ca ON c.lodCRI = ca.criterion_lodCRI
+        INNER JOIN s_Imperative i ON ca.imperative_lodIMP = i.lodIMP
+        INNER JOIN p_Principle_Criterion pc ON c.lodCRI = pc.criterion_lodCRI
+        INNER JOIN p_Principle p ON pc.principle_lodPRI = p.lodPRI;

--- a/repository/src/main/java/org/grnet/cat/repositories/registry/RegistryTemplateRepository.java
+++ b/repository/src/main/java/org/grnet/cat/repositories/registry/RegistryTemplateRepository.java
@@ -11,6 +11,7 @@ import java.util.stream.Collectors;
 public class RegistryTemplateRepository implements Repository<RegistryTemplate, String> {
 
     public Set<RegistryTemplate> findByActorAndMotivation(String actorId, String motivationId) {
-        return find("id.lodActor = ?1 and id.principleCriterionMotivationId = ?2 ", actorId, motivationId).stream().collect(Collectors.toSet());
+        return find("id.lodActor = ?1 and mt_mtv = ?2 and md_mtv = ?3 and cm_mtv = ?4 and id.principleCriterionMotivationId = ?5 ", actorId,motivationId, motivationId, motivationId,motivationId).stream().collect(Collectors.toSet());
+
     }
 }


### PR DESCRIPTION
Seemed that the registry_template view needed to add motivation id for metrics, metric tests and criterion metrics relations to be retrieved the entities only for the one motivation