### PR TITLE
CAT-792: Retrieve Associated Motivations for Metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,6 +103,7 @@ According to [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) , the `Unr
 - [#429](https://github.com/FC4E-CAT/fc4e-cat-api/pull/429) CAT-744 Issue when actor- criteria vary betwen 2 motivations which are parent-child(cloned)
 - [#431](https://github.com/FC4E-CAT/fc4e-cat-api/pull/431) CAT-745 C7 criterion fails due to wrong benchmark value
 - [#439](https://github.com/FC4E-CAT/fc4e-cat-api/pull/439) CAT-749 API call: admin publish assessment gets 403 when admin
+- [#443](https://github.com/FC4E-CAT/fc4e-cat-api/pull/443) CAT-792: Retrieve Associated Motivations for Metrics
 - [#441](https://github.com/FC4E-CAT/fc4e-cat-api/pull/441) CAT-783 CAT-791 API- GET Public Assessment 400 error/Assessment's id inside assessment_doc is null 
 
 

--- a/data-transfer-object/src/main/java/org/grnet/cat/dtos/registry/MetricDefinitionExtendedResponse.java
+++ b/data-transfer-object/src/main/java/org/grnet/cat/dtos/registry/MetricDefinitionExtendedResponse.java
@@ -1,9 +1,14 @@
 package org.grnet.cat.dtos.registry;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.validation.constraints.NotEmpty;
+import lombok.Setter;
 import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
+import org.grnet.cat.dtos.registry.motivation.PartialMotivationResponse;
+
+import java.util.List;
 
 @Schema(name="MetricDefinitionExtendedResponse", description="This object represents a response for a Metric Definition.")
 public class MetricDefinitionExtendedResponse {
@@ -133,4 +138,14 @@ public class MetricDefinitionExtendedResponse {
     )
     @JsonProperty("value_benchmark")
     public String valueBenchmark;
+
+    @Setter
+    @Schema(
+            type = SchemaType.ARRAY,
+            implementation = PartialMotivationResponse.class,
+            description = "List of motivations related to this test."
+    )
+    @JsonProperty("used_by_motivations")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public List<PartialMotivationResponse> motivations;
 }

--- a/repository/src/main/java/org/grnet/cat/repositories/registry/MetricDefinitionRepository.java
+++ b/repository/src/main/java/org/grnet/cat/repositories/registry/MetricDefinitionRepository.java
@@ -8,6 +8,7 @@ import org.grnet.cat.entities.Page;
 import org.grnet.cat.entities.PageQuery;
 import org.grnet.cat.entities.PageQueryImpl;
 import org.grnet.cat.entities.registry.MetricDefinitionJunction;
+import org.grnet.cat.entities.registry.Motivation;
 import org.grnet.cat.entities.registry.metric.Metric;
 import org.grnet.cat.repositories.Repository;
 
@@ -128,8 +129,17 @@ public class MetricDefinitionRepository implements Repository<MetricDefinitionJu
         return pageable;
     }
 
+    @Transactional
+    public List<Motivation> getMotivationIdsByMetric(String metricId) {
 
+        var db = "SELECT DISTINCT m FROM Motivation m " +
+                "LEFT JOIN MetricDefinitionJunction md ON md.motivation.id = m.id " +
+                "WHERE md.metric.id = :metricId";
 
+        return getEntityManager().createQuery(db, Motivation.class)
+                .setParameter("metricId", metricId)
+                .getResultList();
+    }
 
 
     public MetricDefinitionJunction fetchMetricDefinitionByMotivationAndMetricId(String motivationId, String metricId) {


### PR DESCRIPTION
**Response:**
```{
  "metric_id": "pid_graph:0A42DC0E",
  "metric_mtr": "M11",
  "metric_label": "Versioning Procedure",
  "metric_description": "Evidence is available that a clear versioning procedure or policy exists and is available",
  "type_algorithm_id": "pid_graph:7A976659",
  "type_algorithm_label": "Test = Metric",
  "type_metric_id": "pid_graph:8D79984F",
  "type_metric_label": "Binary",
  "type_benchmark_id": "pid_graph:7085006F",
  "type_benchmark_label": "Binary-Binary",
  "type_benchmark_description": "The benchmark maps a binary metric value to binary assessment outcome (Pass/ Fail). The inverse can also be done.",
  "type_benchmark_patter": "M[0,1] → [Fail, Pass]",
  "motivation_id": "pid_graph:34A9189F",
  "value_benchmark": "1",
  "used_by_motivations": [
    {
      "id": "pid_graph:34A9189F",
      "mtv": "NL-PID",
      "label": "Netherlands National PID Policy"
    },
    {
      "id": "pid_graph:3E109BBA",
      "mtv": "EOSC-PID",
      "label": "EOSC PID Policy"
    }
  ]
}
```