### PR TITLE
CAT-856 Fix keycloak CORS policy towards 127.0.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,9 @@ According to [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) , the `Unr
 - [#470](https://github.com/FC4E-CAT/fc4e-cat-api/pull/470) CAT-836 Get deposit info from Zenodo 
 - [#471](https://github.com/FC4E-CAT/fc4e-cat-api/pull/471) CAT-830 Configure zenodo feature in cat
 
+### Fixed 
+- [#472](https://github.com/FC4E-CAT/fc4e-cat-api/pull/472) CAT-856 Fix keycloak CORS policy towards 127.0.0.1
+
 
 ## 1.9.2 - 2025-02-26
 ---

--- a/api/config/quarkus-realm.json
+++ b/api/config/quarkus-realm.json
@@ -551,7 +551,7 @@
       "webOrigins": [
         "http://localhost:3000",
         "http://localhost:8080",
-        "http://127.0.0.1:3000/*"
+        "http://127.0.0.1:3000"
       ],
       "notBefore": 0,
       "bearerOnly": false,


### PR DESCRIPTION
Fix keycloak > frontend client > web origins entry for 127.0.0.1:3000
