### PR TITLE
CAT-788: Wrong sort values for /registry/metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -105,6 +105,7 @@ According to [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) , the `Unr
 - [#439](https://github.com/FC4E-CAT/fc4e-cat-api/pull/439) CAT-749 API call: admin publish assessment gets 403 when admin
 - [#443](https://github.com/FC4E-CAT/fc4e-cat-api/pull/443) CAT-792: Retrieve Associated Motivations for Metrics
 - [#441](https://github.com/FC4E-CAT/fc4e-cat-api/pull/441) CAT-783 CAT-791 API- GET Public Assessment 400 error/Assessment's id inside assessment_doc is null 
+- [#442](https://github.com/FC4E-CAT/fc4e-cat-api/pull/442) CAT-788: Wrong sort values for /registry/metrics
 
 
 ### Removed

--- a/api/src/main/java/org/grnet/cat/api/endpoints/registry/MetricEndpoint.java
+++ b/api/src/main/java/org/grnet/cat/api/endpoints/registry/MetricEndpoint.java
@@ -324,7 +324,7 @@ public class MetricEndpoint {
                     schema = @Schema(type = SchemaType.STRING, defaultValue = "lastTouch"),
                     examples = {
                             @ExampleObject(name = "Last Touch", value = "lastTouch"),
-                            @ExampleObject(name = "Metric", value = "metric"),
+                            @ExampleObject(name = "MTR", value = "metric.MTR"),
                             @ExampleObject(name = "Benchmark Value", value = "valueBenchmark")},
                     description = "The \"sort\" parameter allows clients to specify the field by which they want the results to be sorted.")
             @DefaultValue("lastTouch")
@@ -351,7 +351,7 @@ public class MetricEndpoint {
             @Context UriInfo uriInfo) {
 
         var orderValues = List.of("ASC", "DESC");
-        var sortValues = List.of("lastTouch", "metric", "valueBenchmark");
+        var sortValues = List.of("lastTouch", "metric.MTR", "valueBenchmark");
 
         SortAndOrderValidator.validateSortAndOrder(sort, order, sortValues, orderValues);
 

--- a/repository/src/main/java/org/grnet/cat/repositories/registry/MetricDefinitionRepository.java
+++ b/repository/src/main/java/org/grnet/cat/repositories/registry/MetricDefinitionRepository.java
@@ -27,26 +27,27 @@ public class MetricDefinitionRepository implements Repository<MetricDefinitionJu
         joiner.add("from MetricDefinitionJunction m")
                 .add("left join fetch m.metric met")
                 .add("left join fetch m.typeBenchmark tb");
-
         joiner.add("where 1=1");
 
         var map = new HashMap<String, Object>();
 
         if (StringUtils.isNotEmpty(search)) {
-            joiner.add("and (m.metric.id like :search")
-                    .add("or m.typeBenchmark.id like :search")
-                    .add("or m.motivation.Id like :search")
-                    .add("or m.metricDefinition like :search")
-                    .add("or m.lodReference like :search")
-                    .add("or m.valueBenchmark like :search")
-                    .add("or m.motivationX like :search)");
+            joiner.add("and (m.metric.id ilike :search")
+                    .add("or m.metric.MTR ilike :search")
+                    .add("or m.typeBenchmark.id ilike :search")
+                    .add("or m.typeBenchmark.label ilike :search")
+                    .add("or m.motivation.id ilike :search")
+                    .add("or m.metricDefinition ilike :search")
+                    .add("or m.lodReference ilike :search")
+                    .add("or m.valueBenchmark ilike :search")
+                    .add("or m.motivationX ilike :search)");
 
             map.put("search", "%" + search + "%");
         }
 
         joiner.add("order by");
         joiner.add("m."+ sort);
-        joiner.add(order + ", m.id ASC");
+        joiner.add(order + ", m.metric.id ASC");
 
         var panache = find(joiner.toString(), map).page(page, size);
 
@@ -74,23 +75,11 @@ public class MetricDefinitionRepository implements Repository<MetricDefinitionJu
         return pageable;
     }
 
-//    public PageQuery<MetricDefinitionJunction> fetchMetricDefinitionByPage(int page, int size){
-//
-//        var panache = find("from MetricDefinitionJunction", Sort.by("lastTouch", Sort.Direction.Descending).and("id", Sort.Direction.Ascending)).page(page, size);
-//
-//        var pageable = new PageQueryImpl<MetricDefinitionJunction>();
-//        pageable.list = panache.list();
-//        pageable.index = page;
-//        pageable.size = size;
-//        pageable.count = panache.count();
-//        pageable.page = Page.of(page, size);
-//
-//        return pageable;
-//    }
-
-
-
-    public PageQuery<MetricDefinitionJunction> fetchMetricDefinitionByPage(String search, String sort, String order, int page, int size){
+    /**
+     * Retrieves a page of Metric And it's definition.
+     * @return A page of MetricDefinitionJunction objects representing the Metric and it's definitions.
+     */
+    public PageQuery<MetricDefinitionJunction> fetchMetricAndDefinitionByPage(String search, String sort, String order, int page, int size){
 
         var joiner = new StringJoiner(StringUtils.SPACE);
 
@@ -103,20 +92,20 @@ public class MetricDefinitionRepository implements Repository<MetricDefinitionJu
         var map = new HashMap<String, Object>();
 
         if (StringUtils.isNotEmpty(search)) {
-            joiner.add("and (m.metric.id like :search")
-                    .add("or m.metric.MTR like :search")
-                    .add("or m.typeBenchmark.id like :search")
-                    .add("or m.typeBenchmark.labelBenchmarkType like :search")
-                    .add("or m.motivation.Id like :search")
-                    .add("or m.valueBenchmark like :search")
-                    .add("or m.motivationX like :search)");
+            joiner.add("and (m.metric.id ilike :search")
+                    .add("or m.metric.MTR ilike :search")
+                    .add("or m.typeBenchmark.id ilike :search")
+                    .add("or m.typeBenchmark.labelBenchmarkType ilike :search")
+                    .add("or m.motivation.id ilike :search")
+                    .add("or m.valueBenchmark ilike :search")
+                    .add("or m.motivationX ilike :search)");
 
             map.put("search", "%" + search + "%");
         }
 
         joiner.add("order by");
         joiner.add("m."+ sort);
-        joiner.add(order + ", m.id ASC");
+        joiner.add(order + ", m.metric.id ASC");
 
         var panache = find(joiner.toString(), map).page(page, size);
         var pageable = new PageQueryImpl<MetricDefinitionJunction>();

--- a/service/src/main/java/org/grnet/cat/services/registry/metric/MetricService.java
+++ b/service/src/main/java/org/grnet/cat/services/registry/metric/MetricService.java
@@ -54,20 +54,6 @@ public class MetricService {
 
     private static final Logger LOG = Logger.getLogger(MetricService.class);
 
-//    /**
-//     * Retrieves a specific Metric item by its ID.
-//     *
-//     * @param id The unique ID of the Metric item.
-//     * @return The corresponding Metric DTO.
-//     */
-//    public MetricResponseDto getMetricById(String id) {
-//
-//        var metric = metricRepository.findById(id);
-//
-//        return MetricMapper.INSTANCE.metricToDto(metric);
-//    }
-
-
     /**
      * Retrieves a specific Metric item by its ID.
      *
@@ -193,7 +179,7 @@ public class MetricService {
      */
     public PageResource<MetricDefinitionExtendedResponse> getMetricListAll(String search, String sort, String order, int page, int size, UriInfo uriInfo) {
 
-        var metricDefinitionPage = metricDefinitionRepository.fetchMetricDefinitionByPage(search,sort, order, page, size);
+        var metricDefinitionPage = metricDefinitionRepository.fetchMetricAndDefinitionByPage(search,sort, order, page, size);
 
         var metricDefinitionDtos = MetricMapper.INSTANCE
                 .metricAndDefinitionToDtos(metricDefinitionPage.list());


### PR DESCRIPTION
Updated sorting options to lastTouch, **metric.MTR**, and valueBenchmark (need to check with UI before merging).