### PR TITLE
CAT-827 CAT-829 CAT-828 Publish Assessment in Zenodo / Store zenodo info in database/ Notifications to creator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ According to [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) , the `Unr
 ### Added
 - [#465](https://github.com/FC4E-CAT/fc4e-cat-api/pull/465) CAT-822 Assessment type view and fill put order in criteria.
 - [#467](https://github.com/FC4E-CAT/fc4e-cat-api/pull/467) CAT-832 Add 127.0.0.1 to Keycloak Public Client to Accept Requests.
+- [#468](https://github.com/FC4E-CAT/fc4e-cat-api/pull/468) CAT-827 CAT-829 CAT-828 Publish Assessment in Zenodo / Store zenodo info in database/ Notifications to creator.
+
 
 
 ## 1.9.2 - 2025-02-26
@@ -36,6 +38,7 @@ According to [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) , the `Unr
 
 ## 1.9.1 - 2025-02-25
 ---
+#### Added
 
 ### Fix
 - [#458](https://github.com/FC4E-CAT/fc4e-cat-api/pull/458) CAT-825 Missing label_algorithm , label_type_metric from assessment doc.

--- a/api/src/main/java/org/grnet/cat/api/endpoints/AdminEndpoint.java
+++ b/api/src/main/java/org/grnet/cat/api/endpoints/AdminEndpoint.java
@@ -42,6 +42,7 @@ import org.grnet.cat.repositories.*;
 import org.grnet.cat.services.*;
 import org.grnet.cat.services.assessment.JsonAssessmentService;
 import org.grnet.cat.services.registry.RegistryActorService;
+import org.grnet.cat.services.zenodo.ZenodoService;
 import org.grnet.cat.utils.Utility;
 
 import java.util.Arrays;
@@ -93,6 +94,7 @@ public class AdminEndpoint {
     /**
      * Injection point for the Utility service
      */
+
     @Inject
     Utility utility;
 
@@ -759,7 +761,6 @@ public class AdminEndpoint {
                                 @Context UriInfo uriInfo) {
 
         var assessments = assessmentService.getAllAssessmentsByPage(page - 1, size, search, uriInfo);
-//        assessments.getContent().stream().forEach(e-> System.out.println("is published-- ? "+e.getPublished()));
 
         return Response.ok().entity(assessments).build();
     }
@@ -948,4 +949,6 @@ public class AdminEndpoint {
         response.message=message;
         return Response.ok().entity(response).build();
     }
+
+
 }

--- a/api/src/main/resources/application.properties
+++ b/api/src/main/resources/application.properties
@@ -122,3 +122,6 @@ api.name=cat
 quarkus.health.openapi.included=true
 
 quarkus.rest-client."org.grnet.cat.api.health.AAIProxyClient".url=${QUARKUS_OIDC_AUTH_SERVER_URL:https://login-devel.einfra.grnet.gr/auth/realms/einfra}
+
+zenodo.api.key=MY_ACCESS_TOKEN
+quarkus.rest-client."org.grnet.cat.services.zenodo.ZenodoClient".url=https://sandbox.zenodo.org

--- a/api/src/main/resources/templates/zenodo_completed_publish_process_notification.html
+++ b/api/src/main/resources/templates/zenodo_completed_publish_process_notification.html
@@ -1,0 +1,302 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+  <title>Assessment Shared</title>
+  <style media="all" type="text/css">
+    /* GLOBAL RESETS */
+    body {
+      font-family: Helvetica, sans-serif;
+      -webkit-font-smoothing: antialiased;
+      font-size: 16px;
+      line-height: 1.3;
+      -ms-text-size-adjust: 100%;
+      -webkit-text-size-adjust: 100%;
+    }
+    table {
+      border-collapse: separate;
+      mso-table-lspace: 0pt;
+      mso-table-rspace: 0pt;
+      width: 100%;
+    }
+    table td {
+      font-family: Helvetica, sans-serif;
+      font-size: 16px;
+      vertical-align: top;
+    }
+    body {
+      background-color: #f4f5f6;
+      margin: 0;
+      padding: 0;
+    }
+    .body {
+      background-color: #f4f5f6;
+      width: 100%;
+    }
+    .container {
+      margin: 0 auto !important;
+      max-width: 600px;
+      padding: 0;
+      padding-top: 24px;
+      width: 600px;
+    }
+    .content {
+      box-sizing: border-box;
+      display: block;
+      margin: 0 auto;
+      max-width: 600px;
+      padding: 0;
+    }
+    .main {
+      background: #ffffff;
+      border: 1px solid #eaebed;
+      border-radius: 16px;
+      width: 100%;
+    }
+    .wrapper {
+      box-sizing: border-box;
+      padding: 24px;
+    }
+    .footer {
+      clear: both;
+      padding-top: 24px;
+      text-align: center;
+      width: 100%;
+    }
+    .footer td,
+    .footer p,
+    .footer span,
+    .footer a {
+      color: #9a9ea6;
+      font-size: 16px;
+      text-align: center;
+    }
+    p {
+      font-family: Helvetica, sans-serif;
+      font-size: 16px;
+      font-weight: normal;
+      margin: 0;
+      margin-bottom: 16px;
+    }
+    a {
+      color: #0867ec;
+      text-decoration: underline;
+    }
+    .btn {
+      box-sizing: border-box;
+      min-width: 100% !important;
+      width: 100%;
+    }
+    .btn table {
+      width: auto;
+    }
+    .btn table td {
+      background-color: #ffffff;
+      border-radius: 4px;
+      text-align: center;
+    }
+    .btn a {
+      background-color: #ffffff;
+      border: solid 2px #0867ec;
+      border-radius: 4px;
+      box-sizing: border-box;
+      color: #0867ec;
+      cursor: pointer;
+      display: inline-block;
+      font-size: 16px;
+      font-weight: bold;
+      margin: 0;
+      padding: 12px 24px;
+      text-decoration: none;
+      text-transform: capitalize;
+    }
+    .btn-primary table td {
+      background-color: #0867ec;
+    }
+    .btn-primary a {
+      background-color: #0867ec;
+      border-color: #0867ec;
+      color: #ffffff;
+    }
+    @media all {
+      .btn-primary table td:hover {
+        background-color: #fed046 !important;
+        color: #000000;
+      }
+      .btn-primary a:hover {
+        background-color: #fed046 !important;
+        border-color: #fed046 !important;
+        color: #000000;
+      }
+    }
+    .last {
+      margin-bottom: 0;
+    }
+    .first {
+      margin-top: 0;
+    }
+    .align-center {
+      text-align: center;
+    }
+    .align-right {
+      text-align: right;
+    }
+    .align-left {
+      text-align: left;
+    }
+    .text-link {
+      color: #0867ec !important;
+      text-decoration: underline !important;
+    }
+    .clear {
+      clear: both;
+    }
+    .mt0 {
+      margin-top: 0;
+    }
+    .mb0 {
+      margin-bottom: 0;
+    }
+    .preheader {
+      color: transparent;
+      display: none;
+      height: 0;
+      max-height: 0;
+      max-width: 0;
+      opacity: 0;
+      overflow: hidden;
+      mso-hide: all;
+      visibility: hidden;
+      width: 0;
+    }
+    .powered-by a {
+      text-decoration: none;
+    }
+    @media only screen and (max-width: 640px) {
+      .main p,
+      .main td,
+      .main span {
+        font-size: 16px !important;
+      }
+      .wrapper {
+        padding: 8px !important;
+      }
+      .content {
+        padding: 0 !important;
+      }
+      .container {
+        padding: 0 !important;
+        padding-top: 8px !important;
+        width: 100% !important;
+      }
+      .main {
+        border-left-width: 0 !important;
+        border-radius: 0 !important;
+        border-right-width: 0 !important;
+      }
+      .btn table {
+        max-width: 100% !important;
+        width: 100% !important;
+      }
+      .btn a {
+        font-size: 16px !important;
+        max-width: 100% !important;
+        width: 100% !important;
+      }
+    }
+    @media all {
+      .ExternalClass {
+        width: 100%;
+      }
+      .ExternalClass,
+      .ExternalClass p,
+      .ExternalClass span,
+      .ExternalClass font,
+      .ExternalClass td,
+      .ExternalClass div {
+        line-height: 100%;
+      }
+      .apple-link a {
+        color: inherit !important;
+        font-family: inherit !important;
+        font-size: inherit !important;
+        font-weight: inherit !important;
+        line-height: inherit !important;
+        text-decoration: none !important;
+      }
+      #MessageViewBody a {
+        color: inherit;
+        text-decoration: none;
+        font-size: inherit;
+        font-family: inherit;
+        font-weight: inherit;
+        line-height: inherit;
+      }
+    }
+  </style>
+</head>
+<body>
+<table role="presentation" border="0" cellpadding="0" cellspacing="0" class="body">
+  <tr>
+    <td>&nbsp;</td>
+    <td class="container">
+      <div class="content">
+        <!-- START CENTERED WHITE CONTAINER -->
+        <table role="presentation" border="0" cellpadding="0" cellspacing="0" class="main">
+          <!-- START MAIN CONTENT AREA -->
+          <tr>
+            <td class="wrapper">
+              <p><img src="{image}"></p>
+              <p>&nbsp;</p>
+              <p><h3>Dear {name},</h3></p>
+              <p> This is to inform you that an assessment :<strong> {assessmentName} </strong> with id:  <strong>{assessmentId}</strong>   has been published to Zenodo under deposit <strong>{depositId}</strong>.
+                <br><br>
+                To view the deposit, click the link below:</p>
+              <table role="presentation" border="0" cellpadding="0" cellspacing="0" class="btn btn-primary">
+                <tbody>
+                <tr>
+                  <td align="left">
+                    <table role="presentation" border="0" cellpadding="0" cellspacing="0">
+                      <tbody>
+                      <tr>
+                        <td> <a href="{depositUrl}" target="_blank">View Deposit</a> </td>
+                      </tr>
+                      </tbody>
+                    </table>
+                  </td>
+                </tr>
+                </tbody>
+              </table>
+              <br>
+              <p>Thank you, <br/>The FAIRCORE4EOSC Compliance Assessment Toolkit - CAT Team.</p>
+              <p><h4>Partners</h4></p>
+              <p>
+                <img src="{image2}" alt="GRNET" height="40px">
+                <img src="{image1}" alt="DANS" height="40px">
+                <img src="{image4}" alt="gwdg" height="30px">
+                <img src="{image3}" alt="DATACITE" height="30px">
+              </p>
+            </td>
+          </tr>
+          <!-- END MAIN CONTENT AREA -->
+        </table>
+        <!-- START FOOTER -->
+        <div class="footer">
+          <table role="presentation" border="0" cellpadding="0" cellspacing="0" style="color:#DCDCDC">
+            <tr>
+              <td class="content-block">
+                <span class="apple-link">The FAIRCORE4EOSC Compliance Assessment Toolkit - CAT Team</span>
+                <br> Need more information? Contact us at <a href="mailto:{contactMail}">Info</a>.
+              </td>
+            </tr>
+          </table>
+        </div>
+        <!-- END FOOTER -->
+        <!-- END CENTERED WHITE CONTAINER --></div>
+    </td>
+    <td>&nbsp;</td>
+  </tr>
+</table>
+</body>
+</html>

--- a/api/src/main/resources/templates/zenodo_draft_deposit_notification.html
+++ b/api/src/main/resources/templates/zenodo_draft_deposit_notification.html
@@ -1,0 +1,306 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+    <title>Assessment Shared</title>
+    <style media="all" type="text/css">
+        /* GLOBAL RESETS */
+        body {
+          font-family: Helvetica, sans-serif;
+          -webkit-font-smoothing: antialiased;
+          font-size: 16px;
+          line-height: 1.3;
+          -ms-text-size-adjust: 100%;
+          -webkit-text-size-adjust: 100%;
+        }
+        table {
+          border-collapse: separate;
+          mso-table-lspace: 0pt;
+          mso-table-rspace: 0pt;
+          width: 100%;
+        }
+        table td {
+          font-family: Helvetica, sans-serif;
+          font-size: 16px;
+          vertical-align: top;
+        }
+        body {
+          background-color: #f4f5f6;
+          margin: 0;
+          padding: 0;
+        }
+        .body {
+          background-color: #f4f5f6;
+          width: 100%;
+        }
+        .container {
+          margin: 0 auto !important;
+          max-width: 600px;
+          padding: 0;
+          padding-top: 24px;
+          width: 600px;
+        }
+        .content {
+          box-sizing: border-box;
+          display: block;
+          margin: 0 auto;
+          max-width: 600px;
+          padding: 0;
+        }
+        .main {
+          background: #ffffff;
+          border: 1px solid #eaebed;
+          border-radius: 16px;
+          width: 100%;
+        }
+        .wrapper {
+          box-sizing: border-box;
+          padding: 24px;
+        }
+        .footer {
+          clear: both;
+          padding-top: 24px;
+          text-align: center;
+          width: 100%;
+        }
+        .footer td,
+        .footer p,
+        .footer span,
+        .footer a {
+          color: #9a9ea6;
+          font-size: 16px;
+          text-align: center;
+        }
+        p {
+          font-family: Helvetica, sans-serif;
+          font-size: 16px;
+          font-weight: normal;
+          margin: 0;
+          margin-bottom: 16px;
+        }
+        a {
+          color: #0867ec;
+          text-decoration: underline;
+        }
+        .btn {
+          box-sizing: border-box;
+          min-width: 100% !important;
+          width: 100%;
+        }
+        .btn table {
+          width: auto;
+        }
+        .btn table td {
+          background-color: #ffffff;
+          border-radius: 4px;
+          text-align: center;
+        }
+        .btn a {
+          background-color: #ffffff;
+          border: solid 2px #0867ec;
+          border-radius: 4px;
+          box-sizing: border-box;
+          color: #0867ec;
+          cursor: pointer;
+          display: inline-block;
+          font-size: 16px;
+          font-weight: bold;
+          margin: 0;
+          padding: 12px 24px;
+          text-decoration: none;
+          text-transform: capitalize;
+        }
+        .btn-primary table td {
+          background-color: #0867ec;
+        }
+        .btn-primary a {
+          background-color: #0867ec;
+          border-color: #0867ec;
+          color: #ffffff;
+        }
+        @media all {
+          .btn-primary table td:hover {
+            background-color: #fed046 !important;
+            color: #000000;
+          }
+          .btn-primary a:hover {
+            background-color: #fed046 !important;
+            border-color: #fed046 !important;
+            color: #000000;
+          }
+        }
+        .last {
+          margin-bottom: 0;
+        }
+        .first {
+          margin-top: 0;
+        }
+        .align-center {
+          text-align: center;
+        }
+        .align-right {
+          text-align: right;
+        }
+        .align-left {
+          text-align: left;
+        }
+        .text-link {
+          color: #0867ec !important;
+          text-decoration: underline !important;
+        }
+        .clear {
+          clear: both;
+        }
+        .mt0 {
+          margin-top: 0;
+        }
+        .mb0 {
+          margin-bottom: 0;
+        }
+        .preheader {
+          color: transparent;
+          display: none;
+          height: 0;
+          max-height: 0;
+          max-width: 0;
+          opacity: 0;
+          overflow: hidden;
+          mso-hide: all;
+          visibility: hidden;
+          width: 0;
+        }
+        .powered-by a {
+          text-decoration: none;
+        }
+        @media only screen and (max-width: 640px) {
+          .main p,
+          .main td,
+          .main span {
+            font-size: 16px !important;
+          }
+          .wrapper {
+            padding: 8px !important;
+          }
+          .content {
+            padding: 0 !important;
+          }
+          .container {
+            padding: 0 !important;
+            padding-top: 8px !important;
+            width: 100% !important;
+          }
+          .main {
+            border-left-width: 0 !important;
+            border-radius: 0 !important;
+            border-right-width: 0 !important;
+          }
+          .btn table {
+            max-width: 100% !important;
+            width: 100% !important;
+          }
+          .btn a {
+            font-size: 16px !important;
+            max-width: 100% !important;
+            width: 100% !important;
+          }
+        }
+        @media all {
+          .ExternalClass {
+            width: 100%;
+          }
+          .ExternalClass,
+          .ExternalClass p,
+          .ExternalClass span,
+          .ExternalClass font,
+          .ExternalClass td,
+          .ExternalClass div {
+            line-height: 100%;
+          }
+          .apple-link a {
+            color: inherit !important;
+            font-family: inherit !important;
+            font-size: inherit !important;
+            font-weight: inherit !important;
+            line-height: inherit !important;
+            text-decoration: none !important;
+          }
+          #MessageViewBody a {
+            color: inherit;
+            text-decoration: none;
+            font-size: inherit;
+            font-family: inherit;
+            font-weight: inherit;
+            line-height: inherit;
+          }
+        }
+    </style>
+</head>
+<body>
+<table role="presentation" border="0" cellpadding="0" cellspacing="0" class="body">
+    <tr>
+        <td>&nbsp;</td>
+        <td class="container">
+            <div class="content">
+                <!-- START CENTERED WHITE CONTAINER -->
+                <table role="presentation" border="0" cellpadding="0" cellspacing="0" class="main">
+                    <!-- START MAIN CONTENT AREA -->
+                    <tr>
+                        <td class="wrapper">
+                            <p><img src="{image}"></p>
+                            <p>&nbsp;</p>
+                            <p>
+                            <h3>Dear {name},</h3></p>
+                            <p> This is to inform you that an assessment :<strong> {assessmentName} </strong> with id:
+                                <strong>{assessmentId}</strong> has been published to Zenodo under deposit <strong>{depositId}</strong>
+                            <p>but the deposit is not yet published. Please try to publish deposit.</p>
+<!--                            <br><br>-->
+<!--                            To view the deposit, click the link below:</p>-->
+<!--                            <table role="presentation" border="0" cellpadding="0" cellspacing="0"-->
+<!--                                   class="btn btn-primary">-->
+<!--                                <tbody>-->
+<!--                                <tr>-->
+<!--                                    <td align="left">-->
+<!--                                        <table role="presentation" border="0" cellpadding="0" cellspacing="0">-->
+<!--                                            <tbody>-->
+<!--                                            <tr>-->
+<!--                                                <td><a href="{depositUrl}" target="_blank">View Deposit</a></td>-->
+<!--                                            </tr>-->
+<!--                                            </tbody>-->
+<!--                                        </table>-->
+<!--                                    </td>-->
+<!--                                </tr>-->
+<!--                                </tbody>-->
+<!--                            </table>-->
+                            <br>
+                            <p>Thank you, <br/>The FAIRCORE4EOSC Compliance Assessment Toolkit - CAT Team.</p>
+                            <p><h4>Partners</h4></p>
+                            <p>
+                                <img src="{image2}" alt="GRNET" height="40px">
+                                <img src="{image1}" alt="DANS" height="40px">
+                                <img src="{image4}" alt="gwdg" height="30px">
+                                <img src="{image3}" alt="DATACITE" height="30px">
+                            </p>
+                        </td>
+                    </tr>
+                    <!-- END MAIN CONTENT AREA -->
+                </table>
+                <!-- START FOOTER -->
+                <div class="footer">
+                    <table role="presentation" border="0" cellpadding="0" cellspacing="0" style="color:#DCDCDC">
+                        <tr>
+                            <td class="content-block">
+                                <span class="apple-link">The FAIRCORE4EOSC Compliance Assessment Toolkit - CAT Team</span>
+                                <br> Need more information? Contact us at <a href="mailto:{contactMail}">Info</a>.
+                            </td>
+                        </tr>
+                    </table>
+                </div>
+                <!-- END FOOTER -->
+                <!-- END CENTERED WHITE CONTAINER --></div>
+        </td>
+        <td>&nbsp;</td>
+    </tr>
+</table>
+</body>
+</html>

