### PR TITLE
CAT-879: View Versions of Metric in a Motivation

### DIFF
--- a/entity/src/main/java/org/grnet/cat/entities/registry/Test.java
+++ b/entity/src/main/java/org/grnet/cat/entities/registry/Test.java
@@ -74,6 +74,5 @@ public class Test {
     private String testQuestion;
 
     @Column(name = "tooltip")
-    @NotNull
     private String toolTip;
 }

--- a/repository/src/main/java/org/grnet/cat/repositories/registry/metric/MetricRepository.java
+++ b/repository/src/main/java/org/grnet/cat/repositories/registry/metric/MetricRepository.java
@@ -51,6 +51,13 @@ public class MetricRepository implements Repository<Metric, String> {
                 .getSingleResult();
     }
 
+    public List<Metric> fetchMetricsByIds(List<String> metricIds) {
+        // Query to fetch all metrics based on the list of metricIds
+        return find("SELECT m FROM Metric m WHERE m.id IN :metricIds ORDER BY m.version DESC",
+                Parameters.with("metricIds", metricIds))
+                .list();
+    }
+
     /**
      * Checks if the specified value for a given field in the Metric entity is not unique.
      *

--- a/service/src/main/java/org/grnet/cat/services/registry/MotivationService.java
+++ b/service/src/main/java/org/grnet/cat/services/registry/MotivationService.java
@@ -825,9 +825,57 @@ public class MotivationService {
 
         var metricDefinition = metricDefinitionRepository.fetchMetricDefinitionByMotivation(motivationId, page, size);
 
-        var metricDefinitionResponse = MetricDefinitionMapper.INSTANCE.metricDefinitionToExtendedResponses(metricDefinition.list());
+        var junctions = metricDefinition.list();
 
-        return new PageResource<>(metricDefinition, metricDefinitionResponse, uriInfo);
+        if (junctions.isEmpty()) {
+            return new PageResource<>(metricDefinition, List.of(), uriInfo);
+        }
+
+        var metricIds = junctions.stream()
+                .map(j -> j.getMetric().getId())
+                .distinct()
+                .collect(Collectors.toList());
+
+        var metrics = metricRepository.fetchMetricsByIds(metricIds);
+
+        // Create the response for each metric, including its versions (excluding the version in use)
+        var dtoList = metrics.stream()
+                .map(metric -> {
+                    // Find the junction related to this metric
+                    var junction = junctions.stream()
+                            .filter(j -> j.getMetric().getId().equals(metric.getId()))
+                            .findFirst()
+                            .orElseThrow(() -> new RuntimeException("Junction not found"));
+
+                    // Create the DTO for the metric
+                    var dto = metricService.metricResponseWithMotivations(metric, junction);
+
+                    // Fetch all versions for this metric, excluding the version in use
+                    var versions = getMetricVersionsExcludingInUse(metric.getLodMTRV(), metric.getVersion());
+
+                    // Add the versions to the DTO
+                    dto.setVersions(versions);
+
+                    return dto;
+                })
+                .collect(Collectors.toList());
+
+        // Return the paginated result with the list of DTOs
+        return new PageResource<>(metricDefinition, dtoList, uriInfo);
+    }
+
+
+    private List<MetricDefinitionExtendedResponse> getMetricVersionsExcludingInUse(String lodMTRV, Integer currentVersion) {
+        // Fetch all versions of the metric based on its lodMTRV
+        var metricVersions = metricDefinitionRepository.fetchMetricAndDefinitionVersion(lodMTRV);
+
+        return metricVersions.stream()
+                .filter(junction -> !junction.getMetric().getVersion().equals(currentVersion)) // Exclude the current version
+                .map(junction -> {
+                    var dto = metricService.metricResponseWithMotivations(junction.getMetric(), junction);
+                    return dto;
+                })
+                .collect(Collectors.toList());
     }
 
     public MetricDefinitionExtendedResponse getMetricDefinitionRelation(String motivationId, String metricId) {

--- a/service/src/main/java/org/grnet/cat/services/registry/metric/MetricService.java
+++ b/service/src/main/java/org/grnet/cat/services/registry/metric/MetricService.java
@@ -234,7 +234,7 @@ public class MetricService {
         return new PageResource<>(metricDefinitionPage, dtoList, uriInfo);
     }
 
-    private List<MetricDefinitionExtendedResponse> getMetricVersions(String metricParent, Integer latestVersion) {
+    public List<MetricDefinitionExtendedResponse> getMetricVersions(String metricParent, Integer latestVersion) {
 
         var metricVersions = metricDefinitionRepository.fetchMetricAndDefinitionVersion(metricParent);
 
@@ -255,7 +255,7 @@ public class MetricService {
      * @param metric The Test entity to be converted and enhanced.
      * @return A PrincipleResponseDto with associated motivations.
      */
