### PR TITLE
CAT-800 Cannot change test that belongs to unpublished motivation - still says published

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -109,6 +109,8 @@ According to [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) , the `Unr
 - [#442](https://github.com/FC4E-CAT/fc4e-cat-api/pull/442) CAT-788: Wrong sort values for /registry/metrics
 - [#444](https://github.com/FC4E-CAT/fc4e-cat-api/pull/444/) CAT-792: Retrieve Associated Motivations for Metrics (fix)
 - [#450](https://github.com/FC4E-CAT/fc4e-cat-api/pull/450) CAT-806: Metrics view displays the same metric multiple times
+- [#445](https://github.com/FC4E-CAT/fc4e-cat-api/pull/445/) CAT-800 Cannot change test that belongs to unpublished motivation - still says published #446
+
 
 ### Removed
 

--- a/api/src/main/java/org/grnet/cat/api/endpoints/UsersEndpoint.java
+++ b/api/src/main/java/org/grnet/cat/api/endpoints/UsersEndpoint.java
@@ -237,6 +237,50 @@ public class UsersEndpoint {
         return Response.ok().entity(userProfile).build();
     }
 
+    @Tag(name = "User")
+    @Operation(
+            summary = "Get user registry eligibility for editing new assessments.",
+            description = "Returns a structured list of organizations, assessment types, and registry actors for which the user is eligible to create new assessments.")
+    @APIResponse(
+            responseCode = "200",
+            description = "Successful response.",
+            content = @Content(schema = @Schema(
+                    type = SchemaType.OBJECT,
+                    implementation = PageableRegistryAssessmentEligibility.class)))
+    @APIResponse(
+            responseCode = "401",
+            description = "User has not been authenticated.",
+            content = @Content(schema = @Schema(
+                    type = SchemaType.OBJECT,
+                    implementation = InformativeResponse.class)))
+    @APIResponse(
+            responseCode = "403",
+            description = "Not permitted.",
+            content = @Content(schema = @Schema(
+                    type = SchemaType.OBJECT,
+                    implementation = InformativeResponse.class)))
+    @APIResponse(
+            responseCode = "500",
+            description = "Internal Server Error.",
+            content = @Content(schema = @Schema(
+                    type = SchemaType.OBJECT,
+                    implementation = InformativeResponse.class)))
+    @SecurityRequirement(name = "Authentication")
+    @Path("/registry-assessment-eligibility-all")
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    @Registration
+    public Response userRegistryAssessmentEligibilityAll(@Parameter(name = "page", in = QUERY,
+                                                              description = "Indicates the page number. Page number must be >= 1.") @DefaultValue("1") @Min(value = 1, message = "Page number must be >= 1.") @QueryParam("page") int page,
+                                                      @Parameter(name = "size", in = QUERY,
+                                                              description = "The page size.") @DefaultValue("10") @Min(value = 1, message = "Page size must be between 1 and 20.")
+                                                      @Max(value = 20, message = "Page size must be between 1 and 20.") @QueryParam("size") int size, @Context UriInfo uriInfo) {
+
+        var userProfile = userService.getUserRegistryAssessmentEligibilityAll(page-1, size, utility.getUserUniqueIdentifier(), uriInfo);
+
+        return Response.ok().entity(userProfile).build();
+    }
+
     public static class PageableUserProfile extends PageResource<UserProfileDto> {
 
         private List<UserProfileDto> content;

--- a/repository/src/main/java/org/grnet/cat/repositories/ValidationRepository.java
+++ b/repository/src/main/java/org/grnet/cat/repositories/ValidationRepository.java
@@ -198,19 +198,44 @@ public class ValidationRepository implements Repository<Validation, Long> {
 
 
     /**
-     * Retrieves the list of assessment types and registry actors for which the user is eligible to create assessments.
+     * Retrieves the list of published assessment types and registry actors for which the user is eligible to create assessments.
      *
      * @param page   The index of the page to retrieve (starting from 0).
      * @param size   The maximum number of validation requests to include in a page.
      * @param userID the ID of the user
      * @return a structured list of organizations, assessment types, and registry actors
      */
-    public PageQuery<UserRegistryAssessmentEligibility> fetchUserRegistryAssessmentEligibility(int page, int size, String userID){
+    public PageQuery<UserRegistryAssessmentEligibility> fetchUserRegistryAssessmentEligibility( int page, int size, String userID){
 
         var panache = find("select v.organisationId, v.organisationName, v.organisationSource, v.organisationRole, " +
                         "ra.id as actorId, ra.labelActor as actorName, m.id as assessmentTypeId, m.label as assessmentTypeName from Validation v inner join MotivationActorJunction ma on v.registryActor.id = ma.id.actorId inner join RegistryActor ra on ma.id.actorId = ra.id inner join Motivation m on ma.id.motivationId = m.id " +
                         "where v.user.id = : userID and v.status = : status and ma.published = : published",
                 Parameters.with("userID", userID).and("status", ValidationStatus.APPROVED).and("published",Boolean.TRUE)).project(UserRegistryAssessmentEligibility.class).page(page, size);
+
+        var pageable = new PageQueryImpl<UserRegistryAssessmentEligibility>();
+        pageable.list = panache.list();
+        pageable.index = page;
+        pageable.size = size;
+        pageable.count = panache.count();
+        pageable.page = Page.of(page, size);
+
+        return pageable;
+    }
+
+    /**
+     * Retrieves the list of all assessment types and registry actors for which the user is eligible to create assessments.
+     *
+     * @param page   The index of the page to retrieve (starting from 0).
+     * @param size   The maximum number of validation requests to include in a page.
+     * @param userID the ID of the user
+     * @return a structured list of organizations, assessment types, and registry actors
+     */
+    public PageQuery<UserRegistryAssessmentEligibility> fetchUserRegistryAssessmentEligibilityAll( int page, int size, String userID){
+
+        var panache = find("select v.organisationId, v.organisationName, v.organisationSource, v.organisationRole, " +
+                        "ra.id as actorId, ra.labelActor as actorName, m.id as assessmentTypeId, m.label as assessmentTypeName from Validation v inner join MotivationActorJunction ma on v.registryActor.id = ma.id.actorId inner join RegistryActor ra on ma.id.actorId = ra.id inner join Motivation m on ma.id.motivationId = m.id " +
+                        "where v.user.id = : userID and v.status = : status ",
+                Parameters.with("userID", userID).and("status", ValidationStatus.APPROVED)).project(UserRegistryAssessmentEligibility.class).page(page, size);
 
         var pageable = new PageQueryImpl<UserRegistryAssessmentEligibility>();
         pageable.list = panache.list();

--- a/repository/src/main/java/org/grnet/cat/repositories/registry/MetricTestRepository.java
+++ b/repository/src/main/java/org/grnet/cat/repositories/registry/MetricTestRepository.java
@@ -111,14 +111,14 @@ public class MetricTestRepository implements Repository<MetricTestJunction, Stri
     }
 
     public boolean existTestInStatus(String testId, boolean status) {
-        return find("SELECT 1 FROM MetricTestJunction mt inner join CriterionMetricJunction cm on mt.id.metricId=cm.id.metricId INNER JOIN CriterionActorJunction ca on ca.id.criterionId=cm.id.criterionId INNER JOIN MotivationActorJunction ma ON ca.id.actorId=ma.id.actorId   WHERE mt.id.testId= ?1 AND ma.published= ?2", testId, status)
+        return find("SELECT 1 FROM MetricTestJunction mt inner join CriterionMetricJunction cm on mt.id.metricId=cm.id.metricId and mt.id.motivationId =cm.id.motivationId INNER JOIN CriterionActorJunction ca on ca.id.criterionId=cm.id.criterionId and ca.id.motivationId=cm.id.motivationId INNER JOIN MotivationActorJunction ma ON ca.id.actorId=ma.id.actorId and ma.id.motivationId=ca.id.motivationId WHERE mt.id.testId= ?1 AND ma.published= ?2", testId, status)
                 .firstResultOptional()
                 .isPresent();
 
     }
 
     public boolean existTestDefinitionInStatus(String testId, boolean status) {
-        return find("SELECT 1 FROM MetricTestJunction mt inner join CriterionMetricJunction cm on mt.id.metricId=cm.id.metricId INNER JOIN CriterionActorJunction ca on ca.id.criterionId=cm.id.criterionId INNER JOIN MotivationActorJunction ma ON ca.id.actorId=ma.id.actorId   WHERE mt.testDefinition.id= ?1 AND ma.published= ?2", testId, status)
+        return find("SELECT 1 FROM MetricTestJunction mt inner join CriterionMetricJunction cm on mt.id.metricId=cm.id.metricId and mt.id.motivationId =cm.id.motivationId INNER JOIN CriterionActorJunction ca on ca.id.criterionId=cm.id.criterionId and ca.id.motivationId=cm.id.motivationId INNER JOIN MotivationActorJunction ma ON ca.id.actorId=ma.id.actorId and ma.id.motivationId=ca.id.motivationId   WHERE mt.testDefinition.id= ?1 AND ma.published= ?2", testId, status)
                 .firstResultOptional()
                 .isPresent();
 

--- a/service/src/main/java/org/grnet/cat/services/UserService.java
+++ b/service/src/main/java/org/grnet/cat/services/UserService.java
@@ -299,9 +299,15 @@ public class UserService {
         roleRepository.removeRoles(userId, List.of("deny_access"));
     }
 
-    public PageResource<UserRegistryAssessmentEligibilityResponse> getUserRegistryAssessmentEligibility(int page, int size, String userID, UriInfo uriInfo) {
+    public PageResource<UserRegistryAssessmentEligibilityResponse> getUserRegistryAssessmentEligibility( int page, int size, String userID, UriInfo uriInfo) {
 
         var list = validationService.getUserRegistryAssessmentEligibility(page, size, userID);
+
+        return new PageResource<>(list, UserMapper.INSTANCE.listOfUserRegistryRegistryAssessmentEligibilityToDto(list.list()), uriInfo);
+    }
+    public PageResource<UserRegistryAssessmentEligibilityResponse> getUserRegistryAssessmentEligibilityAll( int page, int size, String userID, UriInfo uriInfo) {
+
+        var list = validationService.getUserRegistryAssessmentEligibilityAll(page, size, userID);
 
         return new PageResource<>(list, UserMapper.INSTANCE.listOfUserRegistryRegistryAssessmentEligibilityToDto(list.list()), uriInfo);
     }

--- a/service/src/main/java/org/grnet/cat/services/ValidationService.java
+++ b/service/src/main/java/org/grnet/cat/services/ValidationService.java
@@ -216,16 +216,29 @@ public class ValidationService {
     }
 
     /**
-     * Retrieves the list of assessment types and registry actors for which the user is eligible to create assessments.
+     * Retrieves the list of published assessment types and registry actors for which the user is eligible to create assessments.
      *
      * @param page   The index of the page to retrieve (starting from 0).
      * @param size   The maximum number of validation requests to include in a page.
      * @param userID the ID of the user
      * @return a structured list of organizations, assessment types, and registry actors
      */
-    public PageQuery<UserRegistryAssessmentEligibility> getUserRegistryAssessmentEligibility(int page, int size, String userID){
+    public PageQuery<UserRegistryAssessmentEligibility> getUserRegistryAssessmentEligibility( int page, int size, String userID){
 
-        return validationRepository.fetchUserRegistryAssessmentEligibility(page, size, userID);
+        return validationRepository.fetchUserRegistryAssessmentEligibility( page, size, userID);
+    }
+
+    /**
+     * Retrieves the list of all assessment types and registry actors for which the user is eligible to create assessments.
+     *
+     * @param page   The index of the page to retrieve (starting from 0).
+     * @param size   The maximum number of validation requests to include in a page.
+     * @param userID the ID of the user
+     * @return a structured list of organizations, assessment types, and registry actors
+     */
+    public PageQuery<UserRegistryAssessmentEligibility> getUserRegistryAssessmentEligibilityAll( int page, int size, String userID){
+
+        return validationRepository.fetchUserRegistryAssessmentEligibilityAll( page, size, userID);
     }
 
     @Transactional


### PR DESCRIPTION
1) fixed query retrieving tests only if assigned to motivation 

2) also  added /registry-assessment-eligibility-all to retrieve all the eligible validations , both related to published or unpublished assessment types. this call can be used when editing assessment to display all the validations and not only the corresponding to published ones