### PR TITLE
CAT-783  CAT-791 API- GET Public Assessment 400 error/Assessment's id inside assessment_doc is null

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,6 +103,7 @@ According to [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) , the `Unr
 - [#429](https://github.com/FC4E-CAT/fc4e-cat-api/pull/429) CAT-744 Issue when actor- criteria vary betwen 2 motivations which are parent-child(cloned)
 - [#431](https://github.com/FC4E-CAT/fc4e-cat-api/pull/431) CAT-745 C7 criterion fails due to wrong benchmark value
 - [#439](https://github.com/FC4E-CAT/fc4e-cat-api/pull/439) CAT-749 API call: admin publish assessment gets 403 when admin
+- [#441](https://github.com/FC4E-CAT/fc4e-cat-api/pull/441) CAT-783 CAT-791 API- GET Public Assessment 400 error/Assessment's id inside assessment_doc is null 
 
 
 ### Removed

--- a/api/src/test/java/org/grnet/cat/api/AssessmentsEndpointTest.java
+++ b/api/src/test/java/org/grnet/cat/api/AssessmentsEndpointTest.java
@@ -31,11 +31,24 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 public class AssessmentsEndpointTest extends KeycloakTest {
 
     private static UserJsonRegistryAssessmentResponse assessment;
+    private static UserJsonRegistryAssessmentResponse publicAssessment;
 
     @BeforeAll
     public void initMakeValidation()  throws IOException{
         makeValidation("validated", "pid_graph:B5CC396B");
         assessment = createRegistryAssessment(validatedToken);
+        publicAssessment = createRegistryAssessment(validatedToken);
+        var response = given()
+                .auth()
+                .oauth2(validatedToken)
+                .basePath("/v2/assessments/")
+                .put("/{id}/publish", publicAssessment.id)
+                .then()
+                .assertThat()
+                .statusCode(200)
+                .extract()
+                .as(InformativeResponse.class);
+
     }
 
     @Test
@@ -753,5 +766,21 @@ public class AssessmentsEndpointTest extends KeycloakTest {
         assertEquals("You do not have permission to access this resource.", error.message);
 
     }
+    @Test
+    public void getPublicAssessment() throws IOException {
+
+
+
+        var assessment = given()
+                .basePath("/v2/assessments")
+                .get("/public/{id}", publicAssessment.id)
+                .then()
+                .assertThat()
+                .statusCode(200)
+                .extract()
+                .as(UserJsonRegistryAssessmentResponse.class);
+        assertEquals(assessment.id,publicAssessment.id);
+    }
+
 
 }

--- a/mapper/src/main/java/org/grnet/cat/mappers/AssessmentMapper.java
+++ b/mapper/src/main/java/org/grnet/cat/mappers/AssessmentMapper.java
@@ -136,4 +136,18 @@ public interface AssessmentMapper {
 
         return !currentUser.equals(userId);
     }
+
+    @Named("publicMapWithRegistryExpression")
+    @Mapping(target = "assessmentDoc", expression = "java(registryStringJsonToDto(assessment.getAssessmentDoc()))")
+    @Mapping(target = "validationId", expression = "java(assessment.getValidation().getId())")
+    @Mapping(target = "createdOn", expression = "java(assessment.getCreatedOn().toString())")
+    @Mapping(target = "userId", expression = "java(assessment.getValidation().getUser().getId())")
+    @Mapping(target = "updatedOn", expression = "java(assessment.getUpdatedOn() != null ? assessment.getUpdatedOn().toString() : \"\")")
+    @Mapping(target = "updatedBy", expression = "java(assessment.getUpdatedBy() != null ? assessment.getUpdatedBy() : \"\")")
+    @Mapping(target = "sharedToUser", ignore = true)
+    @Mapping(target = "sharedByUser", ignore = true)
+    @Mapping(target = "published", source = "assessment.published")
+
+    UserJsonRegistryAssessmentResponse publicUserRegistryAssessmentToJsonAssessment(MotivationAssessment assessment);
+
 }


### PR DESCRIPTION
1) When get public assessment without loggin to CAT , the user does not have a voperson_id. as the assessment to be returned contained sharedByUser, sharedToUser a check to the voperson_id was done and this returned null. we fixed this and  also added a test , that we were missing
2) At some point for some reason, we missed filling the assessment's id inside the assessment_doc. fixed this