-    private MetricDefinitionExtendedResponse metricResponseWithMotivations(Metric metric, MetricDefinitionJunction junction) {
+    public MetricDefinitionExtendedResponse metricResponseWithMotivations(Metric metric, MetricDefinitionJunction junction) {
 
         var metricAndDefinitionToDto = MetricMapper.INSTANCE.metricAndDefinitionToDto(metric, junction);
 


### PR DESCRIPTION
This PR implements the functionality to view all versions of a metric associated with a specific motivation. It updates the GET /metric-definition endpoint to not only return the version of a metric the motivation is using, but also a list of its versions.

### Changes:
* Updated GET /metric-definition Endpoint:
 The endpoint now fetches all versions of a metric related to a specific motivation.

### Example Response for EOSC-PID:
```
{
  "size_of_page": 10,
  "number_of_page": 1,
  "total_elements": 35,
  "total_pages": 4,
  "content": [
    {
      "metric_id": "pid_graph:0A42DC0E",
      "metric_mtr": "M11",
      "metric_label": "Versioning Procedure",
      "metric_description": "Evidence is available that a clear versioning procedure or policy exists and is available",
      "metric_version": "1",
      "type_algorithm_id": "pid_graph:7A976659",
      "type_algorithm_label": "Test = Metric",
      "type_algorithm_description": "The metric is the same as the test result without any modification",
      "type_metric_id": "pid_graph:8D79984F",
      "type_metric_label": "Binary",
      "type_metric_description": "True or false, for example by determining whether there is evidence supporting a compliance claim",
      "type_benchmark_id": "pid_graph:7085006F",
      "type_benchmark_label": "Binary-Binary",
      "type_benchmark_description": "The benchmark maps a binary metric value to binary assessment outcome (Pass/ Fail). The inverse can also be done.",
      "type_benchmark_patter": "M[0,1] → [Fail, Pass]",
      "motivation_id": "pid_graph:3E109BBA",
      "value_benchmark": "1",
      "used_by_motivations": [
        {
          "id": "pid_graph:34A9189F",
          "mtv": "NL-PID",
          "label": "Netherlands National PID Policy"
        },
        {
          "id": "pid_graph:3E109BBA",
          "mtv": "EOSC-PID",
          "label": "EOSC PID Policy"
        }
      ],
      "metric_versions": [
        {
          "metric_id": "pid_graph:2FABAAFE",
          "metric_mtr": "M11",
          "metric_label": "newversion",
          "metric_description": "This metric measures performance.",
          "metric_version": "2",
          "type_algorithm_id": "pid_graph:2050775C",
          "type_algorithm_label": "Weighted Sum",
          "type_algorithm_description": "Weighted sum of two or more normalised test results, by applying an array of weights",
          "type_metric_id": "pid_graph:35966E2B",
          "type_metric_label": "Open Review",
          "type_metric_description": "No guidelines are present, and reviewers make a completely subjective and independent conclusion about performance.",
          "type_benchmark_id": "pid_graph:0917EC0D",
          "type_benchmark_label": "Integer-Binary-AND",
          "type_benchmark_description": "The benchmark maps the aggregate of a number of binary tests, expressed as an integer, to a binary assessment and all tests must pass. The benchmark equals the number of tests.",
          "type_benchmark_patter": "M → [Fail, Pass]",
          "motivation_id": "pid_graph:7C39FE83",
          "value_benchmark": "3",
          "used_by_motivations": [
            {
              "id": "pid_graph:7C39FE83",
              "mtv": "test",
              "label": "test"
            }
          ]
        }
      ]
    },
    ...
}
```

### Example for TEST motivation:
```
{
  "size_of_page": 1,
  "number_of_page": 1,
  "total_elements": 1,
  "total_pages": 1,
  "content": [
    {
      "metric_id": "pid_graph:2FABAAFE",
      "metric_mtr": "M11",
      "metric_label": "newversion",
      "metric_description": "This metric measures performance.",
      "metric_version": "2",
      "type_algorithm_id": "pid_graph:2050775C",
      "type_algorithm_label": "Weighted Sum",
      "type_algorithm_description": "Weighted sum of two or more normalised test results, by applying an array of weights",
      "type_metric_id": "pid_graph:35966E2B",
      "type_metric_label": "Open Review",
      "type_metric_description": "No guidelines are present, and reviewers make a completely subjective and independent conclusion about performance.",
      "type_benchmark_id": "pid_graph:0917EC0D",
      "type_benchmark_label": "Integer-Binary-AND",
      "type_benchmark_description": "The benchmark maps the aggregate of a number of binary tests, expressed as an integer, to a binary assessment and all tests must pass. The benchmark equals the number of tests.",
      "type_benchmark_patter": "M → [Fail, Pass]",
      "motivation_id": "pid_graph:7C39FE83",
      "value_benchmark": "3",
      "used_by_motivations": [
        {
          "id": "pid_graph:7C39FE83",
          "mtv": "test",
          "label": "test"
        }
      ],
      "metric_versions": [
        {
          "metric_id": "pid_graph:0A42DC0E",
          "metric_mtr": "M11",
          "metric_label": "Versioning Procedure",
          "metric_description": "Evidence is available that a clear versioning procedure or policy exists and is available",
          "metric_version": "1",
          "type_algorithm_id": "pid_graph:7A976659",
          "type_algorithm_label": "Test = Metric",
          "type_algorithm_description": "The metric is the same as the test result without any modification",
          "type_metric_id": "pid_graph:8D79984F",
          "type_metric_label": "Binary",
          "type_metric_description": "True or false, for example by determining whether there is evidence supporting a compliance claim",
          "type_benchmark_id": "pid_graph:7085006F",
          "type_benchmark_label": "Binary-Binary",
          "type_benchmark_description": "The benchmark maps a binary metric value to binary assessment outcome (Pass/ Fail). The inverse can also be done.",
          "type_benchmark_patter": "M[0,1] → [Fail, Pass]",
          "motivation_id": "pid_graph:34A9189F",
          "value_benchmark": "1",
          "used_by_motivations": [
            {
              "id": "pid_graph:34A9189F",
              "mtv": "NL-PID",
              "label": "Netherlands National PID Policy"
            },
            {
              "id": "pid_graph:3E109BBA",
              "mtv": "EOSC-PID",
              "label": "EOSC PID Policy"
            }
          ]
        }
      ]
    }
  ],
  "links": []
}
```