--- a/api/src/main/resources/templates/zenodo_failed_publish_deposit_notification.html
+++ b/api/src/main/resources/templates/zenodo_failed_publish_deposit_notification.html
@@ -1,0 +1,302 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+    <title>Assessment Shared</title>
+    <style media="all" type="text/css">
+        /* GLOBAL RESETS */
+        body {
+          font-family: Helvetica, sans-serif;
+          -webkit-font-smoothing: antialiased;
+          font-size: 16px;
+          line-height: 1.3;
+          -ms-text-size-adjust: 100%;
+          -webkit-text-size-adjust: 100%;
+        }
+        table {
+          border-collapse: separate;
+          mso-table-lspace: 0pt;
+          mso-table-rspace: 0pt;
+          width: 100%;
+        }
+        table td {
+          font-family: Helvetica, sans-serif;
+          font-size: 16px;
+          vertical-align: top;
+        }
+        body {
+          background-color: #f4f5f6;
+          margin: 0;
+          padding: 0;
+        }
+        .body {
+          background-color: #f4f5f6;
+          width: 100%;
+        }
+        .container {
+          margin: 0 auto !important;
+          max-width: 600px;
+          padding: 0;
+          padding-top: 24px;
+          width: 600px;
+        }
+        .content {
+          box-sizing: border-box;
+          display: block;
+          margin: 0 auto;
+          max-width: 600px;
+          padding: 0;
+        }
+        .main {
+          background: #ffffff;
+          border: 1px solid #eaebed;
+          border-radius: 16px;
+          width: 100%;
+        }
+        .wrapper {
+          box-sizing: border-box;
+          padding: 24px;
+        }
+        .footer {
+          clear: both;
+          padding-top: 24px;
+          text-align: center;
+          width: 100%;
+        }
+        .footer td,
+        .footer p,
+        .footer span,
+        .footer a {
+          color: #9a9ea6;
+          font-size: 16px;
+          text-align: center;
+        }
+        p {
+          font-family: Helvetica, sans-serif;
+          font-size: 16px;
+          font-weight: normal;
+          margin: 0;
+          margin-bottom: 16px;
+        }
+        a {
+          color: #0867ec;
+          text-decoration: underline;
+        }
+        .btn {
+          box-sizing: border-box;
+          min-width: 100% !important;
+          width: 100%;
+        }
+        .btn table {
+          width: auto;
+        }
+        .btn table td {
+          background-color: #ffffff;
+          border-radius: 4px;
+          text-align: center;
+        }
+        .btn a {
+          background-color: #ffffff;
+          border: solid 2px #0867ec;
+          border-radius: 4px;
+          box-sizing: border-box;
+          color: #0867ec;
+          cursor: pointer;
+          display: inline-block;
+          font-size: 16px;
+          font-weight: bold;
+          margin: 0;
+          padding: 12px 24px;
+          text-decoration: none;
+          text-transform: capitalize;
+        }
+        .btn-primary table td {
+          background-color: #0867ec;
+        }
+        .btn-primary a {
+          background-color: #0867ec;
+          border-color: #0867ec;
+          color: #ffffff;
+        }
+        @media all {
+          .btn-primary table td:hover {
+            background-color: #fed046 !important;
+            color: #000000;
+          }
+          .btn-primary a:hover {
+            background-color: #fed046 !important;
+            border-color: #fed046 !important;
+            color: #000000;
+          }
+        }
+        .last {
+          margin-bottom: 0;
+        }
+        .first {
+          margin-top: 0;
+        }
+        .align-center {
+          text-align: center;
+        }
+        .align-right {
+          text-align: right;
+        }
+        .align-left {
+          text-align: left;
+        }
+        .text-link {
+          color: #0867ec !important;
+          text-decoration: underline !important;
+        }
+        .clear {
+          clear: both;
+        }
+        .mt0 {
+          margin-top: 0;
+        }
+        .mb0 {
+          margin-bottom: 0;
+        }
+        .preheader {
+          color: transparent;
+          display: none;
+          height: 0;
+          max-height: 0;
+          max-width: 0;
+          opacity: 0;
+          overflow: hidden;
+          mso-hide: all;
+          visibility: hidden;
+          width: 0;
+        }
+        .powered-by a {
+          text-decoration: none;
+        }
+        @media only screen and (max-width: 640px) {
+          .main p,
+          .main td,
+          .main span {
+            font-size: 16px !important;
+          }
+          .wrapper {
+            padding: 8px !important;
+          }
+          .content {
+            padding: 0 !important;
+          }
+          .container {
+            padding: 0 !important;
+            padding-top: 8px !important;
+            width: 100% !important;
+          }
+          .main {
+            border-left-width: 0 !important;
+            border-radius: 0 !important;
+            border-right-width: 0 !important;
+          }
+          .btn table {
+            max-width: 100% !important;
+            width: 100% !important;
+          }
+          .btn a {
+            font-size: 16px !important;
+            max-width: 100% !important;
+            width: 100% !important;
+          }
+        }
+        @media all {
+          .ExternalClass {
+            width: 100%;
+          }
+          .ExternalClass,
+          .ExternalClass p,
+          .ExternalClass span,
+          .ExternalClass font,
+          .ExternalClass td,
+          .ExternalClass div {
+            line-height: 100%;
+          }
+          .apple-link a {
+            color: inherit !important;
+            font-family: inherit !important;
+            font-size: inherit !important;
+            font-weight: inherit !important;
+            line-height: inherit !important;
+            text-decoration: none !important;
+          }
+          #MessageViewBody a {
+            color: inherit;
+            text-decoration: none;
+            font-size: inherit;
+            font-family: inherit;
+            font-weight: inherit;
+            line-height: inherit;
+          }
+        }
+    </style>
+</head>
+<body>
+<table role="presentation" border="0" cellpadding="0" cellspacing="0" class="body">
+    <tr>
+        <td>&nbsp;</td>
+        <td class="container">
+            <div class="content">
+                <!-- START CENTERED WHITE CONTAINER -->
+                <table role="presentation" border="0" cellpadding="0" cellspacing="0" class="main">
+                    <!-- START MAIN CONTENT AREA -->
+                    <tr>
+                        <td class="wrapper">
+                            <p><img src="{image}"></p>
+                            <p>&nbsp;</p>
+                            <p><h3>Dear {name},</h3></p>
+                            <p> This is to inform you that the deposit with id:  <strong>{depositId}</strong> has been published to Zenodo.
+                                <br><br>
+                                To view the deposit, click the link below:</p>
+                            <table role="presentation" border="0" cellpadding="0" cellspacing="0" class="btn btn-primary">
+                                <tbody>
+                                <tr>
+                                    <td align="left">
+                                        <table role="presentation" border="0" cellpadding="0" cellspacing="0">
+                                            <tbody>
+                                            <tr>
+                                                <td> <a href="{depositUrl}" target="_blank">View Deposit</a> </td>
+                                            </tr>
+                                            </tbody>
+                                        </table>
+                                    </td>
+                                </tr>
+                                </tbody>
+                            </table>
+                            <br>
+                            <p>Thank you, <br/>The FAIRCORE4EOSC Compliance Assessment Toolkit - CAT Team.</p>
+                            <p><h4>Partners</h4></p>
+                            <p>
+                                <img src="{image2}" alt="GRNET" height="40px">
+                                <img src="{image1}" alt="DANS" height="40px">
+                                <img src="{image4}" alt="gwdg" height="30px">
+                                <img src="{image3}" alt="DATACITE" height="30px">
+                            </p>
+                        </td>
+                    </tr>
+                    <!-- END MAIN CONTENT AREA -->
+                </table>
+                <!-- START FOOTER -->
+                <div class="footer">
+                    <table role="presentation" border="0" cellpadding="0" cellspacing="0" style="color:#DCDCDC">
+                        <tr>
+                            <td class="content-block">
+                                <span class="apple-link">The FAIRCORE4EOSC Compliance Assessment Toolkit - CAT Team</span>
+                                <br> Need more information? Contact us at <a href="mailto:{contactMail}">Info</a>.
+                            </td>
+                        </tr>
+                    </table>
+                </div>
+                <!-- END FOOTER -->
+                <!-- END CENTERED WHITE CONTAINER --></div>
+        </td>
+        <td>&nbsp;</td>
+    </tr>
+</table>
+</body>
+</html>

