### PR TITLE
CAT-860: Version Tests in Library (fix search)

### DIFF
--- a/repository/src/main/java/org/grnet/cat/repositories/registry/TestRepository.java
+++ b/repository/src/main/java/org/grnet/cat/repositories/registry/TestRepository.java
@@ -37,12 +37,12 @@ public class TestRepository implements Repository<Test, String> {
             joiner.add("where (t.id ilike :search")
                     .add("or t.labelTest ilike :search")
                     .add("or t.TES ilike :search")
-                    .add("or t.descTest ilike :search)");
-
+                    .add("or t.descTest ilike :search)")
+                    .add("and t.version = (select max(t2.version) from Test t2 where t2.lodTES_V = t.lodTES_V)"); // Ensure only the latest version
             map.put("search", "%" + search + "%");
+        } else {
+            joiner.add("where t.version = (select max(t2.version) from Test t2 where t2.lodTES_V = t.lodTES_V)"); // Ensure only the latest version
         }
-
-        joiner.add("where t.version = (select max(t2.version) from Test t2 where t2.lodTES_V = t.lodTES_V)");
 
         joiner.add("order by t." + sort + " " + order + ", t.id ASC");
 


### PR DESCRIPTION
### Fixed query issue for fetching the latest version of tests:

Previously, the where clause was being applied twice, which caused a syntax error in the query. This has been resolved by combining the conditions into a single where clause.