### PR TITLE
CAT-867: Update Auto-AAI-Check-Entitlements tests parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,9 @@ According to [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) , the `Unr
 - [#477](https://github.com/FC4E-CAT/fc4e-cat-api/pull/477) CAT-861 Implement Automated Test AARC-G069 to Validate NACO Entitlements Claim.
 
 
+### Fix
+- [#482](https://github.com/FC4E-CAT/fc4e-cat-api/pull/482) CAT-867: Update Auto-AAI-Check-Entitlements tests parameters
+
 ## 2.0.0 - 2025-03-31
 ---
 

--- a/entity/src/main/resources/db/migration/tables/registry/V1.62__update_test_to_G069.sql
+++ b/entity/src/main/resources/db/migration/tables/registry/V1.62__update_test_to_G069.sql
@@ -1,0 +1,15 @@
+-- ------------------------------------------------
+-- Version: v1.62
+--
+-- Description: Migration that updates the description on Test and parameters on TestDefinition.
+-- ------------------------------------------------
+
+UPDATE p_Test
+SET descTest = 'Fetches metadata from NACO and checks whether the ''entitlements'' claim is present in both ''user_info'' and ''introspection_info'', and conforms to the URN format defined in AARC-G069.'
+WHERE lodTES = 'pid_graph:069489G8';
+
+UPDATE p_Test_Definition
+SET testParams = 'aaiProviderId',
+    testQuestion = 'The AAI Provider ID to validate AARC-G069 compliance.',
+    toolTip = 'Please provide a valid AAI Provider ID'
+WHERE lodTDF = 'pid_graph:G0AR813A';


### PR DESCRIPTION
 ## Fix incorrect quotes 
This PR updates the SQL script to modify the test description and adjust the parameter types and values in the p_Test and p_Test_Definition tables.  It addresses the issue of incorrect quotes by replacing or removing them on the G069 test.