--- a/api/src/main/resources/templates/zenodo_failed_publish_process_notification.html
+++ b/api/src/main/resources/templates/zenodo_failed_publish_process_notification.html
@@ -1,0 +1,286 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+    <title>Assessment Shared</title>
+    <style media="all" type="text/css">
+        /* GLOBAL RESETS */
+        body {
+          font-family: Helvetica, sans-serif;
+          -webkit-font-smoothing: antialiased;
+          font-size: 16px;
+          line-height: 1.3;
+          -ms-text-size-adjust: 100%;
+          -webkit-text-size-adjust: 100%;
+        }
+        table {
+          border-collapse: separate;
+          mso-table-lspace: 0pt;
+          mso-table-rspace: 0pt;
+          width: 100%;
+        }
+        table td {
+          font-family: Helvetica, sans-serif;
+          font-size: 16px;
+          vertical-align: top;
+        }
+        body {
+          background-color: #f4f5f6;
+          margin: 0;
+          padding: 0;
+        }
+        .body {
+          background-color: #f4f5f6;
+          width: 100%;
+        }
+        .container {
+          margin: 0 auto !important;
+          max-width: 600px;
+          padding: 0;
+          padding-top: 24px;
+          width: 600px;
+        }
+        .content {
+          box-sizing: border-box;
+          display: block;
+          margin: 0 auto;
+          max-width: 600px;
+          padding: 0;
+        }
+        .main {
+          background: #ffffff;
+          border: 1px solid #eaebed;
+          border-radius: 16px;
+          width: 100%;
+        }
+        .wrapper {
+          box-sizing: border-box;
+          padding: 24px;
+        }
+        .footer {
+          clear: both;
+          padding-top: 24px;
+          text-align: center;
+          width: 100%;
+        }
+        .footer td,
+        .footer p,
+        .footer span,
+        .footer a {
+          color: #9a9ea6;
+          font-size: 16px;
+          text-align: center;
+        }
+        p {
+          font-family: Helvetica, sans-serif;
+          font-size: 16px;
+          font-weight: normal;
+          margin: 0;
+          margin-bottom: 16px;
+        }
+        a {
+          color: #0867ec;
+          text-decoration: underline;
+        }
+        .btn {
+          box-sizing: border-box;
+          min-width: 100% !important;
+          width: 100%;
+        }
+        .btn table {
+          width: auto;
+        }
+        .btn table td {
+          background-color: #ffffff;
+          border-radius: 4px;
+          text-align: center;
+        }
+        .btn a {
+          background-color: #ffffff;
+          border: solid 2px #0867ec;
+          border-radius: 4px;
+          box-sizing: border-box;
+          color: #0867ec;
+          cursor: pointer;
+          display: inline-block;
+          font-size: 16px;
+          font-weight: bold;
+          margin: 0;
+          padding: 12px 24px;
+          text-decoration: none;
+          text-transform: capitalize;
+        }
+        .btn-primary table td {
+          background-color: #0867ec;
+        }
+        .btn-primary a {
+          background-color: #0867ec;
+          border-color: #0867ec;
+          color: #ffffff;
+        }
+        @media all {
+          .btn-primary table td:hover {
+            background-color: #fed046 !important;
+            color: #000000;
+          }
+          .btn-primary a:hover {
+            background-color: #fed046 !important;
+            border-color: #fed046 !important;
+            color: #000000;
+          }
+        }
+        .last {
+          margin-bottom: 0;
+        }
+        .first {
+          margin-top: 0;
+        }
+        .align-center {
+          text-align: center;
+        }
+        .align-right {
+          text-align: right;
+        }
+        .align-left {
+          text-align: left;
+        }
+        .text-link {
+          color: #0867ec !important;
+          text-decoration: underline !important;
+        }
+        .clear {
+          clear: both;
+        }
+        .mt0 {
+          margin-top: 0;
+        }
+        .mb0 {
+          margin-bottom: 0;
+        }
+        .preheader {
+          color: transparent;
+          display: none;
+          height: 0;
+          max-height: 0;
+          max-width: 0;
+          opacity: 0;
+          overflow: hidden;
+          mso-hide: all;
+          visibility: hidden;
+          width: 0;
+        }
+        .powered-by a {
+          text-decoration: none;
+        }
+        @media only screen and (max-width: 640px) {
+          .main p,
+          .main td,
+          .main span {
+            font-size: 16px !important;
+          }
+          .wrapper {
+            padding: 8px !important;
+          }
+          .content {
+            padding: 0 !important;
+          }
+          .container {
+            padding: 0 !important;
+            padding-top: 8px !important;
+            width: 100% !important;
+          }
+          .main {
+            border-left-width: 0 !important;
+            border-radius: 0 !important;
+            border-right-width: 0 !important;
+          }
+          .btn table {
+            max-width: 100% !important;
+            width: 100% !important;
+          }
+          .btn a {
+            font-size: 16px !important;
+            max-width: 100% !important;
+            width: 100% !important;
+          }
+        }
+        @media all {
+          .ExternalClass {
+            width: 100%;
+          }
+          .ExternalClass,
+          .ExternalClass p,
+          .ExternalClass span,
+          .ExternalClass font,
+          .ExternalClass td,
+          .ExternalClass div {
+            line-height: 100%;
+          }
+          .apple-link a {
+            color: inherit !important;
+            font-family: inherit !important;
+            font-size: inherit !important;
+            font-weight: inherit !important;
+            line-height: inherit !important;
+            text-decoration: none !important;
+          }
+          #MessageViewBody a {
+            color: inherit;
+            text-decoration: none;
+            font-size: inherit;
+            font-family: inherit;
+            font-weight: inherit;
+            line-height: inherit;
+          }
+        }
+    </style>
+</head>
+<body>
+<table role="presentation" border="0" cellpadding="0" cellspacing="0" class="body">
+    <tr>
+        <td>&nbsp;</td>
+        <td class="container">
+            <div class="content">
+                <!-- START CENTERED WHITE CONTAINER -->
+                <table role="presentation" border="0" cellpadding="0" cellspacing="0" class="main">
+                    <!-- START MAIN CONTENT AREA -->
+                    <tr>
+                        <td class="wrapper">
+                            <p><img src="{image}"></p>
+                            <p>&nbsp;</p>
+                            <p><h3>Dear {name},</h3></p>
+                            <p> This is to inform you that an assessment :<strong> {assessmentName} </strong> with id:  <strong>{assessmentId}</strong>  failed to be published to Zenodo.
+                            <p>Please try again.</p>
+                            <br>
+                            <p>Thank you, <br/>The FAIRCORE4EOSC Compliance Assessment Toolkit - CAT Team.</p>
+                            <p><h4>Partners</h4></p>
+                            <p>
+                                <img src="{image2}" alt="GRNET" height="40px">
+                                <img src="{image1}" alt="DANS" height="40px">
+                                <img src="{image4}" alt="gwdg" height="30px">
+                                <img src="{image3}" alt="DATACITE" height="30px">
+                            </p>
+                        </td>
+                    </tr>
+                    <!-- END MAIN CONTENT AREA -->
+                </table>
+                <!-- START FOOTER -->
+                <div class="footer">
+                    <table role="presentation" border="0" cellpadding="0" cellspacing="0" style="color:#DCDCDC">
+                        <tr>
+                            <td class="content-block">
+                                <span class="apple-link">The FAIRCORE4EOSC Compliance Assessment Toolkit - CAT Team</span>
+                                <br> Need more information? Contact us at <a href="mailto:{contactMail}">Info</a>.
+                            </td>
+                        </tr>
+                    </table>
+                </div>
+                <!-- END FOOTER -->
+                <!-- END CENTERED WHITE CONTAINER --></div>
+        </td>
+        <td>&nbsp;</td>
+    </tr>
+</table>
+</body>
+</html>

--- a/api/src/main/resources/templates/zenodo_publish_assessment_notification.html
+++ b/api/src/main/resources/templates/zenodo_publish_assessment_notification.html
@@ -1,0 +1,303 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+    <title>Assessment Shared</title>
+    <style media="all" type="text/css">
+        /* GLOBAL RESETS */
+        body {
+          font-family: Helvetica, sans-serif;
+          -webkit-font-smoothing: antialiased;
+          font-size: 16px;
+          line-height: 1.3;
+          -ms-text-size-adjust: 100%;
+          -webkit-text-size-adjust: 100%;
+        }
+        table {
+          border-collapse: separate;
+          mso-table-lspace: 0pt;
+          mso-table-rspace: 0pt;
+          width: 100%;
+        }
+        table td {
+          font-family: Helvetica, sans-serif;
+          font-size: 16px;
+          vertical-align: top;
+        }
+        body {
+          background-color: #f4f5f6;
+          margin: 0;
+          padding: 0;
+        }
+        .body {
+          background-color: #f4f5f6;
+          width: 100%;
+        }
+        .container {
+          margin: 0 auto !important;
+          max-width: 600px;
+          padding: 0;
+          padding-top: 24px;
+          width: 600px;
+        }
+        .content {
+          box-sizing: border-box;
+          display: block;
+          margin: 0 auto;
+          max-width: 600px;
+          padding: 0;
+        }
+        .main {
+          background: #ffffff;
+          border: 1px solid #eaebed;
+          border-radius: 16px;
+          width: 100%;
+        }
+        .wrapper {
+          box-sizing: border-box;
+          padding: 24px;
+        }
+        .footer {
+          clear: both;
+          padding-top: 24px;
+          text-align: center;
+          width: 100%;
+        }
+        .footer td,
+        .footer p,
+        .footer span,
+        .footer a {
+          color: #9a9ea6;
+          font-size: 16px;
+          text-align: center;
+        }
+        p {
+          font-family: Helvetica, sans-serif;
+          font-size: 16px;
+          font-weight: normal;
+          margin: 0;
+          margin-bottom: 16px;
+        }
+        a {
+          color: #0867ec;
+          text-decoration: underline;
+        }
+        .btn {
+          box-sizing: border-box;
+          min-width: 100% !important;
+          width: 100%;
+        }
+        .btn table {
+          width: auto;
+        }
+        .btn table td {
+          background-color: #ffffff;
+          border-radius: 4px;
+          text-align: center;
+        }
+        .btn a {
+          background-color: #ffffff;
+          border: solid 2px #0867ec;
+          border-radius: 4px;
+          box-sizing: border-box;
+          color: #0867ec;
+          cursor: pointer;
+          display: inline-block;
+          font-size: 16px;
+          font-weight: bold;
+          margin: 0;
+          padding: 12px 24px;
+          text-decoration: none;
+          text-transform: capitalize;
+        }
+        .btn-primary table td {
+          background-color: #0867ec;
+        }
+        .btn-primary a {
+          background-color: #0867ec;
+          border-color: #0867ec;
+          color: #ffffff;
+        }
+        @media all {
+          .btn-primary table td:hover {
+            background-color: #fed046 !important;
+            color: #000000;
+          }
+          .btn-primary a:hover {
+            background-color: #fed046 !important;
+            border-color: #fed046 !important;
+            color: #000000;
+          }
+        }
+        .last {
+          margin-bottom: 0;
+        }
+        .first {
+          margin-top: 0;
+        }
+        .align-center {
+          text-align: center;
+        }
+        .align-right {
+          text-align: right;
+        }
+        .align-left {
+          text-align: left;
+        }
+        .text-link {
+          color: #0867ec !important;
+          text-decoration: underline !important;
+        }
+        .clear {
+          clear: both;
+        }
+        .mt0 {
+          margin-top: 0;
+        }
+        .mb0 {
+          margin-bottom: 0;
+        }
+        .preheader {
+          color: transparent;
+          display: none;
+          height: 0;
+          max-height: 0;
+          max-width: 0;
+          opacity: 0;
+          overflow: hidden;
+          mso-hide: all;
+          visibility: hidden;
+          width: 0;
+        }
+        .powered-by a {
+          text-decoration: none;
+        }
+        @media only screen and (max-width: 640px) {
+          .main p,
+          .main td,
+          .main span {
+            font-size: 16px !important;
+          }
+          .wrapper {
+            padding: 8px !important;
+          }
+          .content {
+            padding: 0 !important;
+          }
+          .container {
+            padding: 0 !important;
+            padding-top: 8px !important;
+            width: 100% !important;
+          }
+          .main {
+            border-left-width: 0 !important;
+            border-radius: 0 !important;
+            border-right-width: 0 !important;
+          }
+          .btn table {
+            max-width: 100% !important;
+            width: 100% !important;
+          }
+          .btn a {
+            font-size: 16px !important;
+            max-width: 100% !important;
+            width: 100% !important;
+          }
+        }
+        @media all {
+          .ExternalClass {
+            width: 100%;
+          }
+          .ExternalClass,
+          .ExternalClass p,
+          .ExternalClass span,
+          .ExternalClass font,
+          .ExternalClass td,
+          .ExternalClass div {
+            line-height: 100%;
+          }
+          .apple-link a {
+            color: inherit !important;
+            font-family: inherit !important;
+            font-size: inherit !important;
+            font-weight: inherit !important;
+            line-height: inherit !important;
+            text-decoration: none !important;
+          }
+          #MessageViewBody a {
+            color: inherit;
+            text-decoration: none;
+            font-size: inherit;
+            font-family: inherit;
+            font-weight: inherit;
+            line-height: inherit;
+          }
+        }
+    </style>
+</head>
+<body>
+<table role="presentation" border="0" cellpadding="0" cellspacing="0" class="body">
+    <tr>
+        <td>&nbsp;</td>
+        <td class="container">
+            <div class="content">
+                <!-- START CENTERED WHITE CONTAINER -->
+                <table role="presentation" border="0" cellpadding="0" cellspacing="0" class="main">
+                    <!-- START MAIN CONTENT AREA -->
+                    <tr>
+                        <td class="wrapper">
+                            <p><img src="{image}"></p>
+                            <p>&nbsp;</p>
+                            <p><h3>Dear {name},</h3></p>
+                            <p> This is to inform you that an assessment :<strong> {assessmentName} </strong> with id:  <strong>{assessmentId}</strong>   has been published to Zenodo under deposit <strong>{depositId}</strong>
+                            <p> but the deposit in CAT service still seems unpublished. Please try to update the deposit state in CAT service.</p>
+                                <br><br>
+                                To view the deposit in Zenodo, click the link below:</p>
+                            <table role="presentation" border="0" cellpadding="0" cellspacing="0" class="btn btn-primary">
+                                <tbody>
+                                <tr>
+                                    <td align="left">
+                                        <table role="presentation" border="0" cellpadding="0" cellspacing="0">
+                                            <tbody>
+                                            <tr>
+                                                <td> <a href="{depositUrl}" target="_blank">View Deposit</a> </td>
+                                            </tr>
+                                            </tbody>
+                                        </table>
+                                    </td>
+                                </tr>
+                                </tbody>
+                            </table>
+                            <br>
+                            <p>Thank you, <br/>The FAIRCORE4EOSC Compliance Assessment Toolkit - CAT Team.</p>
+                            <p><h4>Partners</h4></p>
+                            <p>
+                                <img src="{image2}" alt="GRNET" height="40px">
+                                <img src="{image1}" alt="DANS" height="40px">
+                                <img src="{image4}" alt="gwdg" height="30px">
+                                <img src="{image3}" alt="DATACITE" height="30px">
+                            </p>
+                        </td>
+                    </tr>
+                    <!-- END MAIN CONTENT AREA -->
+                </table>
+                <!-- START FOOTER -->
+                <div class="footer">
+                    <table role="presentation" border="0" cellpadding="0" cellspacing="0" style="color:#DCDCDC">
+                        <tr>
+                            <td class="content-block">
+                                <span class="apple-link">The FAIRCORE4EOSC Compliance Assessment Toolkit - CAT Team</span>
+                                <br> Need more information? Contact us at <a href="mailto:{contactMail}">Info</a>.
+                            </td>
+                        </tr>
+                    </table>
+                </div>
+                <!-- END FOOTER -->
+                <!-- END CENTERED WHITE CONTAINER --></div>
+        </td>
+        <td>&nbsp;</td>
+    </tr>
+</table>
+</body>
+</html>

