### PR TITLE
[CAT-859] Dynamically Update Tests When Fetching stored Assessment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,10 @@ According to [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) , the `Unr
 ## Unreleased
 ---
 
+### Added
+- [#475](https://github.com/FC4E-CAT/fc4e-cat-api/pull/475) CAT-859 Dynamically Update Tests When Fetching stored Assessment.
+
+
 ## 2.0.0 - 2025-03-31
 ---
 

--- a/api/src/main/java/org/grnet/cat/api/endpoints/AutomatedCheckEndpoint.java
+++ b/api/src/main/java/org/grnet/cat/api/endpoints/AutomatedCheckEndpoint.java
@@ -16,16 +16,10 @@ import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
 import org.eclipse.microprofile.openapi.annotations.security.SecurityRequirement;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
 import org.grnet.cat.api.filters.Registration;
-import org.grnet.cat.constraints.NotFoundEntity;
 import org.grnet.cat.dtos.*;
 import org.grnet.cat.enums.ArccTestType;
-import org.grnet.cat.enums.ValidationStatus;
-import org.grnet.cat.repositories.MotivationAssessmentRepository;
 import org.grnet.cat.services.ArccValidationService;
 import org.grnet.cat.services.AutomatedCheckService;
-
-import java.util.Arrays;
-import java.util.stream.Collectors;
 
 @Authenticated
 @Path("/v1/automated")

--- a/api/src/main/java/org/grnet/cat/api/endpoints/TemplatesEndpoint.java
+++ b/api/src/main/java/org/grnet/cat/api/endpoints/TemplatesEndpoint.java
@@ -91,7 +91,7 @@ public class TemplatesEndpoint {
                                         @Parameter(
                                                 description = "The Actor to retrieve template.",
                                                 required = true,
-                                                example = "pid_graph:E92B9B49",
+                                                example = "pid_graph:D42428D7",
                                                 schema = @Schema(type = SchemaType.STRING))
                                         @PathParam("actor-id") @Valid @NotFoundEntity(repository = RegistryActorRepository.class, message = "There is no Actor with the following id:") String actorId) {
 

--- a/api/src/main/java/org/grnet/cat/api/endpoints/registry/TestEndpoint.java
+++ b/api/src/main/java/org/grnet/cat/api/endpoints/registry/TestEndpoint.java
@@ -203,7 +203,7 @@ public class TestEndpoint {
                     schema = @Schema(type = SchemaType.STRING))
             @PathParam("id")
             @Valid @NotFoundEntity(repository = TestRepository.class, message = "There is no Test with the following id:") String id,
-            @Valid TestAndTestDefinitionUpdateRequest testUpdateDto) {
+            @Valid @NotNull(message = "The request body is empty.") TestAndTestDefinitionUpdateRequest testUpdateDto) {
 
         testService.updateTest(id, utility.getUserUniqueIdentifier(), testUpdateDto);
 

--- a/api/src/test/java/org/grnet/cat/api/registry/TestDefinitionEndpointTest.java
+++ b/api/src/test/java/org/grnet/cat/api/registry/TestDefinitionEndpointTest.java
@@ -99,7 +99,6 @@ public class TestDefinitionEndpointTest extends KeycloakTest {
 
     private TestDefinitionUpdateDto createTestDefinitionUpdateRequest(TestDefinitionRequestDto originalRequest) {
         var updateRequest = new TestDefinitionUpdateDto();
-        updateRequest.testMethodId = originalRequest.testMethodId;
         updateRequest.labelTestDefinition = "Updated confirmation of user authentication";
         updateRequest.paramType = "onscreen";
         updateRequest.testParams = "userAuth|updated_evidence";

--- a/api/src/test/java/org/grnet/cat/api/registry/TestEndpointTest.java
+++ b/api/src/test/java/org/grnet/cat/api/registry/TestEndpointTest.java
@@ -98,7 +98,6 @@ public class TestEndpointTest extends KeycloakTest {
         var testUpdate = new TestUpdateDto();
         var testDefUpdate = new TestDefinitionUpdateDto();
 
-        testUpdate.TES = createdTest.testResponse.TES + "-UPDATED";
         testUpdate.labelTest = "Updated Performance Test";
         testUpdate.descTest = "Updated description for performance test.";
 

--- a/data-transfer-object/src/main/java/org/grnet/cat/dtos/assessment/registry/MetricNodeDto.java
+++ b/data-transfer-object/src/main/java/org/grnet/cat/dtos/assessment/registry/MetricNodeDto.java
@@ -1,17 +1,14 @@
 package org.grnet.cat.dtos.assessment.registry;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.Setter;
-import org.grnet.cat.dtos.registry.template.Node;
 
 import java.util.List;
 
-@JsonPropertyOrder({ "id", "name", "type", "benchmark_value", "value", "result", "tests","label_algorithm_type","label_type_metric" })
+@JsonPropertyOrder({ "id", "name", "type", "benchmark_value", "label_algorithm_type","label_type_metric", "value", "result", "tests"})
 @Getter
 @Setter
 @AllArgsConstructor

--- a/data-transfer-object/src/main/java/org/grnet/cat/dtos/assessment/registry/RegistryAssessmentDto.java
+++ b/data-transfer-object/src/main/java/org/grnet/cat/dtos/assessment/registry/RegistryAssessmentDto.java
@@ -1,6 +1,5 @@
 package org.grnet.cat.dtos.assessment.registry;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
@@ -9,7 +8,6 @@ import org.grnet.cat.dtos.registry.template.RegistryTemplateMotivationDto;
 import org.grnet.cat.dtos.template.TemplateOrganisationDto;
 import org.grnet.cat.dtos.template.TemplateResultDto;
 import org.grnet.cat.dtos.template.TemplateSubjectDto;
-import org.junit.Ignore;
 
 import java.util.List;
 
@@ -40,7 +38,6 @@ public class RegistryAssessmentDto {
     @JsonProperty(value = "assessment_type")
     public RegistryTemplateMotivationDto motivation;
 
-//    @JsonIgnore
     public boolean published;
 
     public String timestamp = "";

--- a/data-transfer-object/src/main/java/org/grnet/cat/dtos/assessment/registry/TestNodeDto.java
+++ b/data-transfer-object/src/main/java/org/grnet/cat/dtos/assessment/registry/TestNodeDto.java
@@ -45,4 +45,5 @@ public class TestNodeDto {
     @JsonInclude(JsonInclude.Include.NON_NULL)
     private TestExtraInfoNodeDto lastRun;
 
+    private Boolean changed = Boolean.FALSE;
 }

--- a/data-transfer-object/src/main/java/org/grnet/cat/dtos/registry/test/TestDefinitionUpdateDto.java
+++ b/data-transfer-object/src/main/java/org/grnet/cat/dtos/registry/test/TestDefinitionUpdateDto.java
@@ -3,20 +3,8 @@ package org.grnet.cat.dtos.registry.test;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
-import org.grnet.cat.constraints.NotFoundEntity;
-import org.grnet.cat.repositories.registry.TestMethodRepository;
 
 public class TestDefinitionUpdateDto {
-
-    @Schema(
-            type = SchemaType.STRING,
-            implementation = String.class,
-            description = "The unique identifier of the test method",
-            example = "pid_graph:B733A7D5"
-    )
-    @JsonProperty("test_method_id")
-    @NotFoundEntity(repository = TestMethodRepository.class, message = "There is no Test Method with the following id:")
-    public String testMethodId;
 
     @Schema(
             type = SchemaType.STRING,

--- a/data-transfer-object/src/main/java/org/grnet/cat/dtos/registry/test/TestUpdateDto.java
+++ b/data-transfer-object/src/main/java/org/grnet/cat/dtos/registry/test/TestUpdateDto.java
@@ -10,16 +10,6 @@ public class TestUpdateDto {
     @Schema(
             type = SchemaType.STRING,
             implementation = String.class,
-            description = "The Test Name",
-            example = "T12"
-    )
-    @JsonProperty("tes")
-    @NotEmpty(message = "tes may not be empty.")
-    public String TES;
-
-    @Schema(
-            type = SchemaType.STRING,
-            implementation = String.class,
             description = "Label for the test",
             example = "PID Persistence - Service - Evidence"
     )

--- a/entity/src/main/java/org/grnet/cat/entities/registry/TestDefinition.java
+++ b/entity/src/main/java/org/grnet/cat/entities/registry/TestDefinition.java
@@ -69,6 +69,4 @@ public class TestDefinition {
 
     @Column(name = "dataType")
     private String dataType;
-
-
 }

--- a/mapper/src/main/java/org/grnet/cat/mappers/AssessmentMapper.java
+++ b/mapper/src/main/java/org/grnet/cat/mappers/AssessmentMapper.java
@@ -3,17 +3,20 @@ package org.grnet.cat.mappers;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.enterprise.inject.spi.CDI;
-import jdk.jshell.execution.Util;
 import lombok.SneakyThrows;
 import org.grnet.cat.dtos.assessment.AssessmentDoc;
 import org.grnet.cat.dtos.assessment.AdminPartialJsonAssessmentResponse;
 import org.grnet.cat.dtos.assessment.UserPartialJsonAssessmentResponse;
 import org.grnet.cat.dtos.assessment.registry.AdminJsonRegistryAssessmentResponse;
+import org.grnet.cat.dtos.assessment.registry.CriNodeDto;
 import org.grnet.cat.dtos.assessment.registry.RegistryAssessmentDto;
 import org.grnet.cat.dtos.assessment.registry.UserJsonRegistryAssessmentResponse;
 import org.grnet.cat.dtos.statistics.AssessmentPerActorDto;
 import org.grnet.cat.entities.AssessmentPerActor;
 import org.grnet.cat.entities.MotivationAssessment;
+import org.grnet.cat.repositories.registry.TestDefinitionRepository;
+import org.grnet.cat.repositories.registry.TestRepository;
+import org.grnet.cat.utils.TestParamsTransformer;
 import org.grnet.cat.utils.Utility;
 import org.mapstruct.IterableMapping;
 import org.mapstruct.Mapper;
@@ -23,7 +26,10 @@ import org.mapstruct.factory.Mappers;
 
 import java.sql.Timestamp;
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
 
 /**
  * The AssessmentMapper is responsible for mapping Assessment entities to DTOs.
@@ -91,7 +97,6 @@ public interface AssessmentMapper {
     @Mapping(target = "sharedToUser", expression = "java(isSharedToUser(assessment.getValidation().getUser().getId()))")
     @Mapping(target = "sharedByUser", expression = "java(isRegistryAssessmentSharedByUser(assessment, assessment.getValidation().getUser().getId()))")
     @Mapping(target = "published", source = "assessment.published")
-
     UserJsonRegistryAssessmentResponse userRegistryAssessmentToJsonAssessment(MotivationAssessment assessment);
 
     @IterableMapping(qualifiedByName = "mapWithRegistryExpression")
@@ -150,10 +155,7 @@ public interface AssessmentMapper {
     @Mapping(target = "sharedToUser", ignore = true)
     @Mapping(target = "sharedByUser", ignore = true)
     @Mapping(target = "published", source = "assessment.published")
-
     UserJsonRegistryAssessmentResponse publicUserRegistryAssessmentToJsonAssessment(MotivationAssessment assessment);
-
-
 
     @Named("mapZenodoWithRegistryExpression")
     @Mapping(target = "assessmentDoc", expression = "java(registryStringJsonToDto(assessment.getAssessmentDoc()))")
@@ -165,7 +167,73 @@ public interface AssessmentMapper {
     @Mapping(target = "sharedToUser", expression = "java(!uniqueIdentifier.equals(assessment.getValidation().getUser().getId()))")
     @Mapping(target = "sharedByUser", expression = "java(assessment.getShared() && assessment.getValidation() != null && assessment.getValidation().getUser() != null && uniqueIdentifier.equals(assessment.getValidation().getUser().getId()))")
     @Mapping(target = "published", source = "assessment.published")
-
     UserJsonRegistryAssessmentResponse zenodoUserRegistryAssessmentToJsonAssessment(MotivationAssessment assessment,String  uniqueIdentifier);
 
+    @Named("jsonWithLatestChanges")
+    @Mapping(target = "assessmentDoc", expression = "java(assessmentWithLatestChanges(assessment))")
+    @Mapping(target = "validationId", expression = "java(assessment.getValidation().getId())")
+    @Mapping(target = "createdOn", expression = "java(assessment.getCreatedOn().toString())")
+    @Mapping(target = "userId", expression = "java(assessment.getValidation().getUser().getId())")
+    @Mapping(target = "updatedOn", expression = "java(assessment.getUpdatedOn() != null ? assessment.getUpdatedOn().toString() : \"\")")
+    @Mapping(target = "updatedBy", expression = "java(assessment.getUpdatedBy() != null ? assessment.getUpdatedBy() : \"\")")
+    @Mapping(target = "sharedToUser", expression = "java(isSharedToUser(assessment.getValidation().getUser().getId()))")
+    @Mapping(target = "sharedByUser", expression = "java(isRegistryAssessmentSharedByUser(assessment, assessment.getValidation().getUser().getId()))")
+    @Mapping(target = "published", source = "assessment.published")
+    UserJsonRegistryAssessmentResponse userRegistryAssessmentToJsonUpdatedWithLatestChangesAssessment(MotivationAssessment assessment);
+
+    @SneakyThrows
+    default RegistryAssessmentDto assessmentWithLatestChanges(MotivationAssessment assessment) {
+
+        var objectMapper = new ObjectMapper();
+
+        var testRepository = CDI.current().select(TestRepository.class).get();
+
+        var tests = testRepository.getUpdatedTests(assessment.getCreatedOn());
+
+        var json = objectMapper.readValue(assessment.getAssessmentDoc(), RegistryAssessmentDto.class);
+
+        if(!tests.isEmpty()){
+
+            var jsonTests = json
+                    .principles
+                    .stream()
+                    .flatMap(pri->pri.criteria.stream())
+                    .map(CriNodeDto::getMetric)
+                    .flatMap(metric->metric.getTests().stream())
+                    .collect(Collectors.toList());
+
+            jsonTests
+                    .forEach(jsonTest->{
+
+                        var optional =  tests
+                                .stream()
+                                .filter(obj -> obj.getTES().equals(jsonTest.getId()))
+                                .findFirst();
+
+                        if(optional.isPresent()){
+
+                            var dbTest = optional.get();
+
+                            jsonTest.setDescription(dbTest.getDescTest().trim());
+                            jsonTest.setName(dbTest.getLabelTest().trim());
+                            jsonTest.setResult(null);
+                            jsonTest.setValue(null);
+
+                            var testDefinitionRepository = CDI.current().select(TestDefinitionRepository.class).get();
+                            var testDefinition = testDefinitionRepository.fetchTestDefinitionByTestId(dbTest.getId());
+                            jsonTest.setParams(TestParamsTransformer.transformTestParams(testDefinition.getTestParams()));
+                            jsonTest.setToolTip(testDefinition.getToolTip().trim());
+                            jsonTest.setText(testDefinition.getTestQuestion().trim());
+                            jsonTest.setChanged(Boolean.TRUE);
+
+                            if(!Objects.isNull(jsonTest.getUrls())){
+
+                                jsonTest.setUrls(new ArrayList<>());
+                            }
+                        }
+                    });
+        }
+
+        return json;
+    }
 }

--- a/mapper/src/main/java/org/grnet/cat/mappers/registry/TestMapper.java
+++ b/mapper/src/main/java/org/grnet/cat/mappers/registry/TestMapper.java
@@ -25,10 +25,10 @@ public interface TestMapper {
     @Mapping(target = "lastTouch", expression = "java(Timestamp.from(Instant.now()))")
     Test testToEntity(TestRequestDto request);
 
-    @Mapping(target = "TES", expression = "java(StringUtils.isNotEmpty(request.TES) ? request.TES : test.getTES())")
+    @Mapping(target = "TES", ignore = true)
     @Mapping(target = "labelTest", expression = "java(StringUtils.isNotEmpty(request.labelTest) ? request.labelTest : test.getLabelTest())")
     @Mapping(target = "descTest", expression = "java(StringUtils.isNotEmpty(request.descTest) ? request.descTest : test.getDescTest())")
-    @Mapping(target = "lastTouch", expression = "java(Timestamp.from(Instant.now()))")
+    @Mapping(target = "lastTouch", ignore = true)
     @Mapping(target = "populatedBy", ignore = true)
     @Mapping(target = "id", ignore = true)
     @Mapping(target = "lodMTV", ignore = true)

--- a/repository/src/main/java/org/grnet/cat/repositories/registry/TestRepository.java
+++ b/repository/src/main/java/org/grnet/cat/repositories/registry/TestRepository.java
@@ -11,6 +11,7 @@ import org.grnet.cat.entities.registry.Motivation;
 import org.grnet.cat.entities.registry.Test;
 import org.grnet.cat.repositories.Repository;
 
+import java.sql.Timestamp;
 import java.util.HashMap;
 import java.util.List;
 import java.util.StringJoiner;
@@ -76,5 +77,9 @@ public class TestRepository implements Repository<Test, String> {
                 .setParameter(1, value)
                 .getSingleResult();
         return count > 0;
+    }
+
+    public List<Test> getUpdatedTests(Timestamp assessmentCreatedTime) {
+        return find("lastTouch > ?1", assessmentCreatedTime).list();
     }
 }

--- a/service/src/main/java/org/grnet/cat/services/registry/TestDefinitionService.java
+++ b/service/src/main/java/org/grnet/cat/services/registry/TestDefinitionService.java
@@ -99,20 +99,15 @@ public class TestDefinitionService {
     @Transactional
     public TestDefinitionResponseDto updateTestDefinition(String id, String userId, TestDefinitionUpdateDto request) {
 
-        if (metricTestRepository.existTestDefinitionInStatus(id, Boolean.TRUE)) {
-            throw new ForbiddenException("No action permitted, test definition exists in a published motivation");
-        }
+//        if (metricTestRepository.existTestDefinitionInStatus(id, Boolean.TRUE)) {
+//            throw new ForbiddenException("No action permitted, test definition exists in a published motivation");
+//        }
 
         var testDefinition = testDefinitionRepository.findById(id);
 
         TestDefinitionMapper.INSTANCE.updateTestDefinitionFromDto(request, testDefinition);
         testDefinition.setPopulatedBy(userId);
 
-        if(!Objects.isNull(request.testMethodId)){
-
-            testMethodRepository.findByIdOptional(request.testMethodId).orElseThrow(()-> new NotFoundException("There is no Algorithm Type with the following id: "+request.testMethodId));
-            testDefinition.setTestMethod(Panache.getEntityManager().getReference(TestMethod.class, request.testMethodId));
-        }
         return TestDefinitionMapper.INSTANCE.testDefinitionToDto(testDefinition);
     }
 


### PR DESCRIPTION
This PR updates the way assessments are fetched by modifying the assessment JSON response to dynamically reflect changes in associated Tests and Test Definitions.

Introduced a `changed` flag on each test in the assessment response to indicate if the test has been modified since the assessment was saved. When updating a Test, changes to the Test ID and Test Definition method are not allowed.

When fetching an assessment, the latest version of each Test is retrieved. If differences are detected (excluding ID and method), the test in the response is overridden with the latest changes and the changed flag is set to true.

```json
"tests": [
                {
                  "id": "T16",
                  "name": "Digital Representation Exists",
                  "description": "Public evidence is provided that digital representations of one or more physical entity is maintained",
                  "type": "test_type",
                  "text": "test_question",
                  "params": "test_params",
                  "value": null,
                  "result": null,
                  "tool_tip": "test_tooltip",
                  "evidence_url": [],
                  "changed": "true"
                }
        ]
```

When a user updates their assessment with the latest Test changes, the updated Tests are persisted and the changed flag is reset to false.







