### PR TITLE
CAT-745 C7 criterion fails due to wrong benchmark value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -98,6 +98,7 @@ According to [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) , the `Unr
 - [#426](https://github.com/FC4E-CAT/fc4e-cat-api/pull/426) CAT-554 API: Motivation Clone Missing MotivationActors in Cloned Item
 - [#428](https://github.com/FC4E-CAT/fc4e-cat-api/pull/428) CAT-741 Motivation preview displays wrong json when add/remove elements in motivation
 - [#429](https://github.com/FC4E-CAT/fc4e-cat-api/pull/429) CAT-744 Issue when actor- criteria vary betwen 2 motivations which are parent-child(cloned)
+- [#431](https://github.com/FC4E-CAT/fc4e-cat-api/pull/431) CAT-745 C7 criterion fails due to wrong benchmark value
 
 
 

--- a/entity/src/main/resources/db/migration/tables/registry/V1.55__update_metric_benchmark.sql
+++ b/entity/src/main/resources/db/migration/tables/registry/V1.55__update_metric_benchmark.sql
@@ -1,0 +1,2 @@
+UPDATE p_Metric_Definition SET valueBenchmark = 1 WHERE lodMDF ='pid_graph:D61CE942';
+UPDATE p_Metric_Definition SET valueBenchmark = 1 WHERE lodMDF ='pid_graph:D61CE97';


### PR DESCRIPTION
change db p_Metric_Definition for C7 criterion -metric , to have value benchmark=1