### PR TITLE
CAT-1031 fix version requests on metric and test

### DIFF
--- a/api/src/main/java/org/grnet/cat/api/endpoints/registry/MotivationEndpoint.java
+++ b/api/src/main/java/org/grnet/cat/api/endpoints/registry/MotivationEndpoint.java
@@ -42,6 +42,7 @@ import org.grnet.cat.dtos.registry.criterion.PrincipleCriterionResponse;
 import org.grnet.cat.dtos.registry.metric.DetailedMetricDto;
 import org.grnet.cat.dtos.registry.metric.MotivationMetricExtendedRequest;
 import org.grnet.cat.dtos.registry.metric.MotivationMetricUpdateRequest;
+import org.grnet.cat.dtos.registry.metric.MotivationMetricVersionRequest;
 import org.grnet.cat.dtos.registry.motivation.*;
 import org.grnet.cat.dtos.registry.principle.MotivationPrincipleExtendedRequestDto;
 import org.grnet.cat.dtos.registry.principle.MotivationPrincipleRequest;
@@ -2637,7 +2638,7 @@ public class MotivationEndpoint {
             @PathParam("metric-id")
             @Valid
             @NotFoundEntity(repository = MetricRepository.class, message = "There is no Metric with the following id:") String metricId,
-            @Valid @NotNull(message = "The request body is empty.") MotivationMetricExtendedRequest request) {
+            @Valid @NotNull(message = "The request body is empty.") MotivationMetricVersionRequest request) {
 
         var response = motivationService.createMetricDefinitionVersionForMotivation(id, metricId, request, utility.getUserUniqueIdentifier());
 

--- a/api/src/test/java/org/grnet/cat/api/ZenodoEndpointTest.java
+++ b/api/src/test/java/org/grnet/cat/api/ZenodoEndpointTest.java
@@ -142,42 +142,7 @@ public class ZenodoEndpointTest extends KeycloakTest {
 
 
     }
-
-    @Test
-    @Execution(ExecutionMode.CONCURRENT)
-    public void testPublishZenodoAssessment_Success() throws IOException, InterruptedException {
-
-        //  zenodoAssessmentInfoRepository.removeAll();
-        //register(validatedToken);
-     //   assessment = createRegistryPublicAssessment(validatedToken);
-      //  assessment.published = true;
-        var pdf = generateValidPdf();
-        var response = given()
-                .auth()
-                .oauth2(validatedToken)
-                .body(pdf)
-                .contentType("application/octet-stream")
-                .post("/publish/assessment/{id}", publicAssessment.id)
-                .then()
-                .assertThat()
-                .statusCode(200)
-                .extract()
-                .as(InformativeResponse.class);
-        //  String expectedMessage = "Process of uploading assessment with ID: " + assessment.id + " has started...";
-        var zenodAssessmentInfo = given()
-                .auth()
-                .oauth2(validatedToken)
-                .get("/assessment/{id}", publicAssessment.id)
-                .then()
-                .assertThat()
-                .statusCode(200)
-                .extract()
-                .as(ZenodoAssessmentInfoResponse.class);
-
-
-        assertEquals(ZenodoState.PROCESS_COMPLETED.getType(), zenodAssessmentInfo.getZenodoState());
-    }
-
+    
     @Test
     @Execution(ExecutionMode.CONCURRENT)
     public void testPublishZenodoAssessment_notPublished() throws IOException {

--- a/data-transfer-object/src/main/java/org/grnet/cat/dtos/registry/metric/MotivationMetricVersionRequest.java
+++ b/data-transfer-object/src/main/java/org/grnet/cat/dtos/registry/metric/MotivationMetricVersionRequest.java
@@ -1,0 +1,89 @@
+package org.grnet.cat.dtos.registry.metric;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.constraints.NotEmpty;
+import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
+import org.grnet.cat.constraints.NotFoundEntity;
+import org.grnet.cat.repositories.registry.metric.TypeAlgorithmRepository;
+import org.grnet.cat.repositories.registry.metric.TypeMetricRepository;
+
+public class MotivationMetricVersionRequest {
+
+    @Schema(
+            type = SchemaType.STRING,
+            implementation = String.class,
+            description = "Label for the metric",
+            required = true,
+            example = "Performance Metric"
+    )
+    @NotEmpty(message = "label may not be empty.")
+    @JsonProperty("label")
+    public String labelMetric;
+
+    @Schema(
+            type = SchemaType.STRING,
+            implementation = String.class,
+            description = "Description of the metric",
+            required = true,
+            example = "This metric measures performance."
+    )
+    @NotEmpty(message = "description may not be empty.")
+    @JsonProperty("description")
+    public String descrMetric;
+
+    @Schema(
+            type = SchemaType.STRING,
+            implementation = String.class,
+            description = "URL for more information about the metric",
+            example = "http://example.com/metric"
+    )
+    @JsonProperty("url")
+    public String urlMetric;
+
+    @Schema(
+            type = SchemaType.STRING,
+            implementation = String.class,
+            description = "The ID of the Type Algorithm associated with this metric",
+            required = true,
+            example = "pid_graph:2050775C"
+    )
+    @NotEmpty(message = "type_algorithm_id may not be empty.")
+    @NotFoundEntity(repository = TypeAlgorithmRepository.class, message = "There is no Algorithm Type with the following id:")
+    @JsonProperty("type_algorithm_id")
+    public String typeAlgorithmId;
+
+    @Schema(
+            type = SchemaType.STRING,
+            implementation = String.class,
+            description = "The ID of the Type Metric associated with this metric",
+            required = true,
+            example = "pid_graph:35966E2B"
+    )
+    @NotEmpty(message = "type_metric_id may not be empty.")
+    @NotFoundEntity(repository = TypeMetricRepository.class, message = "There is no Metric Type with the following id:")
+    @JsonProperty("type_metric_id")
+    public String typeMetricId;
+
+    @Schema(
+            type = SchemaType.STRING,
+            implementation = String.class,
+            description = "The Benchmark Type ID.",
+            required = true,
+            example = "pid_graph:0917EC0D"
+    )
+    @NotEmpty(message = "type_benchmark_id may not be empty.")
+    @JsonProperty("type_benchmark_id")
+    public String typeBenchmarkId;
+
+    @Schema(
+            type = SchemaType.STRING,
+            implementation = String.class,
+            description = "The Benchmark Value.",
+            required = true,
+            example = "3"
+    )
+    @NotEmpty(message = "value_benchmark may not be empty.")
+    @JsonProperty("value_benchmark")
+    public String valueBenchmark;
+}

--- a/data-transfer-object/src/main/java/org/grnet/cat/dtos/registry/test/TestVersionRequestDto.java
+++ b/data-transfer-object/src/main/java/org/grnet/cat/dtos/registry/test/TestVersionRequestDto.java
@@ -12,16 +12,6 @@ public class TestVersionRequestDto {
     @Schema(
             type = SchemaType.STRING,
             implementation = String.class,
-            description = "The Test Name",
-            example = "T12"
-    )
-    @JsonProperty("tes")
-    @NotEmpty(message = "tes may not be empty.")
-    public String TES;
-
-    @Schema(
-            type = SchemaType.STRING,
-            implementation = String.class,
             description = "Label for the test",
             example = "PID Persistence - Service - Evidence"
     )

--- a/service/src/main/java/org/grnet/cat/services/registry/MotivationService.java
+++ b/service/src/main/java/org/grnet/cat/services/registry/MotivationService.java
@@ -16,11 +16,7 @@ import org.grnet.cat.dtos.registry.MetricDefinitionRequest;
 import org.grnet.cat.dtos.registry.PrincipleCriterionResponseDto;
 import org.grnet.cat.dtos.registry.actor.MotivationActorRequest;
 import org.grnet.cat.dtos.registry.actor.MotivationActorResponse;
-import org.grnet.cat.dtos.registry.metric.DetailedMetricDto;
-import org.grnet.cat.dtos.registry.metric.MetricRequestDto;
-import org.grnet.cat.dtos.registry.metric.MetricUpdateDto;
-import org.grnet.cat.dtos.registry.metric.MotivationMetricExtendedRequest;
-import org.grnet.cat.dtos.registry.metric.MotivationMetricUpdateRequest;
+import org.grnet.cat.dtos.registry.metric.*;
 import org.grnet.cat.dtos.registry.motivation.*;
 import org.grnet.cat.dtos.registry.principle.MotivationPrincipleExtendedRequestDto;
 import org.grnet.cat.dtos.registry.principle.MotivationPrincipleRequest;
@@ -659,48 +655,46 @@ public class MotivationService {
     }
 
     @Transactional
-    public InformativeResponse createMetricDefinitionVersionForMotivation(String motivationId, String metricId, MotivationMetricExtendedRequest request, String userId) {
+    public InformativeResponse createMetricDefinitionVersionForMotivation(String motivationId, String metricId, MotivationMetricVersionRequest request, String userId) {
 
         var response = new InformativeResponse();
 
         var metricParent = metricRepository.findById(metricId);
 
-        if (Objects.equals(metricParent.getMTR(), request.MTR)) {
+        var metricRequest = new MetricRequestDto();
+        metricRequest.MTR = metricParent.getMTR();
+        metricRequest.urlMetric = request.urlMetric;
+        metricRequest.typeMetricId = request.typeMetricId;
+        metricRequest.typeAlgorithmId = request.typeAlgorithmId;
+        metricRequest.labelMetric = request.labelMetric;
+        metricRequest.descrMetric = request.descrMetric;
 
-            var metricRequest = new MetricRequestDto();
-            metricRequest.MTR = request.MTR;
-            metricRequest.urlMetric = request.urlMetric;
-            metricRequest.typeMetricId = request.typeMetricId;
-            metricRequest.typeAlgorithmId = request.typeAlgorithmId;
-            metricRequest.labelMetric = request.labelMetric;
-            metricRequest.descrMetric = request.descrMetric;
+        var metric = MetricMapper.INSTANCE.metricToEntity(metricRequest);
 
-            var metric = MetricMapper.INSTANCE.metricToEntity(metricRequest);
+        metric.setLodMTV(motivationId);
+        metric.setPopulatedBy(userId);
+        metric.setTypeAlgorithm(Panache.getEntityManager().getReference(TypeAlgorithm.class, metricRequest.typeAlgorithmId));
+        metric.setTypeMetric(Panache.getEntityManager().getReference(TypeMetric.class, metricRequest.typeMetricId));
+        metric.setPopulatedBy(userId);
+        metric.setLodMTRV(metricParent.getLodMTRV());
 
-            metric.setLodMTV(motivationId);
-            metric.setPopulatedBy(userId);
-            metric.setTypeAlgorithm(Panache.getEntityManager().getReference(TypeAlgorithm.class, metricRequest.typeAlgorithmId));
-            metric.setTypeMetric(Panache.getEntityManager().getReference(TypeMetric.class, metricRequest.typeMetricId));
-            metric.setPopulatedBy(userId);
-            metric.setLodMTRV(metricParent.getLodMTRV());
-
-            var parentMetricVersion = metricRepository.countVersion(metricId);
-            metric.setVersion((int) (parentMetricVersion + 1));
+        var parentMetricVersion = metricRepository.countVersion(metricId);
+        metric.setVersion((int) (parentMetricVersion + 1));
 
 
-            metricRepository.persist(metric);
+        metricRepository.persist(metric);
 
-            var metricDefinitionJunction = new MetricDefinitionJunction(
-                    Panache.getEntityManager().getReference(Motivation.class, motivationId),
-                    Panache.getEntityManager().getReference(Metric.class, metric.getId()),
-                    Panache.getEntityManager().getReference(TypeBenchmark.class, request.typeBenchmarkId),
-                    request.valueBenchmark,
-                    motivationId,
-                    1,
-                    (Timestamp.from(Instant.now())).toLocalDateTime().toLocalDate(),
-                    userId,
-                    Timestamp.from(Instant.now())
-            );
+        var metricDefinitionJunction = new MetricDefinitionJunction(
+                Panache.getEntityManager().getReference(Motivation.class, motivationId),
+                Panache.getEntityManager().getReference(Metric.class, metric.getId()),
+                Panache.getEntityManager().getReference(TypeBenchmark.class, request.typeBenchmarkId),
+                request.valueBenchmark,
+                motivationId,
+                1,
+                (Timestamp.from(Instant.now())).toLocalDateTime().toLocalDate(),
+                userId,
+                Timestamp.from(Instant.now())
+        );
 
             metricDefinitionRepository.persist(metricDefinitionJunction);
 
@@ -709,10 +703,6 @@ public class MotivationService {
 
             response.code = 200;
             response.message = "A version of a metric and a Metric Definition successfully created and linked to the specified motivation.";
-        } else {
-            response.code = 409;
-            response.message = "A metric with the identifier '" + request.MTR.toUpperCase() + "' already exists.";
-        }
 
         return response;
     }

--- a/service/src/main/java/org/grnet/cat/services/registry/TestService.java
+++ b/service/src/main/java/org/grnet/cat/services/registry/TestService.java
@@ -157,13 +157,11 @@ public class TestService {
     @Transactional
     public TestResponseDto versionTest(String id, String userId, TestVersionRequestDto request) {
 
-        if (!Objects.equals(testRepository.findById(id).getTES(), request.TES)) {
-            throw new ForbiddenException("The TES name must be the same as the parent test: " + testRepository.findById(id).getTES());
-        }
         var parentId = testRepository.findById(id).getLodTES_V();
         var parentTestVersion = testRepository.countVersion(parentId);
 
         var childTest = TestMapper.INSTANCE.versionTestToEntity(request);
+        childTest.setTES(testRepository.findById(id).getTES());
         childTest.setPopulatedBy(userId);
         childTest.setLodTES_V(testRepository.findById(id).getLodTES_V());
         childTest.setTestMethod(Panache.getEntityManager().getReference(TestMethod.class, request.testMethodId));


### PR DESCRIPTION
### Changes:

* Updated the logic to create a new version of a metric linked to a specific motivation without requiring MTR and TES to be passed in the request.

* The MTR and TES values are now derived from the parent metric, ensuring they align with the existing versioned metric’s information.