### PR TITLE
CAT-749 API call: admin publish assessment gets 403 when admin -version 2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -110,6 +110,7 @@ According to [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) , the `Unr
 - [#444](https://github.com/FC4E-CAT/fc4e-cat-api/pull/444/) CAT-792: Retrieve Associated Motivations for Metrics (fix)
 - [#450](https://github.com/FC4E-CAT/fc4e-cat-api/pull/450) CAT-806: Metrics view displays the same metric multiple times
 - [#445](https://github.com/FC4E-CAT/fc4e-cat-api/pull/445/) CAT-800 Cannot change test that belongs to unpublished motivation - still says published #446
+- [#449](https://github.com/FC4E-CAT/fc4e-cat-api/pull/449/) CAT-749 API call: admin publish assessment gets 403 when admin -version 2
 
 
 ### Removed

--- a/service/src/main/java/org/grnet/cat/services/assessment/JsonAssessmentService.java
+++ b/service/src/main/java/org/grnet/cat/services/assessment/JsonAssessmentService.java
@@ -577,11 +577,12 @@ public class JsonAssessmentService {
         ObjectNode jsonNode = null;
         try {
             jsonNode = (ObjectNode) objectMapper.readTree(doc);
+            jsonNode.put("published", publish);
             assessment.setAssessmentDoc(objectMapper.writeValueAsString(jsonNode));
         } catch (JsonProcessingException e) {
             throw new RuntimeException(e);
         }
-        assessment.setPublished(true);
+        assessment.setPublished(publish);
         return String.format("Assessment is %s successfully", publish ? "published" : "unpublished");
 
     }


### PR DESCRIPTION
published element in json was not updated correctly when publish/unpublish from admin