--- a/api/src/main/resources/templates/zenodo_publish_deposit_notification.html
+++ b/api/src/main/resources/templates/zenodo_publish_deposit_notification.html
@@ -1,0 +1,302 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+    <title>Assessment Shared</title>
+    <style media="all" type="text/css">
+        /* GLOBAL RESETS */
+        body {
+          font-family: Helvetica, sans-serif;
+          -webkit-font-smoothing: antialiased;
+          font-size: 16px;
+          line-height: 1.3;
+          -ms-text-size-adjust: 100%;
+          -webkit-text-size-adjust: 100%;
+        }
+        table {
+          border-collapse: separate;
+          mso-table-lspace: 0pt;
+          mso-table-rspace: 0pt;
+          width: 100%;
+        }
+        table td {
+          font-family: Helvetica, sans-serif;
+          font-size: 16px;
+          vertical-align: top;
+        }
+        body {
+          background-color: #f4f5f6;
+          margin: 0;
+          padding: 0;
+        }
+        .body {
+          background-color: #f4f5f6;
+          width: 100%;
+        }
+        .container {
+          margin: 0 auto !important;
+          max-width: 600px;
+          padding: 0;
+          padding-top: 24px;
+          width: 600px;
+        }
+        .content {
+          box-sizing: border-box;
+          display: block;
+          margin: 0 auto;
+          max-width: 600px;
+          padding: 0;
+        }
+        .main {
+          background: #ffffff;
+          border: 1px solid #eaebed;
+          border-radius: 16px;
+          width: 100%;
+        }
+        .wrapper {
+          box-sizing: border-box;
+          padding: 24px;
+        }
+        .footer {
+          clear: both;
+          padding-top: 24px;
+          text-align: center;
+          width: 100%;
+        }
+        .footer td,
+        .footer p,
+        .footer span,
+        .footer a {
+          color: #9a9ea6;
+          font-size: 16px;
+          text-align: center;
+        }
+        p {
+          font-family: Helvetica, sans-serif;
+          font-size: 16px;
+          font-weight: normal;
+          margin: 0;
+          margin-bottom: 16px;
+        }
+        a {
+          color: #0867ec;
+          text-decoration: underline;
+        }
+        .btn {
+          box-sizing: border-box;
+          min-width: 100% !important;
+          width: 100%;
+        }
+        .btn table {
+          width: auto;
+        }
+        .btn table td {
+          background-color: #ffffff;
+          border-radius: 4px;
+          text-align: center;
+        }
+        .btn a {
+          background-color: #ffffff;
+          border: solid 2px #0867ec;
+          border-radius: 4px;
+          box-sizing: border-box;
+          color: #0867ec;
+          cursor: pointer;
+          display: inline-block;
+          font-size: 16px;
+          font-weight: bold;
+          margin: 0;
+          padding: 12px 24px;
+          text-decoration: none;
+          text-transform: capitalize;
+        }
+        .btn-primary table td {
+          background-color: #0867ec;
+        }
+        .btn-primary a {
+          background-color: #0867ec;
+          border-color: #0867ec;
+          color: #ffffff;
+        }
+        @media all {
+          .btn-primary table td:hover {
+            background-color: #fed046 !important;
+            color: #000000;
+          }
+          .btn-primary a:hover {
+            background-color: #fed046 !important;
+            border-color: #fed046 !important;
+            color: #000000;
+          }
+        }
+        .last {
+          margin-bottom: 0;
+        }
+        .first {
+          margin-top: 0;
+        }
+        .align-center {
+          text-align: center;
+        }
+        .align-right {
+          text-align: right;
+        }
+        .align-left {
+          text-align: left;
+        }
+        .text-link {
+          color: #0867ec !important;
+          text-decoration: underline !important;
+        }
+        .clear {
+          clear: both;
+        }
+        .mt0 {
+          margin-top: 0;
+        }
+        .mb0 {
+          margin-bottom: 0;
+        }
+        .preheader {
+          color: transparent;
+          display: none;
+          height: 0;
+          max-height: 0;
+          max-width: 0;
+          opacity: 0;
+          overflow: hidden;
+          mso-hide: all;
+          visibility: hidden;
+          width: 0;
+        }
+        .powered-by a {
+          text-decoration: none;
+        }
+        @media only screen and (max-width: 640px) {
+          .main p,
+          .main td,
+          .main span {
+            font-size: 16px !important;
+          }
+          .wrapper {
+            padding: 8px !important;
+          }
+          .content {
+            padding: 0 !important;
+          }
+          .container {
+            padding: 0 !important;
+            padding-top: 8px !important;
+            width: 100% !important;
+          }
+          .main {
+            border-left-width: 0 !important;
+            border-radius: 0 !important;
+            border-right-width: 0 !important;
+          }
+          .btn table {
+            max-width: 100% !important;
+            width: 100% !important;
+          }
+          .btn a {
+            font-size: 16px !important;
+            max-width: 100% !important;
+            width: 100% !important;
+          }
+        }
+        @media all {
+          .ExternalClass {
+            width: 100%;
+          }
+          .ExternalClass,
+          .ExternalClass p,
+          .ExternalClass span,
+          .ExternalClass font,
+          .ExternalClass td,
+          .ExternalClass div {
+            line-height: 100%;
+          }
+          .apple-link a {
+            color: inherit !important;
+            font-family: inherit !important;
+            font-size: inherit !important;
+            font-weight: inherit !important;
+            line-height: inherit !important;
+            text-decoration: none !important;
+          }
+          #MessageViewBody a {
+            color: inherit;
+            text-decoration: none;
+            font-size: inherit;
+            font-family: inherit;
+            font-weight: inherit;
+            line-height: inherit;
+          }
+        }
+    </style>
+</head>
+<body>
+<table role="presentation" border="0" cellpadding="0" cellspacing="0" class="body">
+    <tr>
+        <td>&nbsp;</td>
+        <td class="container">
+            <div class="content">
+                <!-- START CENTERED WHITE CONTAINER -->
+                <table role="presentation" border="0" cellpadding="0" cellspacing="0" class="main">
+                    <!-- START MAIN CONTENT AREA -->
+                    <tr>
+                        <td class="wrapper">
+                            <p><img src="{image}"></p>
+                            <p>&nbsp;</p>
+                            <p><h3>Dear {name},</h3></p>
+                            <p> This is to inform you that the deposit with id:  <strong>{depositId}</strong> has been published to Zenodo.
+                                <br><br>
+                                To view the deposit, click the link below:</p>
+                            <table role="presentation" border="0" cellpadding="0" cellspacing="0" class="btn btn-primary">
+                                <tbody>
+                                <tr>
+                                    <td align="left">
+                                        <table role="presentation" border="0" cellpadding="0" cellspacing="0">
+                                            <tbody>
+                                            <tr>
+                                                <td> <a href="{depositUrl}" target="_blank">View Deposit</a> </td>
+                                            </tr>
+                                            </tbody>
+                                        </table>
+                                    </td>
+                                </tr>
+                                </tbody>
+                            </table>
+                            <br>
+                            <p>Thank you, <br/>The FAIRCORE4EOSC Compliance Assessment Toolkit - CAT Team.</p>
+                            <p><h4>Partners</h4></p>
+                            <p>
+                                <img src="{image2}" alt="GRNET" height="40px">
+                                <img src="{image1}" alt="DANS" height="40px">
+                                <img src="{image4}" alt="gwdg" height="30px">
+                                <img src="{image3}" alt="DATACITE" height="30px">
+                            </p>
+                        </td>
+                    </tr>
+                    <!-- END MAIN CONTENT AREA -->
+                </table>
+                <!-- START FOOTER -->
+                <div class="footer">
+                    <table role="presentation" border="0" cellpadding="0" cellspacing="0" style="color:#DCDCDC">
+                        <tr>
+                            <td class="content-block">
+                                <span class="apple-link">The FAIRCORE4EOSC Compliance Assessment Toolkit - CAT Team</span>
+                                <br> Need more information? Contact us at <a href="mailto:{contactMail}">Info</a>.
+                            </td>
+                        </tr>
+                    </table>
+                </div>
+                <!-- END FOOTER -->
+                <!-- END CENTERED WHITE CONTAINER --></div>
+        </td>
+        <td>&nbsp;</td>
+    </tr>
+</table>
+</body>
+</html>

--- a/api/src/test/java/org/grnet/cat/api/AssessmentsEndpointTest.java
+++ b/api/src/test/java/org/grnet/cat/api/AssessmentsEndpointTest.java
@@ -767,10 +767,7 @@ public class AssessmentsEndpointTest extends KeycloakTest {
 
     }
     @Test
-    public void getPublicAssessment() throws IOException {
-
-
-
+    public void getPublicAssessment() {
         var assessment = given()
                 .basePath("/v2/assessments")
                 .get("/public/{id}", publicAssessment.id)
@@ -781,6 +778,4 @@ public class AssessmentsEndpointTest extends KeycloakTest {
                 .as(UserJsonRegistryAssessmentResponse.class);
         assertEquals(assessment.id,publicAssessment.id);
     }
-
-
 }

--- a/data-transfer-object/src/main/java/org/grnet/cat/dtos/assessment/ZenodoAssessmentInfoResponse.java
+++ b/data-transfer-object/src/main/java/org/grnet/cat/dtos/assessment/ZenodoAssessmentInfoResponse.java
@@ -1,0 +1,64 @@
+package org.grnet.cat.dtos.assessment;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.Setter;
+import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
+@Schema(name = "ZenodoAssessmentInfoResponse", description = "Response DTO for assessment published to Zenodo")
+@Getter
+@Setter
+public class ZenodoAssessmentInfoResponse {
+    @Schema(
+            type = SchemaType.STRING,
+            implementation = String.class,
+            description = "ID of the Assessment published in Zenodo",
+            example = "pid_graph:12345"
+    )
+    private String assessmentId;
+    @Schema(
+            type = SchemaType.STRING,
+            implementation = String.class,
+            description = "ID of the deposit in Zenodo",
+            example = "14566"
+    )
+    private String depositId;
+
+    @Schema(
+            type = SchemaType.STRING,
+            implementation = String.class,
+            description = "Date and Time when the Assessment is published to Zenodo",
+            example = " 2023-06-09 12:19:31.333059"
+    )
+    @NotNull
+    @JsonProperty("published_at")
+    public String publishedAt;
+
+    @Schema(
+            type = SchemaType.STRING,
+            implementation = String.class,
+            description = "Date and Time when the Assessment is uploaded to Zenodo",
+            example = " 2023-06-09 12:19:31.333059"
+    )
+    @JsonProperty("uploaded_at")
+    public String uploadedAt;
+
+    @Schema(
+            type = SchemaType.BOOLEAN,
+            implementation = Boolean.class,
+            description = "Indicates that the Assessment has been published to Zenodo",
+            example = "true"
+    )
+    @JsonProperty("is_published")
+    public Boolean isPublished;
+
+    @Schema(
+            type = SchemaType.STRING,
+            implementation = String.class,
+            description = "Current state of the Zenodo deposit",
+            example = "PROCESS_INIT"
+    )
+    @JsonProperty("zenodo_state")
+    private String zenodoState; // New field to represent the state
+}

--- a/entity/src/main/java/org/grnet/cat/entities/ZenodoAssessmentInfo.java
+++ b/entity/src/main/java/org/grnet/cat/entities/ZenodoAssessmentInfo.java
@@ -1,0 +1,48 @@
+package org.grnet.cat.entities;
+
+import com.vladmihalcea.hibernate.type.json.JsonType;
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.Setter;
+import org.grnet.cat.enums.ZenodoState;
+
+import java.sql.Timestamp;
+/**
+ * This entity represents the Zenodo Info for an Assessment published.
+ *
+ */
+@Entity
+@Getter
+@Setter
+@Table(name = "ZenodoAssessmentInfo")
+public class ZenodoAssessmentInfo {
+
+    @EmbeddedId
+    private ZenodoAssessmentInfoId id;
+
+    @Column(name="is_published")
+    @NotNull
+    private  Boolean isPublished;
+
+    @Column(name = "uploaded_at")
+    @NotNull
+    private Timestamp uploadedAt;
+
+    @Column(name = "published_at")
+    private Timestamp publishedAt;
+
+    @ManyToOne
+    @MapsId("assessmentId")
+    @JoinColumn(name = "assessment_id", nullable = false)
+    private MotivationAssessment assessment;
+
+    @Enumerated(EnumType.STRING) // Persist the enum as a string
+    @Column(name = "zenodo_state")
+    private ZenodoState zenodoState;
+
+
+    public Boolean getPublished() {
+        return isPublished;
+    }
+}

--- a/entity/src/main/java/org/grnet/cat/entities/ZenodoAssessmentInfoId.java
+++ b/entity/src/main/java/org/grnet/cat/entities/ZenodoAssessmentInfoId.java
@@ -1,0 +1,58 @@
+package org.grnet.cat.entities;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+
+import java.io.Serializable;
+import java.util.Objects;
+
+@Embeddable
+public class ZenodoAssessmentInfoId implements Serializable {
+
+    @Column(name = "assessment_id")
+    private String assessmentId;
+
+    @Column(name = "deposit_id")  // <-- Correct column name mapping
+    private String depositId;
+
+    // Constructors
+    public ZenodoAssessmentInfoId() {
+    }
+
+    public ZenodoAssessmentInfoId(String assessmentId, String depositId) {
+        this.assessmentId = assessmentId;
+        this.depositId = depositId;
+    }
+
+    // Getters and Setters
+    public String getAssessmentId() {
+        return assessmentId;
+    }
+
+    public void setAssessmentId(String assessmentId) {
+        this.assessmentId = assessmentId;
+    }
+
+    public String getDepositId() {
+        return depositId;
+    }
+
+    public void setDepositId(String depositId) {
+        this.depositId = depositId;
+    }
+
+    // Equals and HashCode (Required for Embedded ID)
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        ZenodoAssessmentInfoId that = (ZenodoAssessmentInfoId) o;
+        return Objects.equals(assessmentId, that.assessmentId) &&
+                Objects.equals(depositId, that.depositId);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(assessmentId, depositId);
+    }
+}

--- a/entity/src/main/resources/db/migration/tables/assessment/V1.60__add_zenodo_assessment_info.sql
+++ b/entity/src/main/resources/db/migration/tables/assessment/V1.60__add_zenodo_assessment_info.sql
@@ -1,0 +1,16 @@
+-- ------------------------------------------------
+-- Version: v1.6
+--
+-- Description: Migration that introduces the Assessment table
+-- -------------------------------------------------
+CREATE TABLE ZenodoAssessmentInfo (
+    assessment_id VARCHAR(100) NOT NULL,
+    deposit_id VARCHAR(100) NOT NULL,
+    is_published BOOLEAN DEFAULT FALSE,
+    uploaded_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    published_at TIMESTAMP  DEFAULT CURRENT_TIMESTAMP,
+    zenodo_state VARCHAR(100) ,
+
+    PRIMARY KEY (assessment_id, deposit_id),
+    FOREIGN KEY (assessment_id) REFERENCES MotivationAssessment(id) ON DELETE CASCADE
+);

--- a/enum/src/main/java/org/grnet/cat/enums/MailType.java
+++ b/enum/src/main/java/org/grnet/cat/enums/MailType.java
@@ -122,11 +122,165 @@ public enum MailType {
                     .data("image4", templateParams.get("image4"))
                     .data("cat", templateParams.get("cat"))
                     .data("userrole", templateParams.get("userrole"))
-                    .data("name",templateParams.get("name"))
+                    .data("name", templateParams.get("name"))
                     .data("contactMail", templateParams.get("contactMail"))
                     .render();
 
             return new MailTemplate("[" + templateParams.get("title") + "] - Shared Assessment with name: " + templateParams.get("assessmentName"), body);
+        }
+        },
+    ZENODO_COMPLETED_PUBLISH_PROCESS {
+        public MailTemplate execute(Template emailTemplate, HashMap<String, String> templateParams) {
+
+            URL url;
+            String urlString = templateParams.get("depositUrl");
+            try {
+                url = new URL(urlString);
+            } catch (MalformedURLException e) {
+                throw new RuntimeException(e);
+            }
+
+            String body = emailTemplate.data("depositUrl", url.toString())
+                    .data("depositId", templateParams.get("depositId"))
+                    .data("assessmentName", templateParams.get("assessmentName"))
+
+                    .data("assessmentId", templateParams.get("assessmentId"))
+                    .data("image", templateParams.get("image"))
+                    .data("image1", templateParams.get("image1"))
+                    .data("image2", templateParams.get("image2"))
+                    .data("image3", templateParams.get("image3"))
+                    .data("image4", templateParams.get("image4"))
+                    .data("name",templateParams.get("name"))
+                    .data("contactMail", templateParams.get("contactMail"))
+                    .render();
+
+            return new MailTemplate("[" + templateParams.get("title") + "] - Completed Process to Publish to Zenodo : " + templateParams.get("assessmentName"), body);
+        }
+    },
+    ZENODO_DRAFT_DEPOSIT {
+        public MailTemplate execute(Template emailTemplate, HashMap<String, String> templateParams) {
+
+            URL url;
+            String urlString = templateParams.get("depositUrl");
+            try {
+                url = new URL(urlString);
+            } catch (MalformedURLException e) {
+                throw new RuntimeException(e);
+            }
+
+            String body = emailTemplate.data("depositUrl", url.toString())
+                    .data("depositId", templateParams.get("depositId"))
+                    .data("assessmentName", templateParams.get("assessmentName"))
+
+                    .data("assessmentId", templateParams.get("assessmentId"))
+                    .data("image", templateParams.get("image"))
+                    .data("image1", templateParams.get("image1"))
+                    .data("image2", templateParams.get("image2"))
+                    .data("image3", templateParams.get("image3"))
+                    .data("image4", templateParams.get("image4"))
+                    .data("name",templateParams.get("name"))
+                    .data("contactMail", templateParams.get("contactMail"))
+                    .render();
+
+            return new MailTemplate("[" + templateParams.get("title") + "] - Uploaded Assessment to Zenodo in draft state " + templateParams.get("assessmentName"), body);
+        }
+    },
+        ZENODO_PUBLISH_ASSESSMENT {
+            public MailTemplate execute(Template emailTemplate, HashMap<String, String> templateParams) {
+
+                URL url;
+                String urlString = templateParams.get("depositUrl");
+                try {
+                    url = new URL(urlString);
+                } catch (MalformedURLException e) {
+                    throw new RuntimeException(e);
+                }
+
+                String body = emailTemplate.data("depositUrl", url.toString())
+                        .data("depositId", templateParams.get("depositId"))
+                        .data("assessmentName", templateParams.get("assessmentName"))
+
+                        .data("assessmentId", templateParams.get("assessmentId"))
+                        .data("image", templateParams.get("image"))
+                        .data("image1", templateParams.get("image1"))
+                        .data("image2", templateParams.get("image2"))
+                        .data("image3", templateParams.get("image3"))
+                        .data("image4", templateParams.get("image4"))
+                        .data("name",templateParams.get("name"))
+                        .data("contactMail", templateParams.get("contactMail"))
+                        .render();
+
+                return new MailTemplate("[" + templateParams.get("title") + "] - Publish to Zenodo : " + templateParams.get("assessmentName"), body);
+            }
+    },
+    ZENODO_PUBLISH_DEPOSIT {
+        public MailTemplate execute(Template emailTemplate, HashMap<String, String> templateParams) {
+
+            URL url;
+            String urlString = templateParams.get("depositUrl");
+            try {
+                url = new URL(urlString);
+            } catch (MalformedURLException e) {
+                throw new RuntimeException(e);
+            }
+
+            String body = emailTemplate.data("depositUrl", url.toString())
+                    .data("depositId", templateParams.get("depositId"))
+                    .data("image", templateParams.get("image"))
+                    .data("image1", templateParams.get("image1"))
+                    .data("image2", templateParams.get("image2"))
+                    .data("image3", templateParams.get("image3"))
+                    .data("image4", templateParams.get("image4"))
+                    .data("name",templateParams.get("name"))
+                    .data("contactMail", templateParams.get("contactMail"))
+                    .render();
+
+            return new MailTemplate("[" + templateParams.get("title") + "] -  Publish Deposit to Zenodo : " + templateParams.get("depositId"), body);
+        }
+    },
+    ZENODO_FAILED_PUBLISH_PROCESS {
+        public MailTemplate execute(Template emailTemplate, HashMap<String, String> templateParams) {
+
+
+            String body = emailTemplate
+                    .data("assessmentName", templateParams.get("assessmentName"))
+
+                    .data("assessmentId", templateParams.get("assessmentId"))
+                    .data("image", templateParams.get("image"))
+                    .data("image1", templateParams.get("image1"))
+                    .data("image2", templateParams.get("image2"))
+                    .data("image3", templateParams.get("image3"))
+                    .data("image4", templateParams.get("image4"))
+                    .data("name",templateParams.get("name"))
+                    .data("contactMail", templateParams.get("contactMail"))
+                    .render();
+
+            return new MailTemplate("[" + templateParams.get("title") + "] - Failed to Publish to Zenodo : " + templateParams.get("assessmentName"), body);
+        }
+    },
+    ZENODO_FAILED_PUBLISH_DEPOSIT {
+        public MailTemplate execute(Template emailTemplate, HashMap<String, String> templateParams) {
+
+            URL url;
+            String urlString = templateParams.get("depositUrl");
+            try {
+                url = new URL(urlString);
+            } catch (MalformedURLException e) {
+                throw new RuntimeException(e);
+            }
+
+            String body = emailTemplate.data("depositUrl", url.toString())
+                    .data("depositId", templateParams.get("depositId"))
+                    .data("image", templateParams.get("image"))
+                    .data("image1", templateParams.get("image1"))
+                    .data("image2", templateParams.get("image2"))
+                    .data("image3", templateParams.get("image3"))
+                    .data("image4", templateParams.get("image4"))
+                    .data("name",templateParams.get("name"))
+                    .data("contactMail", templateParams.get("contactMail"))
+                    .render();
+
+            return new MailTemplate("[" + templateParams.get("title") + "] -  Publish Deposit to Zenodo : " + templateParams.get("depositId"), body);
         }
     };
 

--- a/enum/src/main/java/org/grnet/cat/enums/ZenodoState.java
+++ b/enum/src/main/java/org/grnet/cat/enums/ZenodoState.java
@@ -1,0 +1,30 @@
+package org.grnet.cat.enums;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public enum ZenodoState {
+    PROCESS_INIT("PROCESS INIT"),
+    DEPOSIT_CREATED("DEPOSIT CREATED"),
+    FILE_UPLOADED_TO_DEPOSIT("FILE UPLOADED TO DEPOSIT"),
+    DEPOSIT_PUBLISHED("DEPOSIT PUBLISHED"),
+    PROCESS_COMPLETED("PROCESS COMPLETED INIT"),
+    PROCESS_FAILED("PROCESS FAILED");
+
+    private String type;
+
+    ZenodoState(String type) {
+        this.type = type;
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public static List<String> getTypes() {
+        return Arrays.stream(ZenodoState.values())
+                .map(ZenodoState::getType)
+                .collect(Collectors.toList());
+    }
+}

--- a/mapper/src/main/java/org/grnet/cat/mappers/AssessmentMapper.java
+++ b/mapper/src/main/java/org/grnet/cat/mappers/AssessmentMapper.java
@@ -3,6 +3,7 @@ package org.grnet.cat.mappers;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.enterprise.inject.spi.CDI;
+import jdk.jshell.execution.Util;
 import lombok.SneakyThrows;
 import org.grnet.cat.dtos.assessment.AssessmentDoc;
 import org.grnet.cat.dtos.assessment.AdminPartialJsonAssessmentResponse;
@@ -108,9 +109,9 @@ public interface AssessmentMapper {
     default Boolean isRegistryAssessmentSharedByUser(MotivationAssessment assessment, String userId) {
 
         var utility = CDI.current().select(Utility.class).get();
+
         var currentUser = utility.getUserUniqueIdentifier();
         var sameUser = currentUser.equals(userId); //user logged is same as user owning the assessment
-
         return assessment.getShared() && sameUser; //if the assessment is shared and the user is the owner, the assessment is shared by the user
     }
 
@@ -131,7 +132,6 @@ public interface AssessmentMapper {
     default Boolean isSharedToUser(String userId) {
 
         var utility = CDI.current().select(Utility.class).get();
-
         var currentUser = utility.getUserUniqueIdentifier();
 
         return !currentUser.equals(userId);
@@ -149,5 +149,20 @@ public interface AssessmentMapper {
     @Mapping(target = "published", source = "assessment.published")
 
     UserJsonRegistryAssessmentResponse publicUserRegistryAssessmentToJsonAssessment(MotivationAssessment assessment);
+
+
+
+    @Named("mapZenodoWithRegistryExpression")
+    @Mapping(target = "assessmentDoc", expression = "java(registryStringJsonToDto(assessment.getAssessmentDoc()))")
+    @Mapping(target = "validationId", expression = "java(assessment.getValidation().getId())")
+    @Mapping(target = "createdOn", expression = "java(assessment.getCreatedOn().toString())")
+    @Mapping(target = "userId", expression = "java(assessment.getValidation().getUser().getId())")
+    @Mapping(target = "updatedOn", expression = "java(assessment.getUpdatedOn() != null ? assessment.getUpdatedOn().toString() : \"\")")
+    @Mapping(target = "updatedBy", expression = "java(assessment.getUpdatedBy() != null ? assessment.getUpdatedBy() : \"\")")
+    @Mapping(target = "sharedToUser", expression = "java(!uniqueIdentifier.equals(assessment.getValidation().getUser().getId()))")
+    @Mapping(target = "sharedByUser", expression = "java(assessment.getShared() && assessment.getValidation() != null && assessment.getValidation().getUser() != null && uniqueIdentifier.equals(assessment.getValidation().getUser().getId()))")
+    @Mapping(target = "published", source = "assessment.published")
+
+    UserJsonRegistryAssessmentResponse zenodoUserRegistryAssessmentToJsonAssessment(MotivationAssessment assessment,String  uniqueIdentifier);
 
 }

--- a/mapper/src/main/java/org/grnet/cat/mappers/ZenodoAssessmentInfoMapper.java
+++ b/mapper/src/main/java/org/grnet/cat/mappers/ZenodoAssessmentInfoMapper.java
@@ -1,0 +1,34 @@
+package org.grnet.cat.mappers;
+
+import org.grnet.cat.dtos.assessment.ZenodoAssessmentInfoResponse;
+import org.grnet.cat.entities.ZenodoAssessmentInfo;
+import org.grnet.cat.enums.ZenodoState;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.factory.Mappers;
+
+import java.sql.Timestamp;
+import java.util.Objects;
+
+@Mapper(imports = {Objects.class})
+public interface ZenodoAssessmentInfoMapper {
+
+    ZenodoAssessmentInfoMapper INSTANCE = Mappers.getMapper(ZenodoAssessmentInfoMapper.class);
+
+    @Mapping(source = "id.assessmentId", target = "assessmentId")
+    @Mapping(source = "id.depositId", target = "depositId")
+    @Mapping(target = "publishedAt", expression = "java(mapTimestampToString(entity.getPublishedAt()))")
+    @Mapping(target = "uploadedAt", expression = "java(mapTimestampToString(entity.getUploadedAt()))")
+    @Mapping(target = "isPublished", expression = "java(entity.getPublished())")
+    @Mapping(target = "zenodoState", expression = "java(mapZenodoStateToString(entity.getZenodoState()))") // New mapping
+
+    ZenodoAssessmentInfoResponse zenodoAssessmentInfoToResponse(ZenodoAssessmentInfo entity);
+
+    default String mapTimestampToString(Timestamp timestamp) {
+        return timestamp != null ? timestamp.toInstant().toString() : null;
+    }
+    // Updated method to return the custom string value
+    default String mapZenodoStateToString(ZenodoState state) {
+        return state != null ? state.getType() : null;  // Use getType() instead of name()
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -45,6 +45,11 @@
   <dependencyManagement>
     <dependencies>
       <dependency>
+        <groupId>org.jboss.resteasy</groupId>
+        <artifactId>resteasy-multipart-provider</artifactId>
+      </dependency>
+
+      <dependency>
         <groupId>${quarkus.platform.group-id}</groupId>
         <artifactId>${quarkus.platform.artifact-id}</artifactId>
         <version>${quarkus.platform.version}</version>

--- a/repository/src/main/java/org/grnet/cat/repositories/ZenodoAssessmentInfoRepository.java
+++ b/repository/src/main/java/org/grnet/cat/repositories/ZenodoAssessmentInfoRepository.java
@@ -1,0 +1,42 @@
+package org.grnet.cat.repositories;
+
+import io.quarkus.panache.common.Sort;
+import jakarta.enterprise.context.ApplicationScoped;
+import org.grnet.cat.entities.*;
+
+import java.util.Optional;
+
+@ApplicationScoped
+public class ZenodoAssessmentInfoRepository implements Repository<ZenodoAssessmentInfo, String> {
+
+    public Boolean isZenodoAssessmentPublished(String assessmentId, Boolean isPublished) {
+        return find("assessment.id = ?1 and isPublished = ?2", assessmentId, isPublished).firstResultOptional().isPresent();
+    }
+    // Custom method to fetch the latest uploadedAt and check if it's published
+    public Boolean isLatestAssessmentPublished(String assessmentId) {
+        // Query to get the latest ZenodoAssessmentInfo by uploadedAt for a given assessmentId
+        ZenodoAssessmentInfo latestAssessment = find("assessment.id = ?1 ORDER BY uploadedAt DESC", assessmentId)
+                .firstResult();
+
+        // If no record is found, return false (or handle as needed)
+        if (latestAssessment == null) {
+            return false;  // or throw exception or return Optional
+        }
+
+        // Return the published status of the latest assessment
+        return latestAssessment.getIsPublished();
+    }
+    // Get the latest ZenodoAssessmentInfo for a given assessmentId, ordered by uploadedAt descending
+    public Optional<ZenodoAssessmentInfo> getAssessmentByAsessmentId(String assessmentId) {
+        return find("assessment.id = ?1", Sort.by("uploadedAt", Sort.Direction.Descending), assessmentId).firstResultOptional();
+    }
+    // Get the latest ZenodoAssessmentInfo for a given assessmentId, ordered by uploadedAt descending
+    public Optional<ZenodoAssessmentInfo> getAssessmentByDepositId(String depositId) {
+        return find("id.depositId = ?1", Sort.by("uploadedAt", Sort.Direction.Descending), depositId).firstResultOptional();
+    }
+
+    public Optional<ZenodoAssessmentInfo> getAssessmentByDepositIdAndAssessmentId( String depositId,String assessmentId) {
+        return find("id.depositId = ?1 and id.assessmentId = ?2", Sort.by("uploadedAt", Sort.Direction.Descending), depositId,assessmentId).firstResultOptional();
+    }
+
+}

--- a/service/pom.xml
+++ b/service/pom.xml
@@ -13,6 +13,12 @@
     <version>${revision}</version>
     <name>cat-services</name>
     <dependencies>
+            <!-- REST Client with Jackson for JSON processing -->
+            <dependency>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-rest-client-reactive-jackson</artifactId>
+            </dependency>
+
         <dependency>
             <groupId>org.grnet</groupId>
             <artifactId>cat-repositories</artifactId>
@@ -47,7 +53,7 @@
             <artifactId>quarkus-mailpit</artifactId>
             <version>0.0.9</version>
         </dependency>
-    </dependencies>
+  </dependencies>
 
     <build>
         <plugins>

--- a/service/src/main/java/org/grnet/cat/services/MailerService.java
+++ b/service/src/main/java/org/grnet/cat/services/MailerService.java
@@ -38,6 +38,9 @@ public class MailerService {
     UserRepository userRepository;
     @ConfigProperty(name = "api.ui.url")
     String uiBaseUrl;
+    @ConfigProperty(name = "quarkus.rest-client.\"org.grnet.cat.services.zenodo.ZenodoClient\".url")
+    String zenodoUrl;
+
     @ConfigProperty(name = "api.server.url")
     String serviceUrl;
 
@@ -59,8 +62,24 @@ public class MailerService {
     @Inject
     @Location("shared_assessment_notification")
     Template userSharedAssessmentTemplate;
-    private static final Logger LOG = Logger.getLogger(MailerService.class);
-
+    @Inject
+    @Location("zenodo_publish_assessment_notification")
+    Template zenodoPublishAssessment;
+    @Inject
+    @Location("zenodo_completed_publish_process_notification")
+    Template zenodoCompletedPublishProcess;
+    @Inject
+    @Location("zenodo_publish_deposit_notification")
+    Template zenodoPublishDeposit;
+    @Inject
+    @Location("zenodo_failed_publish_process_notification")
+    Template zenodoFailedPublishProcess;
+    @Inject
+    @Location("zenodo_draft_deposit_notification")
+    Template zenodoDraftDeposit;
+    @Inject
+    @Location("zenodo_failed_publish_deposit_notification")
+    Template zenodoFailedPublishDeposit;
     @Inject
     KeycloakAdminRepository keycloakAdminRepository;
     @ConfigProperty(name = "api.keycloak.user.id")
@@ -68,6 +87,7 @@ public class MailerService {
 
     @ConfigProperty(name = "api.name")
     String apiName;
+    private static final Logger LOG = Logger.getLogger(MailerService.class);
 
     public List<String> retrieveAdminEmails() {
 
@@ -142,7 +162,79 @@ public class MailerService {
         }
     }
 
+    public void sendMails(MotivationAssessment assessment,String depositId, String name,MailType type, List<String> mailAddrs) {
 
+        HashMap<String, String> templateParams = new HashMap<>();
+        templateParams.put("contactMail", contactMail);
+        templateParams.put("image", serviceUrl + "/v1/images/logo.png");
+        templateParams.put("image1", serviceUrl + "/v1/images/logo-dans.png");
+        templateParams.put("image2", serviceUrl + "/v1/images/logo-grnet.png");
+        templateParams.put("image3", serviceUrl + "/v1/images/logo-datacite.png");
+        templateParams.put("image4", serviceUrl + "/v1/images/logo-gwdg.png");
+        templateParams.put("name", name);
+        templateParams.put("title", apiName.toUpperCase());
+
+        switch (type) {
+            case ZENODO_DRAFT_DEPOSIT:
+                templateParams.put("depositUrl", zenodoUrl + "/uploads/" + depositId);
+                templateParams.put("depositId", depositId);
+
+                templateParams.put("assessmentName", extractAssessmentName(assessment.getAssessmentDoc()));
+                templateParams.put("assessmentId", assessment.getId());
+
+                LOG.info("zenodo publish assessment Template parameters: " + templateParams);
+
+                notifyUser(zenodoDraftDeposit, templateParams, mailAddrs, type);
+                break;
+
+            case ZENODO_COMPLETED_PUBLISH_PROCESS:
+                templateParams.put("depositUrl", zenodoUrl + "/records/" + depositId);
+                templateParams.put("depositId", depositId);
+
+                templateParams.put("assessmentName", extractAssessmentName(assessment.getAssessmentDoc()));
+                templateParams.put("assessmentId", assessment.getId());
+
+                LOG.info("zenodo publish assessment Template parameters: " + templateParams);
+
+                notifyUser(zenodoCompletedPublishProcess, templateParams, mailAddrs, type);
+                break;
+
+            case ZENODO_PUBLISH_ASSESSMENT:
+                templateParams.put("depositUrl", zenodoUrl + "/records/" + depositId);
+                templateParams.put("depositId", depositId);
+
+                templateParams.put("assessmentName", extractAssessmentName(assessment.getAssessmentDoc()));
+                templateParams.put("assessmentId", assessment.getId());
+
+                LOG.info("Template parameters: " + templateParams);
+                notifyUser(zenodoPublishAssessment, templateParams, mailAddrs, type);
+                break;
+            case ZENODO_PUBLISH_DEPOSIT:
+                templateParams.put("depositUrl", zenodoUrl + "/records/" + depositId);
+                templateParams.put("depositId", depositId);
+
+                LOG.info("Template parameters: " + templateParams);
+                notifyUser(zenodoPublishDeposit, templateParams, mailAddrs, type);
+                break;
+            case ZENODO_FAILED_PUBLISH_PROCESS:
+                templateParams.put("assessmentName", extractAssessmentName(assessment.getAssessmentDoc()));
+                templateParams.put("assessmentId", assessment.getId());
+
+                LOG.info("Template parameters: " + templateParams);
+                notifyUser(zenodoFailedPublishProcess, templateParams, mailAddrs, type);
+                break;
+            case ZENODO_FAILED_PUBLISH_DEPOSIT:
+                templateParams.put("depositUrl", zenodoUrl + "/records/" + depositId);
+                templateParams.put("depositId", depositId);
+
+                LOG.info("Template parameters: " + templateParams);
+                notifyUser(zenodoFailedPublishDeposit, templateParams, mailAddrs, type);
+                break;
+
+            default:
+                break;
+        }
+    }
 
     public Mail buildEmail(Template emailTemplate, HashMap<String, String> templateParams, MailType mailType) {
 
@@ -153,7 +245,8 @@ public class MailerService {
         return mail;
     }
 
-    private void notifyUser(Template emailTemplate, HashMap<String, String> templateParams, List<String> mailAddrs, MailType mailType) {
+    private void notifyUser(Template
+                                    emailTemplate, HashMap<String, String> templateParams, List<String> mailAddrs, MailType mailType) {
 
 
         var mail = buildEmail(emailTemplate, templateParams, mailType);
@@ -167,7 +260,8 @@ public class MailerService {
         }
     }
 
-    private void notifyAdmins(Template emailTemplate, HashMap<String, String> templateParams, List<String> mailAddrs) {
+    private void notifyAdmins(Template
+                                      emailTemplate, HashMap<String, String> templateParams, List<String> mailAddrs) {
 
         var mail = buildEmail(emailTemplate, templateParams, MailType.ADMIN_ALERT_NEW_VALIDATION);
         mail.setBcc(mailAddrs);

--- a/service/src/main/java/org/grnet/cat/services/zenodo/ZenodoClient.java
+++ b/service/src/main/java/org/grnet/cat/services/zenodo/ZenodoClient.java
@@ -1,0 +1,42 @@
+package org.grnet.cat.services.zenodo;
+
+import jakarta.ws.rs.*;
+import jakarta.ws.rs.core.MediaType;
+import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
+
+import java.util.List;
+import java.util.Map;
+
+
+@RegisterRestClient
+@Produces(MediaType.APPLICATION_JSON)
+@Consumes(MediaType.APPLICATION_JSON)
+public interface ZenodoClient {
+
+    @POST
+    @Path("/api/deposit/depositions")
+    Map<String, Object> createDeposit(@HeaderParam("Authorization") String token, Map<String, Object> emptyBody) throws WebApplicationException, ProcessingException;
+
+    @PUT
+    @Path("/api/deposit/depositions/{id}")
+    Map<String, Object> updateMetadata(@HeaderParam("Authorization") String token, @PathParam("id") String id, Map<String, Object> metadata) throws WebApplicationException, ProcessingException;
+
+    @POST
+    @Path("/api/deposit/depositions/{id}/actions/publish")
+    Map<String, Object> publishDeposit(@HeaderParam("Authorization") String token, @PathParam("id") String id) throws WebApplicationException, ProcessingException;
+
+    @GET
+    @Path("/api/deposit/depositions")
+    List<Map<String, Object>> listDeposits(@HeaderParam("Authorization") String token);
+
+    @DELETE
+    @Path("/api/deposit/depositions/{id}")
+    Map<String, Object> deleteDeposit(@HeaderParam("Authorization") String token, @PathParam("id") String id) throws WebApplicationException, ProcessingException;
+
+    @POST
+    @Path("/api/deposit/depositions/{id}/files")
+    @Consumes(MediaType.MULTIPART_FORM_DATA)
+    @Produces(MediaType.APPLICATION_JSON)
+    Map<String, Object> uploadFile(@HeaderParam("Authorization") String token, @PathParam("id") String depositionId, byte[] fileBytes, @HeaderParam("Content-Type") String contentType) throws WebApplicationException, ProcessingException;
+
+}

--- a/service/src/main/java/org/grnet/cat/services/zenodo/ZenodoService.java
+++ b/service/src/main/java/org/grnet/cat/services/zenodo/ZenodoService.java
@@ -1,0 +1,392 @@
+package org.grnet.cat.services.zenodo;
+
+import io.quarkus.hibernate.validator.runtime.interceptor.MethodValidated;
+import io.quarkus.logging.Log;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.context.control.ActivateRequestContext;
+import jakarta.inject.Inject;
+import jakarta.transaction.Transactional;
+import jakarta.ws.rs.NotFoundException;
+import jakarta.ws.rs.ProcessingException;
+import jakarta.ws.rs.WebApplicationException;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.eclipse.microprofile.rest.client.inject.RestClient;
+import org.grnet.cat.constraints.ValidZenodoAction;
+import org.grnet.cat.dtos.assessment.ZenodoAssessmentInfoResponse;
+import org.grnet.cat.dtos.assessment.registry.UserJsonRegistryAssessmentResponse;
+import org.grnet.cat.entities.MotivationAssessment;
+import org.grnet.cat.entities.User;
+import org.grnet.cat.entities.ZenodoAssessmentInfo;
+import org.grnet.cat.entities.ZenodoAssessmentInfoId;
+import org.grnet.cat.enums.MailType;
+import org.grnet.cat.enums.ShareableEntityType;
+import org.grnet.cat.enums.ZenodoState;
+import org.grnet.cat.mappers.AssessmentMapper;
+import org.grnet.cat.mappers.ZenodoAssessmentInfoMapper;
+import org.grnet.cat.repositories.MotivationAssessmentRepository;
+import org.grnet.cat.repositories.UserRepository;
+import org.grnet.cat.repositories.ZenodoAssessmentInfoRepository;
+import org.grnet.cat.services.KeycloakAdminService;
+import org.grnet.cat.services.MailerService;
+import org.grnet.cat.services.interceptors.ShareableEntity;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.util.*;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.grnet.cat.services.KeycloakAdminService.ENTITLEMENTS_DELIMITER;
+
+@ApplicationScoped
+@MethodValidated
+public class ZenodoService {
+
+    @Inject
+    @RestClient
+    ZenodoClient zenodoClient;
+
+
+    @ConfigProperty(name = "zenodo.api.key")
+    String API_KEY;
+
+
+    @Inject
+    MotivationAssessmentRepository motivationAssessmentRepository;
+
+    @Inject
+    UserRepository userRepository;
+    @Inject
+    KeycloakAdminService keycloakAdminService;
+
+    @Inject
+    ZenodoAssessmentInfoRepository zenodoAssessmentInfoRepository;
+    private final ExecutorService executorService = Executors.newFixedThreadPool(2); // Adjust as needed
+
+
+    public String getAccessToken() {
+        return "Bearer " + API_KEY;
+    }
+
+    @Inject
+    MailerService mailerService;
+
+
+    @ShareableEntity(type = ShareableEntityType.ASSESSMENT, id = String.class)
+    @Transactional
+    public String publishAssessment(
+            @ValidZenodoAction(repository = MotivationAssessmentRepository.class, message = "Action not permitted for assessment: ")
+            String assessmentId, byte[] binaryContent, String userId) {
+        long initStart = System.currentTimeMillis();
+
+        var assessment = motivationAssessmentRepository.findById(assessmentId);
+        if (assessment == null) {
+            throw new NotFoundException("Assessment not found for ID: " + assessmentId);
+        }
+
+        var zenodoAssessmentInfoOpt = zenodoAssessmentInfoRepository.getAssessmentByAsessmentId(assessmentId);
+        if (zenodoAssessmentInfoOpt.isPresent()) {
+            String isPublished = zenodoAssessmentInfoOpt.get().getIsPublished() ? "PUBLISHED" : "DRAFT";
+            throw new RuntimeException("Assessment with ID: " + assessmentId + " is already in Zenodo under deposit with ID: " + zenodoAssessmentInfoOpt.get().getId().getDepositId() + " and it's publication status is: " + isPublished);
+        }
+        var activeUser = userRepository.fetchUser(userId);
+        List<String> sharedUserIds = keycloakAdminService.getIdsOfSharedUsers(
+                ShareableEntityType.ASSESSMENT.getValue().concat(ENTITLEMENTS_DELIMITER).concat(assessment.getId())
+        );
+
+
+        CompletableFuture.runAsync(() -> {
+            try {
+                // Call the method to run the steps asynchronously
+                runStepsInSequence(assessment, binaryContent, activeUser, sharedUserIds)
+                        .join(); // Ensures the process completes in the background
+            } catch (Exception e) {
+                // Log the error but do not affect the user response
+                System.err.println("Error in async publishing process: " + e.getMessage());
+            }
+        });
+        return "Process of uploading assessment with ID: " + assessmentId + "  has started, it may take some time.. " +
+                "You will be informed via email when assessment is uploaded to zenodo. ";
+
+    }
+
+    @ShareableEntity(type = ShareableEntityType.ASSESSMENT, id = String.class)
+    @Transactional
+    public ZenodoAssessmentInfoResponse getAssessment(String assessmentId) throws IOException, InterruptedException {
+
+
+        var assessmentOpt = zenodoAssessmentInfoRepository.getAssessmentByAsessmentId(assessmentId);
+        if (assessmentOpt.isEmpty()) {
+            throw new RuntimeException("Assessment not found in zenodo for ID: " + assessmentId);
+        }
+
+        return ZenodoAssessmentInfoMapper.INSTANCE.zenodoAssessmentInfoToResponse(assessmentOpt.get());
+    }
+
+    private void uploadFile(MotivationAssessment assessment, byte[] binaryContent, String depositId) throws IOException {
+        File tempFile = new File(assessment.getId());
+        try (FileOutputStream fos = new FileOutputStream(tempFile)) {
+            fos.write(binaryContent);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+        // Step 3: Upload file to Zenodo
+        upload(tempFile, String.valueOf(depositId));
+
+    }
+
+    //public CompletableFuture<Void> runStepsInSequence(Map<String, Object> metadata, MotivationAssessment assessment, byte[] binaryContent, String userName, String userEmail,User activeUser) {
+    public CompletableFuture<Void> runStepsInSequence(MotivationAssessment assessment, byte[] binaryContent, User activeUser, List<String> sharedUsersIds) {
+        final AtomicReference<ZenodoState> state = new AtomicReference<>(ZenodoState.PROCESS_INIT);
+        final AtomicReference<String> depositIdRef = new AtomicReference<>(null);
+        final AtomicReference<ZenodoAssessmentInfo> zenodoAssessmentInfoRef = new AtomicReference<>(null);
+        //  final AtomicReference<User> activeUserRef = new AtomicReference<>(activeUser);
+
+        return CompletableFuture
+                .supplyAsync(() -> {
+                    // Step 1: Preparation of assessment for Zenodo
+                    System.out.println("Step 1: Preparing assessment for Zenodo...");
+                    var metadata = createMetadata(assessment, activeUser, sharedUsersIds);
+
+                    var response = createDeposit(metadata);
+                    var depositId = response.get("id");
+                    if (depositId == null) {
+                        throw new RuntimeException("Failed to create deposit in Zenodo for assessment ID: " + assessment.getId());
+                    }
+                    depositIdRef.set(String.valueOf(depositId));
+                    return depositId;
+                }, executorService)
+                .thenApply(depositId -> {
+                    // Step 2: Upload to Zenodo
+                    state.set(ZenodoState.DEPOSIT_CREATED);
+
+                    System.out.println("Step 2: Uploading to Zenodo...");
+                    try {
+                        uploadFile(assessment, binaryContent, depositIdRef.get());
+                        return depositId;
+                    } catch (IOException e) {
+
+                        zenodoClient.deleteDeposit(getAccessToken(), depositIdRef.get()); // Cleanup
+                        state.set(ZenodoState.PROCESS_FAILED);
+
+                        throw new RuntimeException("Error uploading file to Zenodo: " + e.getMessage());
+                    }
+                })
+                .thenApply(depositId -> {
+                    // Step 3: Write to database BEFORE publishing
+                    state.set(ZenodoState.FILE_UPLOADED_TO_DEPOSIT);
+
+                    System.out.println("Step 3: Writing to DB before publishing...");
+                    try {
+                        var zenodoAssessmentInfo = createInDatabase(assessment, depositIdRef.get(), state.get());
+                        zenodoAssessmentInfoRef.set(zenodoAssessmentInfo);
+                        return depositId;
+                    } catch (Exception dbException) {
+                        System.err.println("DB write failed, rolling back Zenodo deposit...");
+                        zenodoClient.deleteDeposit(getAccessToken(), depositIdRef.get()); // Cleanup
+                        state.set(ZenodoState.PROCESS_FAILED);
+                        mailerService.sendMails(assessment, depositIdRef.get(), activeUser.getName(), MailType.ZENODO_FAILED_PUBLISH_PROCESS, List.of(activeUser.getEmail()));
+
+                        throw new RuntimeException("DB write failed, rolling back deposit: " + dbException.getMessage());
+                    }
+                })
+                .thenApply(depositId -> {
+                    // Step 4: Publish deposit only after DB write succeeds
+                    System.out.println("Step 4: Publishing deposit...");
+                    publishDeposit(depositIdRef.get());
+                    //publishDeposit(null);
+
+                    return depositId;
+                })
+                .thenAccept(depositId -> {
+                    // Final step: Send notification if everything succeeded
+                    state.set(ZenodoState.DEPOSIT_PUBLISHED);
+
+                    var zenodoAssessmentInfo = updateInDatabase(zenodoAssessmentInfoRef.get());
+
+                    zenodoAssessmentInfoRef.set(zenodoAssessmentInfo);
+                    state.set(ZenodoState.PROCESS_COMPLETED);
+                    if (state.get().equals(ZenodoState.DEPOSIT_PUBLISHED)) {
+                        mailerService.sendMails(assessment, depositIdRef.get(), activeUser.getName(), MailType.ZENODO_PUBLISH_ASSESSMENT, List.of(activeUser.getEmail()));
+                        System.out.println("Step 5: Email sent successfully...");
+                    } else if (state.get().equals(ZenodoState.PROCESS_COMPLETED)) {
+                        mailerService.sendMails(assessment, depositIdRef.get(), activeUser.getName(), MailType.ZENODO_COMPLETED_PUBLISH_PROCESS, List.of(activeUser.getEmail()));
+                        System.out.println("Step 5: Email sent successfully...");
+                    }
+                })
+                .exceptionally(ex -> {
+                    // Handle any failures in previous steps
+                    if (state.get() != ZenodoState.DEPOSIT_PUBLISHED && state.get() != ZenodoState.FILE_UPLOADED_TO_DEPOSIT) { // Only delete if not yet published, when process fails during create deposit, upload file
+                        state.set(ZenodoState.PROCESS_FAILED);
+                        if (depositIdRef.get() != null) {
+                            zenodoClient.deleteDeposit(getAccessToken(), depositIdRef.get());
+                        }
+                        mailerService.sendMails(assessment, null, activeUser.getName(), MailType.ZENODO_FAILED_PUBLISH_PROCESS, List.of(activeUser.getEmail()));
+                    } else if (state.get() == ZenodoState.FILE_UPLOADED_TO_DEPOSIT) { //the process has failed when try to publish the deposit, the deposit remains in draft state in zenodo
+                        mailerService.sendMails(assessment, depositIdRef.get(), activeUser.getName(), MailType.ZENODO_DRAFT_DEPOSIT, List.of(activeUser.getEmail()));
+                    } else { //the process fails when trying to update the database , the deposit is published but this info does not appear in db
+                        mailerService.sendMails(assessment, depositIdRef.get(), activeUser.getName(), MailType.ZENODO_PUBLISH_ASSESSMENT, List.of(activeUser.getEmail()));
+
+                    }
+                    return null;
+                });
+
+    }
+
+
+    @Transactional
+    public ZenodoAssessmentInfo updateInDatabase(ZenodoAssessmentInfo zenodoAssessmentInfo) {
+        var managedAssessment = zenodoAssessmentInfoRepository.getAssessmentByDepositIdAndAssessmentId(zenodoAssessmentInfo.getId().getDepositId(), zenodoAssessmentInfo.getId().getAssessmentId());
+        if (managedAssessment.isEmpty()) {
+            return null;
+        }
+        zenodoAssessmentInfo = managedAssessment.get();
+
+        zenodoAssessmentInfo.setPublishedAt(Timestamp.from(Instant.now()));
+        zenodoAssessmentInfo.setIsPublished(Boolean.TRUE);
+        zenodoAssessmentInfo.setZenodoState(ZenodoState.PROCESS_COMPLETED);
+        zenodoAssessmentInfoRepository.persist(zenodoAssessmentInfo);
+        return zenodoAssessmentInfo;
+    }
+
+
+    @Transactional
+    public ZenodoAssessmentInfo createInDatabase(MotivationAssessment assessment, String depositId, ZenodoState state) {
+
+        MotivationAssessment managedAssessment = motivationAssessmentRepository.findById(assessment.getId());
+        if (managedAssessment != null) {
+            assessment = managedAssessment;
+        }
+        var zenodoAssessmentInfo = new ZenodoAssessmentInfo();
+
+
+        // Step 5: Persist to database
+        zenodoAssessmentInfo.setAssessment(assessment);
+        zenodoAssessmentInfo.setIsPublished(Boolean.FALSE);
+        zenodoAssessmentInfo.setUploadedAt(Timestamp.from(Instant.now()));
+        zenodoAssessmentInfo.setId(new ZenodoAssessmentInfoId(assessment.getId(), String.valueOf(depositId)));
+        zenodoAssessmentInfo.setZenodoState(state);
+        zenodoAssessmentInfoRepository.persist(zenodoAssessmentInfo);
+        return zenodoAssessmentInfo;
+    }
+
+
+    public void upload(File fileContent, String depositionId) throws IOException {
+
+        String boundary = UUID.randomUUID().toString();
+
+        // Build the multipart form body
+        StringBuilder bodyBuilder = new StringBuilder();
+        bodyBuilder.append("--").append(boundary).append("\r\n");
+        bodyBuilder.append("Content-Disposition: form-data; name=\"file\"; filename=\"").append(fileContent.getName()).append("\"\r\n");
+        bodyBuilder.append("Content-Type: application/pdf\r\n");  // Assuming it's a PDF, adjust if it's another type
+        bodyBuilder.append("\r\n");
+
+        // Convert the form data to byte array (the part before the file content)
+        byte[] formData = bodyBuilder.toString().getBytes();
+
+        // Prepare the file's binary content
+        byte[] fileBytes = Files.readAllBytes(fileContent.toPath());
+
+        // Ending boundary
+        String endingBoundary = "\r\n--" + boundary + "--\r\n";
+        byte[] endingBoundaryBytes = endingBoundary.getBytes();
+
+        // Combine form data, file data, and the ending boundary
+        byte[] requestBody = new byte[formData.length + fileBytes.length + endingBoundaryBytes.length];
+        System.arraycopy(formData, 0, requestBody, 0, formData.length);
+        System.arraycopy(fileBytes, 0, requestBody, formData.length, fileBytes.length);
+        System.arraycopy(endingBoundaryBytes, 0, requestBody, formData.length + fileBytes.length, endingBoundaryBytes.length);
+
+        // Upload the file by calling the Zenodo API method
+        Map<String, Object> response = zenodoClient.uploadFile(getAccessToken(), depositionId, requestBody, "multipart/form-data; boundary=" + boundary);
+        // Check the response and handle accordingly
+        if (response.containsKey("id")) {
+            Log.info("File uploaded successfully: " + response);
+        } else {
+            Log.info("Upload failed with response: " + response);
+        }
+
+        // Delete the file after upload (optional)
+        fileContent.delete();
+    }
+
+    public Map<String, Object> createDeposit(Map<String, Object> metadata) {
+        Map<String, Object> deposit = zenodoClient.createDeposit(getAccessToken(), metadata);
+
+        return deposit;
+    }
+
+    @Transactional
+    public Map<String, Object> publishDeposit(String depositId) {
+        try {
+            var response = zenodoClient.publishDeposit(getAccessToken(), depositId);
+            return response;
+        } catch (WebApplicationException e) {
+            throw new WebApplicationException(e.getMessage());
+        } catch (ProcessingException e) {
+            throw new ProcessingException(e.getMessage());
+        }
+    }
+
+    @Transactional
+    public Map<String, Object> createMetadata(MotivationAssessment assessment, User activeUser, List<String> sharedUsersIds) {
+        Map<String, Object> metadata = new HashMap<>();
+        var dbAssessmentToJson = AssessmentMapper.INSTANCE.zenodoUserRegistryAssessmentToJsonAssessment(assessment, activeUser.getId());
+        String title = generateTitle(dbAssessmentToJson);
+        String description = "Publishing assessment " + dbAssessmentToJson.assessmentDoc.name + " to Zenodo";
+        String uploadType = "dataset";
+
+        List<Map<String, String>> creators = new ArrayList<>();
+        List<Map<String, String>> contributors = new ArrayList<>();
+
+        // Add creator to the list
+        creators.add(createCreatorOrContributorMap(activeUser));
+
+        if (!sharedUsersIds.isEmpty()) {
+            var dbUsers = userRepository.fetchUsers(sharedUsersIds);
+            dbUsers.stream()
+                    .filter(dbUser -> !dbUser.getId().equals(activeUser.getId())) // Exclude main user
+                    .forEach(dbUser -> contributors.add(createCreatorOrContributorMap(dbUser, "editor")));
+        }
+        // Prepare metadata map
+        metadata.put("metadata", Map.of(
+                "title", title,
+                "upload_type", uploadType,
+                "description", description,
+                "creators", creators));
+        if (!contributors.isEmpty()) {
+            metadata.put("contributors", contributors);
+        }
+
+        return metadata;
+    }
+
+    private Map<String, String> createCreatorOrContributorMap(User user) {
+        return createCreatorOrContributorMap(user, "creator");
+    }
+
+    private Map<String, String> createCreatorOrContributorMap(User user, String type) {
+        Map<String, String> userMap = new HashMap<>();
+        userMap.put("name", user.getName() + " " + user.getSurname());
+        userMap.put("type", type);
+
+        if (user.getOrcidId() != null) {
+            userMap.put("orcid", user.getOrcidId());
+        }
+
+        return userMap;
+    }
+
+    private String generateTitle(UserJsonRegistryAssessmentResponse dbAssessmentToJson) {
+        return dbAssessmentToJson.assessmentDoc.name + "/"
+                + dbAssessmentToJson.assessmentDoc.organisation.name + "/"
+                + dbAssessmentToJson.assessmentDoc.actor.getName();
+    }
+}

--- a/validator/src/main/java/org/grnet/cat/constraints/ValidZenodoAction.java
+++ b/validator/src/main/java/org/grnet/cat/constraints/ValidZenodoAction.java
@@ -1,0 +1,21 @@
+package org.grnet.cat.constraints;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+import org.grnet.cat.repositories.Repository;
+import org.grnet.cat.validators.ValidZenodoActionValidator;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.PARAMETER, ElementType.FIELD, ElementType.METHOD}) // Add METHOD target
+@Retention(RetentionPolicy.RUNTIME)
+@Constraint(validatedBy = ValidZenodoActionValidator.class)
+public @interface ValidZenodoAction {
+    String message() default "Action not permitted";
+    Class<?>[] groups() default {};
+    Class<? extends Payload>[] payload() default {};
+    Class<? extends Repository<?, ?>> repository();
+}

--- a/validator/src/main/java/org/grnet/cat/validators/ValidZenodoActionValidator.java
+++ b/validator/src/main/java/org/grnet/cat/validators/ValidZenodoActionValidator.java
@@ -1,0 +1,58 @@
+package org.grnet.cat.validators;
+
+import jakarta.enterprise.inject.spi.CDI;
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+import org.grnet.cat.constraints.ValidZenodoAction;
+import org.grnet.cat.entities.MotivationAssessment;
+import org.grnet.cat.repositories.Repository;
+
+import java.util.Objects;
+
+public class ValidZenodoActionValidator implements ConstraintValidator<ValidZenodoAction, String> {
+
+    private String message;
+    private Class<? extends Repository<MotivationAssessment, String>> repository;
+
+    @Override
+    public void initialize(ValidZenodoAction constraintAnnotation) {
+        this.message = constraintAnnotation.message();
+        this.repository = (Class<? extends Repository<MotivationAssessment, String>>) constraintAnnotation.repository();
+    }
+
+    @Override
+    public boolean isValid(String value, ConstraintValidatorContext context) {
+        if (Objects.isNull(value)) {
+            return false; // invalid if value is null
+        }
+
+        // Fetch the repository instance
+        Repository<MotivationAssessment, String> repositoryInstance = CDI.current().select(this.repository).get();
+        MotivationAssessment assessment = repositoryInstance.findById(value);
+
+        // If no assessment is found, return false with a custom message
+        if (assessment == null) {
+            context.disableDefaultConstraintViolation();
+            context.buildConstraintViolationWithTemplate("Assessment not found: " + value)
+                    .addConstraintViolation();
+            return false;
+        }
+
+        // Check if the assessment is published and if the current user is one of the creators
+        boolean isPublished = Boolean.TRUE.equals(assessment.getPublished());
+
+        // Validation logic - only allow action if the assessment is published and user is a creator
+        if (!isPublished){// || !isCreator) {
+            context.disableDefaultConstraintViolation();
+            context.buildConstraintViolationWithTemplate(message + " " + value)
+                    .addConstraintViolation();
+            return false;
+        }
+
+        return true; // Valid if passed the checks
+    }
+
+    private String getCurrentUser() {
+        return "user@example.com"; // Replace with actual authentication logic
+    }
+}


### PR DESCRIPTION
Only published assessments in cat can be published
Only assessment creator or shared user can publish assessment
file should be pdf, in endpoint as binary, byte[]

We have the following statuses to define the steps in publish zenodo


PROCESS_INIT
DEPOSIT_CREATED
FILE_UPLOADED_TO_DEPOSIT
DEPOSIT_PUBLISHED
PROCESS_COMPLETED
PROCESS_FAILED


After each step is completed successfully , the state changes

Steps:     PROCESS_INIT  1. Create deposit to zenodo

                 DEPOSIT_CREATED   2. convert binary to pdf file and upload to deposit

                FILE_UPLOADED_TO_DEPOSIT  3. store in database in ZenodoAssessmentInfo table the information.
                 FILE_UPLOADED_TO_DEPOSIT  4. publish deposit
               DEPOSIT_PUBLISHED   5. update database ZenodoAssessmentInfo
               PROCESS_COMPLETED

if process fails at step 1 , step 2 or step 3 status changes to PROCESS_FAILED and a failed email is sent and deposit is deleted from zenodo (if created) as it is in draft state
if process fails at step 4 a mail is sent to notify that the deposit is created , the file is uploaded, and it is in draft state
if process fails at step 5 , a mail is sent to notify that the deposit is published but in cat service this information is not in sync, the deposit appears draft
if process succeeds at step 5 the process is completed and a mail is sent to inform that the process is completed successfully