### PR TITLE
[CAT-884] Add Fully-Automated-Validation test method and AARC-G056 attribute checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ According to [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) , the `Unr
 - [#476](https://github.com/FC4E-CAT/fc4e-cat-api/pull/476) CAT-860: Version Tests in Library
 - [#485](https://github.com/FC4E-CAT/fc4e-cat-api/pull/485) CAT-871 Version a Metric in Motivation and view metric versions on Library
 - [#489](https://github.com/FC4E-CAT/fc4e-cat-api/pull/489) CAT-878 Version Motivation
+- [#493](https://github.com/FC4E-CAT/fc4e-cat-api/pull/493) CAT-884 Add Fully-Automated-Validation test method and integrate AARC-G056 claim checks.
 - [#494](https://github.com/FC4E-CAT/fc4e-cat-api/pull/494) CAT-885: Statistics of the Combination of Types in a Metric
 - [#495](https://github.com/FC4E-CAT/fc4e-cat-api/pull/495) CAT-886 Implement Search Functionality for Testmethod
 - [#497](https://github.com/FC4E-CAT/fc4e-cat-api/pull/497) CAT-891 Publishing to Zenodo New Version

--- a/api/src/main/java/org/grnet/cat/api/endpoints/AutomatedCheckEndpoint.java
+++ b/api/src/main/java/org/grnet/cat/api/endpoints/AutomatedCheckEndpoint.java
@@ -238,4 +238,58 @@ public class AutomatedCheckEndpoint {
 
         return Response.ok(response).build();
     }
+
+    @Tag(name = "Automated Check")
+    @Operation(
+            summary = "Validate AARC-G056 compliance for a specific AAI provider",
+            description = "Validate AARC-G056 compliance for a specific AAI provider."
+    )
+    @APIResponses({
+            @APIResponse(
+                    responseCode = "200",
+                    description = "Validation result for the AARC-G056 compliance check.",
+                    content = @Content(
+                            mediaType = MediaType.APPLICATION_JSON,
+                            schema = @Schema(implementation = AutomatedTestResponse.class))),
+            @APIResponse(
+                    responseCode = "400",
+                    description = "Invalid request payload.",
+                    content = @Content(schema = @Schema(
+                            type = SchemaType.OBJECT,
+                            implementation = InformativeResponse.class))),
+            @APIResponse(
+                    responseCode = "401",
+                    description = "User has not been authenticated.",
+                    content = @Content(schema = @Schema(
+                            type = SchemaType.OBJECT,
+                            implementation = InformativeResponse.class))),
+            @APIResponse(
+                    responseCode = "403",
+                    description = "Not permitted.",
+                    content = @Content(schema = @Schema(
+                            type = SchemaType.OBJECT,
+                            implementation = InformativeResponse.class))),
+            @APIResponse(
+                    responseCode = "404",
+                    description = "Entity Not Found.",
+                    content = @Content(schema = @Schema(
+                            type = SchemaType.OBJECT,
+                            implementation = InformativeResponse.class))),
+            @APIResponse(
+                    responseCode = "500",
+                    description = "Internal Server Error.",
+                    content = @Content(schema = @Schema(
+                            type = SchemaType.OBJECT,
+                            implementation = InformativeResponse.class)))
+    })
+    @SecurityRequirement(name = "Authentication")
+    @POST
+    @Path("/aarc-g056")
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response validateProviderForG056(@Valid @NotNull(message = "The request body is empty.") AarcG069Request request) {
+
+        var response = arccValidationService.validateAarcG056(request.aaiProviderId);
+
+        return Response.ok(response).build();
+    }
 }

--- a/api/src/main/java/org/grnet/cat/api/endpoints/TemplatesEndpoint.java
+++ b/api/src/main/java/org/grnet/cat/api/endpoints/TemplatesEndpoint.java
@@ -85,9 +85,7 @@ public class TemplatesEndpoint {
             required = true,
             example = "pid_graph:3E109BBA",
             schema = @Schema(type = SchemaType.STRING))
-                                        @PathParam("motivation-id") @Valid @NotFoundEntity(repository = MotivationRepository.class, message = "There is no Motivation with the following id:")
-                                        //@CheckPublished(repository = MotivationRepository.class, message = "No action permitted for unpublished Motivation with the following id:", isPublishedPermitted = true)
-                                        String motivationId,
+                                        @PathParam("motivation-id") @Valid @NotFoundEntity(repository = MotivationRepository.class, message = "There is no Motivation with the following id:") String motivationId,
                                         @Parameter(
                                                 description = "The Actor to retrieve template.",
                                                 required = true,

--- a/api/src/main/java/org/grnet/cat/api/endpoints/registry/MotivationEndpoint.java
+++ b/api/src/main/java/org/grnet/cat/api/endpoints/registry/MotivationEndpoint.java
@@ -494,12 +494,12 @@ public class MotivationEndpoint {
     public Response assignActorToMotivation(@Parameter(
                                                     description = "The ID of the Motivation to update.",
                                                     required = true,
-                                                    example = "1",
+                                                    example = "pid_graph:3E109BBA",
                                                     schema = @Schema(type = SchemaType.STRING))
                                             @PathParam("id")
                                             @Valid
                                             @NotFoundEntity(repository = MotivationRepository.class, message = "There is no Motivation with the following id:")
-                                            @CheckPublished(repository = MotivationRepository.class, message = "No action permitted for published Motivation with the following id:", isPublishedPermitted = false) String id,
+                                                @CheckPublished(repository = MotivationRepository.class, message = "No action permitted for published Motivation with the following id:", isPublishedPermitted = false) String id,
                                             @NotEmpty(message = "Actors list can not be empty.") Set<@Valid MotivationActorRequest> request) {
 
         var messages = motivationService.assignActors(id, request, utility.getUserUniqueIdentifier());
@@ -560,7 +560,7 @@ public class MotivationEndpoint {
     public Response removeActorFromMotivation(@Parameter(
                                                       description = "The ID of the Motivation to update.",
                                                       required = true,
-                                                      example = "1",
+                                                      example = "pid_graph:3E109BBA",
                                                       schema = @Schema(type = SchemaType.STRING))
                                               @PathParam("id")
                                               @Valid

--- a/api/src/main/resources/application.properties
+++ b/api/src/main/resources/application.properties
@@ -140,4 +140,4 @@ zenodo.enabled=true
 quarkus.rest-client.naco-service.url=https://cvs.data.kit.edu
 quarkus.rest-client.naco-service.scope=jakarta.inject.Singleton
 
-naco.service.key = naco_service_key
+naco.service.key = asdlkfjasd02893423

--- a/data-transfer-object/src/main/java/org/grnet/cat/dtos/AarcClaimLocation.java
+++ b/data-transfer-object/src/main/java/org/grnet/cat/dtos/AarcClaimLocation.java
@@ -1,0 +1,23 @@
+package org.grnet.cat.dtos;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class AarcClaimLocation {
+
+    @JsonProperty("user_info")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public ArccValidationResult userInfo;
+
+    @JsonProperty("introspection_info")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public ArccValidationResult introspectionInfo;
+
+    @JsonProperty("access_token_info")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public ArccValidationResult accessTokenInfo;
+
+    @JsonProperty("id_token")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public ArccValidationResult idToken;
+}

--- a/data-transfer-object/src/main/java/org/grnet/cat/dtos/registry/actor/MotivationActorRequest.java
+++ b/data-transfer-object/src/main/java/org/grnet/cat/dtos/registry/actor/MotivationActorRequest.java
@@ -9,6 +9,10 @@ import org.grnet.cat.constraints.NotFoundEntity;
 import org.grnet.cat.repositories.registry.RegistryActorRepository;
 import org.grnet.cat.repositories.registry.RelationRepository;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
 @Schema(name="MotivationActorRequest", description="This object represents a request for assigning Actors to a Motivation.")
 @EqualsAndHashCode(onlyExplicitlyIncluded = true)
 public class MotivationActorRequest {
@@ -38,4 +42,12 @@ public class MotivationActorRequest {
     @NotFoundEntity(repository = RelationRepository.class, message = "There is no Relation  with the following id:")
     @JsonProperty(value = "relation")
     public String relation;
+
+    @Schema(
+            type = SchemaType.OBJECT,
+            additionalProperties = Object.class,
+            description = "List of automated test group configurations. Each item defines a test method, target endpoint, and the dynamic parameters needed to execute the test."
+    )
+    @JsonProperty(value = "automated_group_test")
+    public List<Map<String, Object>> automatedGroupTest = new ArrayList<>();
 }

--- a/data-transfer-object/src/main/java/org/grnet/cat/dtos/registry/template/RegistryTemplateDto.java
+++ b/data-transfer-object/src/main/java/org/grnet/cat/dtos/registry/template/RegistryTemplateDto.java
@@ -7,7 +7,9 @@ import org.grnet.cat.dtos.template.TemplateOrganisationDto;
 import org.grnet.cat.dtos.template.TemplateResultDto;
 import org.grnet.cat.dtos.template.TemplateSubjectDto;
 
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 @Schema(name = "RegistryTemplate", description = "This object represents a Registry Template.")
 public class RegistryTemplateDto {
@@ -26,6 +28,9 @@ public class RegistryTemplateDto {
     public boolean published;
 
     public String timestamp = "";
+
+    @JsonProperty(value = "automated_group_test")
+    public List<Map<String, Object>> automatedGroupTest = new ArrayList<>();
 
     public RegistryTemplateActorDto actor;
 

--- a/entity/src/main/java/org/grnet/cat/entities/registry/Motivation.java
+++ b/entity/src/main/java/org/grnet/cat/entities/registry/Motivation.java
@@ -9,6 +9,8 @@ import org.grnet.cat.entities.registry.generator.RegistryId;
 
 import java.sql.Timestamp;
 import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 @Entity
@@ -76,13 +78,11 @@ public class Motivation extends Registry {
         principle.getMotivations().add(principleMotivation);
     }
 
-    public void addActor(RegistryActor actor, Relation relation, String motivationX, Integer lodMAV, String populatedBy, Timestamp lastTouch) {
+    public void addActor(RegistryActor actor, Relation relation, String motivationX, Integer lodMAV, String populatedBy, Timestamp lastTouch, List<Map<String, Object>> automatedGroupTest) {
 
-        var actorMotivation = new MotivationActorJunction(this, actor, relation, motivationX, lodMAV, populatedBy, lastTouch,Boolean.FALSE);
+        var actorMotivation = new MotivationActorJunction(this, actor, relation, motivationX, lodMAV, populatedBy, lastTouch,Boolean.FALSE, automatedGroupTest);
         actors.add(actorMotivation);
-
         actorMotivation.getMotivation().actors.add(actorMotivation);
-
     }
 
     public String getId() {

--- a/entity/src/main/java/org/grnet/cat/entities/registry/MotivationActorJunction.java
+++ b/entity/src/main/java/org/grnet/cat/entities/registry/MotivationActorJunction.java
@@ -1,12 +1,17 @@
 package org.grnet.cat.entities.registry;
 
 
+import com.vladmihalcea.hibernate.type.json.JsonType;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 import lombok.Setter;
+import org.hibernate.annotations.Type;
 
 import java.sql.Timestamp;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 
 @Entity(name = "MotivationActorJunction")
@@ -38,7 +43,11 @@ public class MotivationActorJunction extends Registry{
     @Column
     private Boolean  published;
 
-    public MotivationActorJunction(Motivation motivation, RegistryActor actor, Relation relation, String motivationX, Integer lodMAV, String populatedBy, Timestamp lastTouch,Boolean published) {
+    @Type(JsonType.class)
+    @Column(name = "automated_group_test", columnDefinition = "jsonb")
+    private List<Map<String, Object>> automatedGroupTest = new ArrayList<>();
+
+    public MotivationActorJunction(Motivation motivation, RegistryActor actor, Relation relation, String motivationX, Integer lodMAV, String populatedBy, Timestamp lastTouch, Boolean published, List<Map<String, Object>> automatedGroupTest) {
 
         this.motivation = motivation;
         this.actor = actor;
@@ -47,6 +56,7 @@ public class MotivationActorJunction extends Registry{
         this.setLastTouch(lastTouch);
         this.setPopulatedBy(populatedBy);
         this.published=published;
+        this.automatedGroupTest = automatedGroupTest;
         this.id = new MotivationActorId(motivation.getId(), actor.getId(), lodMAV);
     }
 

--- a/entity/src/main/resources/db/migration/tables/registry/V1.76__add_new_test_for_G056.sql
+++ b/entity/src/main/resources/db/migration/tables/registry/V1.76__add_new_test_for_G056.sql
@@ -1,0 +1,35 @@
+ALTER TABLE t_Motivation_Actor ADD COLUMN automated_group_test jsonb;
+
+INSERT INTO t_TestMethod
+(lodTME, UUID, labelTestMethod, descTestMethod, lodTypeValue, lodTypeProcess, numParams, requestFragment, responseFragment)
+VALUES
+('pid_graph:G0A5FWLC', 'G0A5FWLC', 'Fully-Automated-Validation', 'This test method executes a fully automated validation. It ensures that all required aspects and attributes defined properly and accessible without manual intervention.', 'pid_graph:binary', 'pid_graph:auto', 1,
+'{
+    "parameters": [
+      {
+        "name": "#p1",
+        "in": "path",
+        "description": "#q1",
+        "tooltip": "#t1",
+        "required": true,
+        "schema": {"type": "String"},
+        "style": "simple"
+      }
+    ]
+}',
+'{
+    "response": [
+      {
+        "name": "#p2",
+        "schema": {
+          "type": "boolean"
+        }
+      }
+    ]
+}');
+
+INSERT INTO p_Test (lodTES , TES , lodTME, testparams, labelTest, descTest, lodMTV , lodTES_V, version, labeltestdefinition, paramtype, testquestion, tooltip) VALUES ('pid_graph:056489G8', 'Userinfo-Name-Claim-Available', 'pid_graph:G0A5FWLC', 'name_user_info', 'Name claim available in Userinfo endpoint.', 'This test verifies that the name claim is available at the Userinfo endpoint of an AARC-compliant Identity Provider.',
+null, 1, 1, 'Automated confirmation of AARC-G056 compliance', 'String', 'Does the OpenID Connect UserInfo endpoint of the AAI service return Display Name information within the name claim as required by AARC-G056?', '"Automatically checks if the required claim is released in compliance with the AARC-G056 specification, with no manual steps involved."');
+
+INSERT INTO p_Test (lodTES , TES , lodTME, testparams, labelTest, descTest, lodMTV , lodTES_V, version, labeltestdefinition, paramtype, testquestion, tooltip) VALUES ('pid_graph:890489L8', 'Userinfo-Given-Name-Claim-Available', 'pid_graph:G0A5FWLC', 'given_name_user_info', 'Given name claim available in Userinfo endpoint.', 'This test verifies that the given name claim is available at the Userinfo endpoint of an AARC-compliant Identity Provider.',
+null, 1, 1, 'Automated confirmation of AARC-G056 compliance', 'String', 'Does the OpenID Connect UserInfo endpoint of the AAI service return Given Name information within the given_name claim as required by AARC-G056?', '"Automatically checks if the required claim is released in compliance with the AARC-G056 specification, with no manual steps involved."');

--- a/repository/src/main/java/org/grnet/cat/repositories/registry/MotivationActorRepository.java
+++ b/repository/src/main/java/org/grnet/cat/repositories/registry/MotivationActorRepository.java
@@ -12,7 +12,7 @@ import org.grnet.cat.repositories.Repository;
 import java.util.Optional;
 
 @ApplicationScoped
-public class MotivationActorRepository  implements Repository<MotivationActorJunction, MotivationActorId> {
+public class MotivationActorRepository implements Repository<MotivationActorJunction, MotivationActorId> {
 
     /**
      * Retrieves a page of Motivations.
@@ -21,9 +21,9 @@ public class MotivationActorRepository  implements Repository<MotivationActorJun
      * @param size The maximum number of Motivations to include in a page.
      * @return A list of Motivations objects representing the Motivations in the requested page.
      */
-    public PageQuery<MotivationActorJunction> fetchActorsByMotivationAndPage(String motivationId, int page, int size){
+    public PageQuery<MotivationActorJunction> fetchActorsByMotivationAndPage(String motivationId, int page, int size) {
 
-        var panache = find("SELECT m FROM MotivationActorJunction m WHERE m.id.motivationId = ?1", Sort.by("lastTouch", Sort.Direction.Descending).and("id", Sort.Direction.Ascending),motivationId).page(page, size);
+        var panache = find("SELECT m FROM MotivationActorJunction m WHERE m.id.motivationId = ?1", Sort.by("lastTouch", Sort.Direction.Descending).and("id", Sort.Direction.Ascending), motivationId).page(page, size);
 
         var pageable = new PageQueryImpl<MotivationActorJunction>();
         pageable.list = panache.list();
@@ -40,17 +40,19 @@ public class MotivationActorRepository  implements Repository<MotivationActorJun
                 .firstResultOptional()
                 .isPresent();
     }
+
     public boolean existsByStatus(String motivationId, String actorId, Boolean status) {
         return find("SELECT 1 FROM MotivationActorJunction m WHERE m.id.motivationId = ?1 AND m.id.actorId = ?2 AND m.published = ?3", motivationId, actorId, status)
                 .firstResultOptional()
                 .isPresent();
     }
+
     public Optional<MotivationActorJunction> fetchByMotivationAndActorAndVersion(String motivationId, String actorId, Integer lodMAV) {
         return find("FROM MotivationActorJunction m WHERE m.id.motivationId = ?1 AND m.id.actorId = ?2 AND m.id.lodMAV = ?3", motivationId, actorId, lodMAV)
                 .firstResultOptional();
     }
 
-        public void deleteByMotivationAndActorAndVersion(String motivationId, String actorId, Integer lodMAV) {
+    public void deleteByMotivationAndActorAndVersion(String motivationId, String actorId, Integer lodMAV) {
 
         delete("DELETE FROM MotivationActorJunction m WHERE m.id.motivationId = ?1 AND m.id.actorId = ?2 AND m.id.lodMAV = ?3", motivationId, actorId, lodMAV);
     }

--- a/service/src/main/java/org/grnet/cat/services/TemplateService.java
+++ b/service/src/main/java/org/grnet/cat/services/TemplateService.java
@@ -31,7 +31,7 @@ public class TemplateService {
 
     @Inject
     RegistryActorRepository registryActorRepository;
-    
+
     @Inject
     MotivationRepository motivationRepository;
 
@@ -44,11 +44,21 @@ public class TemplateService {
 
     public RegistryTemplateDto buildTemplate(String motivationId, String actorId) {
 
-       if( motivationActorRepository.existsByStatus(motivationId,actorId,Boolean.FALSE)){
-           throw new ForbiddenException("No action is permitted , template exists in an unpublished motivation-actor relation");
-       }
-        var motivation = motivationRepository.findByIdOptional(motivationId).orElseThrow(()->new NotFoundException("There is no Motivation with the following id : "+motivationId));
-        var actor = registryActorRepository.findByIdOptional(actorId).orElseThrow(()->new NotFoundException("There is no Actor with the following id : "+actorId));
+        var motivation = motivationRepository.findByIdOptional(motivationId).orElseThrow(() -> new NotFoundException("There is no Motivation with the following id : " + motivationId));
+        var actor = registryActorRepository.findByIdOptional(actorId).orElseThrow(() -> new NotFoundException("There is no Actor with the following id : " + actorId));
+
+        var motivationActorJunctionOpt = motivationActorRepository.fetchByMotivationAndActorAndVersion(motivationId, actorId, 1);
+
+        if(motivationActorJunctionOpt.isEmpty()){
+
+            throw new NotFoundException("There is no template for this motivation and actor.");
+        }
+
+        var motivationActorJunction = motivationActorJunctionOpt.get();
+
+//        if (!motivationActorJunction.getPublished()) {
+//            throw new ForbiddenException("No action is permitted , template exists in an unpublished motivation-actor relation");
+//        }
 
         var template = new RegistryTemplateDto();
 
@@ -68,12 +78,12 @@ public class TemplateService {
 
                 TemplateTestNode tn;
 
-                if(row.getLabelTestMethod().contains("Evidence")){
+                if (row.getLabelTestMethod().contains("Evidence")) {
 
                     tn = new TemplateTestNode(k, row.getLabelTest().trim(), row.getDescTest().trim(), row.getLabelTestMethod().trim(), new ArrayList<>(), row.getTestQuestion(), TestParamsTransformer.transformTestParams(row.getTestParams()), row.getToolTip());
                 } else {
 
-                    tn = new TemplateTestNode(k, row.getLabelTest().trim(), row.getDescTest().trim(), row.getLabelTestMethod().trim(),null, row.getTestQuestion(), TestParamsTransformer.transformTestParams(row.getTestParams()), row.getToolTip());
+                    tn = new TemplateTestNode(k, row.getLabelTest().trim(), row.getDescTest().trim(), row.getLabelTestMethod().trim(), null, row.getTestQuestion(), TestParamsTransformer.transformTestParams(row.getTestParams()), row.getToolTip());
                 }
 
                 return tn;
@@ -98,16 +108,28 @@ public class TemplateService {
 
         template.organisation = new TemplateOrganisationDto();
 
+        template.automatedGroupTest = motivationActorJunction.getAutomatedGroupTest();
+
         template.result = new TemplateResultDto();
 
         template.subject = new TemplateSubjectDto();
 
         return template;
     }
+
     public RegistryTemplateDto buildTemplateForAdmin(String motivationId, String actorId) {
 
-        var motivation = motivationRepository.findByIdOptional(motivationId).orElseThrow(()->new NotFoundException("There is no Motivation with the following id : "+motivationId));
-        var actor = registryActorRepository.findByIdOptional(actorId).orElseThrow(()->new NotFoundException("There is no Actor with the following id : "+actorId));
+        var motivation = motivationRepository.findByIdOptional(motivationId).orElseThrow(() -> new NotFoundException("There is no Motivation with the following id : " + motivationId));
+        var actor = registryActorRepository.findByIdOptional(actorId).orElseThrow(() -> new NotFoundException("There is no Actor with the following id : " + actorId));
+
+        var motivationActorJunctionOpt = motivationActorRepository.fetchByMotivationAndActorAndVersion(motivationId, actorId, 1);
+
+        if(motivationActorJunctionOpt.isEmpty()){
+
+            throw new NotFoundException("There is no template for this motivation and actor.");
+        }
+
+        var motivationActorJunction = motivationActorJunctionOpt.get();
 
         var template = new RegistryTemplateDto();
 
@@ -127,12 +149,12 @@ public class TemplateService {
 
                 TemplateTestNode tn;
 
-                if(row.getLabelTestMethod().contains("Evidence")){
+                if (row.getLabelTestMethod().contains("Evidence")) {
 
                     tn = new TemplateTestNode(k, row.getLabelTest().trim(), row.getDescTest().trim(), row.getLabelTestMethod().trim(), new ArrayList<>(), row.getTestQuestion(), TestParamsTransformer.transformTestParams(row.getTestParams()), row.getToolTip());
                 } else {
 
-                    tn = new TemplateTestNode(k, row.getLabelTest().trim(), row.getDescTest().trim(), row.getLabelTestMethod().trim(),null, row.getTestQuestion(), TestParamsTransformer.transformTestParams(row.getTestParams()), row.getToolTip());
+                    tn = new TemplateTestNode(k, row.getLabelTest().trim(), row.getDescTest().trim(), row.getLabelTestMethod().trim(), null, row.getTestQuestion(), TestParamsTransformer.transformTestParams(row.getTestParams()), row.getToolTip());
                 }
 
                 return tn;
@@ -160,6 +182,8 @@ public class TemplateService {
         template.result = new TemplateResultDto();
 
         template.subject = new TemplateSubjectDto();
+
+        template.automatedGroupTest = motivationActorJunction.getAutomatedGroupTest();
 
         return template;
     }

--- a/service/src/main/java/org/grnet/cat/services/arcc/ArccValidationService.java
+++ b/service/src/main/java/org/grnet/cat/services/arcc/ArccValidationService.java
@@ -4,20 +4,26 @@ import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.NotFoundException;
 import jakarta.ws.rs.ServerErrorException;
+import org.apache.commons.lang3.StringUtils;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.eclipse.microprofile.rest.client.inject.RestClient;
+import org.grnet.cat.dtos.AarcClaimLocation;
 import org.grnet.cat.dtos.ArccValidationRequest;
 import org.grnet.cat.dtos.ArccValidationResult;
 import org.grnet.cat.dtos.AutomatedTestResponse;
 import org.grnet.cat.dtos.AutomatedTestStatus;
 import org.grnet.cat.services.arcc.g069.NacoClient;
+import org.grnet.cat.services.arcc.g069.NacoEntryResponse;
 import org.grnet.cat.validators.XmlMetadataValidator.GeneralMetadataValidator;
 import org.grnet.cat.validators.XmlMetadataValidator.XmlSchemaValidator;
 
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Objects;
 import java.util.Set;
+import java.util.function.Predicate;
 import java.util.regex.Pattern;
 
 @ApplicationScoped
@@ -37,8 +43,10 @@ public class ArccValidationService {
 
     // Define the regex pattern for AARC-G069 entitlements
     private static final String AARC_G069_REGEX = "^([a-zA-Z0-9][a-zA-Z0-9:._-]*):group:([a-zA-Z0-9._-]+(?:[:][a-zA-Z0-9._-]+)*)(:role=[a-zA-Z0-9._-]+)?(#.+)?$";
-    private static final Pattern PATTERN = Pattern.compile(AARC_G069_REGEX);
 
+    private static final String AARC_G056_REGEX = "^([a-zA-Z0-9][a-zA-Z0-9.:-]*):res:([a-zA-Z0-9][a-zA-Z0-9_-]*)(?::[a-zA-Z0-9][a-zA-Z0-9_-]*)*?(?::act:[a-zA-Z0-9][a-zA-Z0-9_-]*(?:,[a-zA-Z0-9][a-zA-Z0-9_-]*)*)?(?:#[a-zA-Z0-9][a-zA-Z0-9.:%_-]*)?$";
+
+    private static final String EMAIL_RFC2821_REGEX = "^(?i)[a-z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?(?:\\.[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?)*$";
 
     public AutomatedTestResponse validateMetadataByTestType(String type, ArccValidationRequest request) {
 
@@ -118,7 +126,7 @@ public class ArccValidationService {
             entitlementsInIntrospection.message = "entitlements claim is missing from the Token Introspection response.";
         } else{
 
-            if(response.getIntrospectionInfo().getEntitlements().stream().anyMatch(this::isValidEntitlement)){
+            if(response.getIntrospectionInfo().getEntitlements().stream().anyMatch(value-> isValidValue(value, AARC_G069_REGEX))){
 
                 entitlementsInIntrospection.isValid = true;
                 entitlementsInIntrospection.message = "entitlements found in introspection_info, and at least one entitlement follows the expected URN format (AARC-G069).";
@@ -140,7 +148,7 @@ public class ArccValidationService {
             entitlementsInUserInfo.message = "entitlements claim is missing from the UserInfo response.";
         } else{
 
-            if(response.getUserInfo().getEntitlements().stream().anyMatch(this::isValidEntitlement)){
+            if(response.getUserInfo().getEntitlements().stream().anyMatch(value-> isValidValue(value, AARC_G069_REGEX))){
 
                 entitlementsInUserInfo.isValid = true;
                 entitlementsInUserInfo.message = "entitlements found in user_info, and at least one entitlement follows the expected URN format (AARC-G069).";
@@ -166,8 +174,537 @@ public class ArccValidationService {
         return arccResponse;
     }
 
-    private boolean isValidEntitlement(String value) {
+    public AutomatedTestResponse validateAarcG056(String aaiProviderId){
 
+        var nacoResponse = nacoClient.getEntry(aaiProviderId, SERVICE_KEY);
+
+        var tests = new ArrayList<ArccValidationResult>();
+
+        var apiResponse = new AutomatedTestResponse();
+
+        validateAarcName(nacoResponse, apiResponse, tests);
+
+        validateAarcGivenName(nacoResponse, apiResponse, tests);
+
+        var status = new AutomatedTestStatus();
+        status.isValid = tests.stream().allMatch(test->test.isValid);
+        status.message = "All validations were executed successfully during the test run.";
+
+        apiResponse.testStatus = status;
+
+        return apiResponse;
+    }
+
+    private void validateAarcName(NacoEntryResponse nacoResponse, AutomatedTestResponse apiResponse, List<ArccValidationResult> tests){
+
+       var name = new ArccValidationResult();
+
+        if(Objects.isNull(nacoResponse.getUserInfo())){
+
+            name.isValid = false;
+            name.message = "user_info section is missing from the response.";
+        } else if (StringUtils.isEmpty(nacoResponse.getUserInfo().getName())){
+
+            name.isValid = false;
+            name.message = "Missing or empty name claim in UserInfo response.";
+        } else{
+
+            name.isValid = true;
+            name.message = "name found in user_info.";
+        }
+
+        apiResponse.additionalInfo.put("name_user_info", name);
+        tests.add(name);
+    }
+
+    private void validateAarcGivenName(NacoEntryResponse nacoResponse, AutomatedTestResponse apiResponse, List<ArccValidationResult> tests){
+
+        var givenName = new ArccValidationResult();
+
+        if(Objects.isNull(nacoResponse.getUserInfo())){
+
+            givenName.isValid = false;
+            givenName.message = "user_info section is missing from the response.";
+        } else if (StringUtils.isEmpty(nacoResponse.getUserInfo().getGivenName())){
+
+            givenName.isValid = false;
+            givenName.message = "Missing or empty given_name claim in UserInfo response.";
+        } else{
+
+            givenName.isValid = true;
+            givenName.message = "given_name found in user_info.";
+        }
+
+        apiResponse.additionalInfo.put("given_name_user_info", givenName);
+    }
+
+    private void validateAarcFamilyName(NacoEntryResponse nacoResponse, AutomatedTestResponse apiResponse){
+
+        var familyName = new ArccValidationResult();
+
+        var location =  new AarcClaimLocation();
+
+        if(Objects.isNull(nacoResponse.getUserInfo())){
+
+            familyName.isValid = false;
+            familyName.message = "user_info section is missing from the response.";
+        } else if (StringUtils.isEmpty(nacoResponse.getUserInfo().getFamilyName())){
+
+            familyName.isValid = false;
+            familyName.message = "Missing or empty family_name claim in UserInfo response.";
+        } else{
+
+            familyName.isValid = true;
+            familyName.message = "family_name found in user_info.";
+        }
+
+        location.userInfo =  familyName;
+
+        apiResponse.additionalInfo.put("family_name", location);
+    }
+
+    private void validateAarcEmail(NacoEntryResponse nacoResponse, AutomatedTestResponse apiResponse){
+
+        var email = new ArccValidationResult();
+
+        var location =  new AarcClaimLocation();
+
+        if(Objects.isNull(nacoResponse.getUserInfo())){
+
+            email.isValid = false;
+            email.message = "user_info section is missing from the response.";
+        } else if (StringUtils.isEmpty(nacoResponse.getUserInfo().getEmail())){
+
+            email.isValid = false;
+            email.message = "Missing or empty email claim in UserInfo response.";
+        } else{
+
+            if(isValidValue(nacoResponse.getUserInfo().getEmail(), EMAIL_RFC2821_REGEX)){
+
+                email.isValid = true;
+                email.message = "email found in user_info, and follows the expected email format (RFC 2821).";
+            } else {
+
+                email.isValid = false;
+                email.message = "email found in user_info, but it doesn't follow the expected email format (RFC 2821).";
+            }
+        }
+
+        location.userInfo =  email;
+
+        apiResponse.additionalInfo.put("email", location);
+    }
+
+    private void validateAarcOrganizationName(NacoEntryResponse nacoResponse, AutomatedTestResponse apiResponse){
+
+        var organizationName = new ArccValidationResult();
+
+        var location =  new AarcClaimLocation();
+
+        if(Objects.isNull(nacoResponse.getUserInfo())){
+
+            organizationName.isValid = false;
+            organizationName.message = "user_info section is missing from the response.";
+        } else if (StringUtils.isEmpty(nacoResponse.getUserInfo().getOrganizationName())){
+
+            organizationName.isValid = false;
+            organizationName.message = "Missing or empty organization_name claim in UserInfo response.";
+        } else{
+
+            organizationName.isValid = true;
+            organizationName.message = "organization_name found in user_info.";
+        }
+
+        location.userInfo = organizationName;
+
+        apiResponse.additionalInfo.put("organization_name", location);
+    }
+
+    private void validateAarcOrganizationDomain(NacoEntryResponse nacoResponse, AutomatedTestResponse apiResponse){
+
+        var organizationNameInUserInfo = new ArccValidationResult();
+
+        var organizationNameInTokenIntrospection = new ArccValidationResult();
+
+        var location =  new AarcClaimLocation();
+
+        if(Objects.isNull(nacoResponse.getUserInfo())){
+
+            organizationNameInUserInfo.isValid = false;
+            organizationNameInUserInfo.message = "user_info section is missing from the response.";
+        } else if (StringUtils.isEmpty(nacoResponse.getUserInfo().getOrganizationDomain())){
+
+            organizationNameInUserInfo.isValid = false;
+            organizationNameInUserInfo.message = "Missing or empty schac_home_organization claim in UserInfo response.";
+        } else{
+
+            organizationNameInUserInfo.isValid = true;
+            organizationNameInUserInfo.message = "schac_home_organization found in user_info.";
+        }
+
+        if(Objects.isNull(nacoResponse.getIntrospectionInfo())){
+
+            organizationNameInTokenIntrospection.isValid = false;
+            organizationNameInTokenIntrospection.message = "introspection_info section is missing from the response.";
+        } else if (StringUtils.isEmpty(nacoResponse.getIntrospectionInfo().getOrganizationDomain())){
+
+            organizationNameInTokenIntrospection.isValid = false;
+            organizationNameInTokenIntrospection.message = "Missing or empty schac_home_organization claim in Token Introspection response.";
+        } else{
+
+            organizationNameInTokenIntrospection.isValid = true;
+            organizationNameInTokenIntrospection.message = "schac_home_organization found in introspection_info.";
+        }
+
+        location.userInfo = organizationNameInUserInfo;
+        location.introspectionInfo = organizationNameInTokenIntrospection;
+
+        apiResponse.additionalInfo.put("schac_home_organization", location);
+    }
+
+    private void validateAarcAffiliationWithinHomeOrganisation(NacoEntryResponse nacoResponse, AutomatedTestResponse apiResponse){
+
+        var affiliationNameInUserInfo = new ArccValidationResult();
+
+        var affiliationInTokenIntrospection = new ArccValidationResult();
+
+        var location =  new AarcClaimLocation();
+
+        if(Objects.isNull(nacoResponse.getUserInfo())){
+
+            affiliationNameInUserInfo.isValid = false;
+            affiliationNameInUserInfo.message = "user_info section is missing from the response.";
+        } else if (Objects.isNull(nacoResponse.getUserInfo().getAffiliationWithHomeOrganization()) || nacoResponse.getUserInfo().getAffiliationWithHomeOrganization().isEmpty()){
+
+            affiliationNameInUserInfo.isValid = false;
+            affiliationNameInUserInfo.message = "Missing or empty voperson_external_affiliation claim in UserInfo response.";
+        } else{
+
+            affiliationNameInUserInfo.isValid = true;
+            affiliationNameInUserInfo.message = "voperson_external_affiliation found in user_info.";
+        }
+
+        if(Objects.isNull(nacoResponse.getIntrospectionInfo())){
+
+            affiliationInTokenIntrospection.isValid = false;
+            affiliationInTokenIntrospection.message = "introspection_info section is missing from the response.";
+        } else if ((Objects.isNull(nacoResponse.getIntrospectionInfo().getAffiliationWithHomeOrganization()) || nacoResponse.getIntrospectionInfo().getAffiliationWithHomeOrganization().isEmpty())){
+
+            affiliationInTokenIntrospection.isValid = false;
+            affiliationInTokenIntrospection.message = "Missing or empty voperson_external_affiliation claim in Token Introspection response.";
+        } else{
+
+            affiliationInTokenIntrospection.isValid = true;
+            affiliationInTokenIntrospection.message = "voperson_external_affiliation found in introspection_info.";
+        }
+
+        location.userInfo = affiliationNameInUserInfo;
+        location.introspectionInfo = affiliationInTokenIntrospection;
+
+        apiResponse.additionalInfo.put("voperson_external_affiliation", location);
+    }
+
+    private void validateAarcAffiliationAssurance(NacoEntryResponse nacoResponse, AutomatedTestResponse apiResponse){
+
+        var affiliationInTokenIntrospection = new ArccValidationResult();
+        var affiliationNameInAccessToken = new ArccValidationResult();
+
+        var location =  new AarcClaimLocation();
+
+        if(Objects.isNull(nacoResponse.getIntrospectionInfo())){
+
+            affiliationInTokenIntrospection.isValid = false;
+            affiliationInTokenIntrospection.message = "introspection_info section is missing from the response.";
+        } else if ((Objects.isNull(nacoResponse.getIntrospectionInfo().getAssurance()) || nacoResponse.getIntrospectionInfo().getAssurance().isEmpty())){
+
+            affiliationInTokenIntrospection.isValid = false;
+            affiliationInTokenIntrospection.message = "Missing or empty eduperson_assurance claim in Token Introspection response.";
+        } else{
+
+            affiliationInTokenIntrospection.isValid = true;
+            affiliationInTokenIntrospection.message = "eduperson_assurance found in introspection_info.";
+        }
+
+        if(Objects.isNull(nacoResponse.getAccessTokenInfo())){
+
+            affiliationNameInAccessToken.isValid = false;
+            affiliationNameInAccessToken.message = "access_token_info section is missing from the response.";
+        } else if ((Objects.isNull(nacoResponse.getAccessTokenInfo().getAssurance()) || nacoResponse.getAccessTokenInfo().getAssurance().isEmpty())){
+
+            affiliationNameInAccessToken.isValid = false;
+            affiliationNameInAccessToken.message = "Missing or empty eduperson_assurance claim in Access Token response.";
+        } else{
+
+            affiliationNameInAccessToken.isValid = true;
+            affiliationNameInAccessToken.message = "eduperson_assurance found in access_token_info.";
+        }
+
+        location.userInfo = affiliationNameInAccessToken;
+        location.introspectionInfo = affiliationInTokenIntrospection;
+
+        apiResponse.additionalInfo.put("eduperson_assurance", location);
+    }
+
+    private void validateAarcGroupAndRole(NacoEntryResponse nacoResponse, AutomatedTestResponse apiResponse) {
+
+        var entitlementsInUserInfo = new ArccValidationResult();
+
+        var entitlementsInIntrospection = new ArccValidationResult();
+
+        var location =  new AarcClaimLocation();
+
+        if(Objects.isNull(nacoResponse.getIntrospectionInfo())){
+
+            entitlementsInIntrospection.isValid = false;
+            entitlementsInIntrospection.message = "introspection_info section is missing from the response.";
+
+        } else if (Objects.isNull(nacoResponse.getIntrospectionInfo().getEntitlements())){
+
+            entitlementsInIntrospection.isValid = false;
+            entitlementsInIntrospection.message = "entitlements claim is missing from the Token Introspection response.";
+        } else{
+
+            if(nacoResponse.getIntrospectionInfo().getEntitlements().stream().anyMatch(value-> isValidValue(value, AARC_G069_REGEX))){
+
+                entitlementsInIntrospection.isValid = true;
+                entitlementsInIntrospection.message = "entitlements found in introspection_info, and at least one entitlement follows the expected URN format (AARC-G069).";
+            } else {
+
+                entitlementsInIntrospection.isValid = false;
+                entitlementsInIntrospection.message = "entitlements found in introspection_info, but none follow the expected URN format (AARC-G069).";
+            }
+        }
+
+        if(Objects.isNull(nacoResponse.getUserInfo())){
+
+            entitlementsInUserInfo.isValid = false;
+            entitlementsInUserInfo.message = "user_info section is missing from the response.";
+
+        } else if (Objects.isNull(nacoResponse.getUserInfo().getEntitlements())){
+
+            entitlementsInUserInfo.isValid = false;
+            entitlementsInUserInfo.message = "entitlements claim is missing from the UserInfo response.";
+        } else{
+
+            if(nacoResponse.getUserInfo().getEntitlements().stream().anyMatch(value-> isValidValue(value, AARC_G069_REGEX))){
+
+                entitlementsInUserInfo.isValid = true;
+                entitlementsInUserInfo.message = "entitlements found in user_info, and at least one entitlement follows the expected URN format (AARC-G069).";
+            } else {
+
+                entitlementsInUserInfo.isValid = false;
+                entitlementsInUserInfo.message = "entitlements found in user_info, but none follow the expected URN format (AARC-G069).";
+            }
+        }
+
+        location.userInfo = entitlementsInUserInfo;
+        location.introspectionInfo = entitlementsInIntrospection;
+
+        apiResponse.additionalInfo.put("group_and_role_entitlements", location);
+    }
+
+    private void validateAarcSub(NacoEntryResponse nacoResponse, AutomatedTestResponse apiResponse){
+
+        var subInUserInfo = new ArccValidationResult();
+
+        var subInTokenIntrospection = new ArccValidationResult();
+
+        var subInAccessToken = new ArccValidationResult();
+
+        var location =  new AarcClaimLocation();
+
+        if(Objects.isNull(nacoResponse.getUserInfo())){
+
+            subInUserInfo.isValid = false;
+            subInUserInfo.message = "user_info section is missing from the response.";
+        } else if (StringUtils.isEmpty(nacoResponse.getUserInfo().getSub())){
+
+            subInUserInfo.isValid = false;
+            subInUserInfo.message = "Missing or empty sub claim in UserInfo response.";
+        } else{
+
+            subInUserInfo.isValid = true;
+            subInUserInfo.message = "sub found in user_info.";
+        }
+
+        if(Objects.isNull(nacoResponse.getIntrospectionInfo())){
+
+            subInTokenIntrospection.isValid = false;
+            subInTokenIntrospection.message = "introspection_info section is missing from the response.";
+        } else if (StringUtils.isEmpty(nacoResponse.getIntrospectionInfo().getSub())){
+
+            subInTokenIntrospection.isValid = false;
+            subInTokenIntrospection.message = "Missing or empty sub claim in Token Introspection response.";
+        } else{
+
+            subInTokenIntrospection.isValid = true;
+            subInTokenIntrospection.message = "sub found in introspection_info.";
+        }
+
+        if(Objects.isNull(nacoResponse.getAccessTokenInfo())){
+
+            subInAccessToken.isValid = false;
+            subInAccessToken.message = "access_token_info section is missing from the response.";
+        } else if (StringUtils.isEmpty(nacoResponse.getAccessTokenInfo().getSub())){
+
+            subInAccessToken.isValid = false;
+            subInAccessToken.message = "Missing or empty sub claim in Access Token response.";
+        } else{
+
+            subInAccessToken.isValid = true;
+            subInAccessToken.message = "sub found in access_token_info.";
+        }
+
+        location.userInfo = subInUserInfo;
+        location.introspectionInfo = subInTokenIntrospection;
+        location.accessTokenInfo = subInAccessToken;
+
+        apiResponse.additionalInfo.put("sub", location);
+    }
+
+    private void validateAarcVopersonId(NacoEntryResponse nacoResponse, AutomatedTestResponse apiResponse){
+
+        var voPersonIdInUserInfo = new ArccValidationResult();
+
+        var voPersonIdInTokenIntrospection = new ArccValidationResult();
+
+        var voPersonIdInAccessToken = new ArccValidationResult();
+
+        var location =  new AarcClaimLocation();
+
+        if(Objects.isNull(nacoResponse.getUserInfo())){
+
+            voPersonIdInUserInfo.isValid = false;
+            voPersonIdInUserInfo.message = "user_info section is missing from the response.";
+        } else if ((Objects.isNull(nacoResponse.getUserInfo().getVopersonId()) || nacoResponse.getUserInfo().getVopersonId().isEmpty())){
+
+            voPersonIdInUserInfo.isValid = false;
+            voPersonIdInUserInfo.message = "Missing or empty voperson_id claim in UserInfo response.";
+        } else{
+
+            if(nacoResponse.getUserInfo().getVopersonId().size() == 1){
+
+                voPersonIdInUserInfo.isValid = true;
+                voPersonIdInUserInfo.message = "voperson_id found in user_info.";
+            } else {
+
+                voPersonIdInUserInfo.isValid = false;
+                voPersonIdInUserInfo.message = "voperson_id in user_info contains multiple values; expected a single value.";
+
+            }
+        }
+
+        if(Objects.isNull(nacoResponse.getIntrospectionInfo())){
+
+            voPersonIdInTokenIntrospection.isValid = false;
+            voPersonIdInTokenIntrospection.message = "introspection_info section is missing from the response.";
+        } else if ((Objects.isNull(nacoResponse.getIntrospectionInfo().getVopersonId()) || nacoResponse.getIntrospectionInfo().getVopersonId().isEmpty())){
+
+            voPersonIdInTokenIntrospection.isValid = false;
+            voPersonIdInTokenIntrospection.message = "Missing or empty voperson_id claim in Token Introspection response.";
+        } else{
+
+            if(nacoResponse.getIntrospectionInfo().getVopersonId().size() == 1){
+
+                voPersonIdInTokenIntrospection.isValid = true;
+                voPersonIdInTokenIntrospection.message = "voperson_id found in introspection_info.";
+            } else {
+
+                voPersonIdInTokenIntrospection.isValid = false;
+                voPersonIdInTokenIntrospection.message = "voperson_id in introspection_info contains multiple values; expected a single value.";
+
+            }
+        }
+
+        if(Objects.isNull(nacoResponse.getAccessTokenInfo())){
+
+            voPersonIdInAccessToken.isValid = false;
+            voPersonIdInAccessToken.message = "access_token_info section is missing from the response.";
+        } else if ((Objects.isNull(nacoResponse.getAccessTokenInfo().getVopersonId()) || nacoResponse.getAccessTokenInfo().getVopersonId().isEmpty())){
+
+            voPersonIdInAccessToken.isValid = false;
+            voPersonIdInAccessToken.message = "Missing or empty voperson_id claim in Access Token response.";
+        } else{
+
+            if(nacoResponse.getAccessTokenInfo().getVopersonId().size() == 1){
+
+                voPersonIdInAccessToken.isValid = true;
+                voPersonIdInAccessToken.message = "voperson_id found in access_token_info.";
+            } else {
+
+                voPersonIdInAccessToken.isValid = false;
+                voPersonIdInAccessToken.message = "voperson_id in access_token_info contains multiple values; expected a single value.";
+            }
+        }
+
+        location.userInfo = voPersonIdInUserInfo;
+        location.introspectionInfo = voPersonIdInTokenIntrospection;
+        location.accessTokenInfo = voPersonIdInAccessToken;
+
+        apiResponse.additionalInfo.put("voperson_id", location);
+    }
+
+    private void validateAarcResourceCapabilities(NacoEntryResponse nacoResponse, AutomatedTestResponse apiResponse) {
+
+        var entitlementsInUserInfo = new ArccValidationResult();
+
+        var entitlementsInIntrospection = new ArccValidationResult();
+
+        var location =  new AarcClaimLocation();
+
+        if(Objects.isNull(nacoResponse.getIntrospectionInfo())){
+
+            entitlementsInIntrospection.isValid = false;
+            entitlementsInIntrospection.message = "introspection_info section is missing from the response.";
+
+        } else if (Objects.isNull(nacoResponse.getIntrospectionInfo().getEntitlements())){
+
+            entitlementsInIntrospection.isValid = false;
+            entitlementsInIntrospection.message = "entitlements claim is missing from the Token Introspection response.";
+        } else{
+
+            if(nacoResponse.getIntrospectionInfo().getEntitlements().stream().anyMatch(value-> isValidValue(value, AARC_G056_REGEX))){
+
+                entitlementsInIntrospection.isValid = true;
+                entitlementsInIntrospection.message = "entitlements found in introspection_info, and at least one entitlement follows the expected URN format (AARC-G056).";
+            } else {
+
+                entitlementsInIntrospection.isValid = false;
+                entitlementsInIntrospection.message = "entitlements found in introspection_info, but none follow the expected URN format (AARC-G056).";
+            }
+        }
+
+        if(Objects.isNull(nacoResponse.getUserInfo())){
+
+            entitlementsInUserInfo.isValid = false;
+            entitlementsInUserInfo.message = "user_info section is missing from the response.";
+
+        } else if (Objects.isNull(nacoResponse.getUserInfo().getEntitlements())){
+
+            entitlementsInUserInfo.isValid = false;
+            entitlementsInUserInfo.message = "entitlements claim is missing from the UserInfo response.";
+        } else{
+
+            if(nacoResponse.getUserInfo().getEntitlements().stream().anyMatch(value-> isValidValue(value, AARC_G056_REGEX))){
+
+                entitlementsInUserInfo.isValid = true;
+                entitlementsInUserInfo.message = "entitlements found in user_info, and at least one entitlement follows the expected URN format (AARC-G056).";
+            } else {
+
+                entitlementsInUserInfo.isValid = false;
+                entitlementsInUserInfo.message = "entitlements found in user_info, but none follow the expected URN format (AARC-G056).";
+            }
+        }
+
+        location.userInfo = entitlementsInUserInfo;
+        location.introspectionInfo = entitlementsInIntrospection;
+
+        apiResponse.additionalInfo.put("resource_capabilities_entitlements", location);
+    }
+
+    private boolean isValidValue(String value, String regex) {
+
+        var PATTERN = Pattern.compile(regex);
         var matcher = PATTERN.matcher(value);
         return matcher.matches();
     }

--- a/service/src/main/java/org/grnet/cat/services/arcc/g069/AccessTokenInfo.java
+++ b/service/src/main/java/org/grnet/cat/services/arcc/g069/AccessTokenInfo.java
@@ -9,10 +9,7 @@ import java.util.List;
 
 @Getter
 @Setter
-public class IntrospectionInfo {
-
-    @JsonProperty("entitlements")
-    private List<String> entitlements;
+public class AccessTokenInfo {
 
     @JsonProperty("sub")
     private String sub;
@@ -20,12 +17,6 @@ public class IntrospectionInfo {
     @JsonProperty("voperson_id")
     @JsonDeserialize(using = StringOrArrayDeserializer.class)
     private List<String> vopersonId;
-
-    @JsonProperty("schac_home_organization")
-    private String organizationDomain;
-
-    @JsonProperty("voperson_external_affiliation")
-    private List<String> affiliationWithHomeOrganization;
 
     @JsonProperty("eduperson_assurance")
     private List<String> assurance;

--- a/service/src/main/java/org/grnet/cat/services/arcc/g069/NacoEntryResponse.java
+++ b/service/src/main/java/org/grnet/cat/services/arcc/g069/NacoEntryResponse.java
@@ -1,7 +1,11 @@
 package org.grnet.cat.services.arcc.g069;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.Setter;
 
+@Getter
+@Setter
 public class NacoEntryResponse {
 
     @JsonProperty("introspection_info")
@@ -10,19 +14,6 @@ public class NacoEntryResponse {
     @JsonProperty("user_info")
     private UserInfo userInfo;
 
-    public IntrospectionInfo getIntrospectionInfo() {
-        return introspectionInfo;
-    }
-
-    public void setIntrospectionInfo(IntrospectionInfo introspectionInfo) {
-        this.introspectionInfo = introspectionInfo;
-    }
-
-    public UserInfo getUserInfo() {
-        return userInfo;
-    }
-
-    public void setUserInfo(UserInfo userInfo) {
-        this.userInfo = userInfo;
-    }
+    @JsonProperty("access_token_info")
+    private AccessTokenInfo accessTokenInfo;
 }

--- a/service/src/main/java/org/grnet/cat/services/arcc/g069/StringOrArrayDeserializer.java
+++ b/service/src/main/java/org/grnet/cat/services/arcc/g069/StringOrArrayDeserializer.java
@@ -1,0 +1,37 @@
+package org.grnet.cat.services.arcc.g069;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+public class StringOrArrayDeserializer extends JsonDeserializer<List<String>> {
+
+    @Override
+    public List<String> deserialize(JsonParser jsonParser, DeserializationContext deserializationContext) throws IOException {
+
+        JsonNode node = jsonParser.getCodec().readTree(jsonParser);
+
+        if (node.isArray()) {
+            var arrayNode = (ArrayNode) node;
+            var list = new ArrayList<String>();
+            for (JsonNode element : arrayNode) {
+                if (!element.asText().isEmpty()) {
+                    list.add(element.asText());
+                }
+            }
+            return list;
+        } else if (node.isTextual()) {
+            String val = node.asText();
+            return val.isEmpty() ? Collections.emptyList() : Collections.singletonList(val);
+        } else {
+            return Collections.emptyList();
+        }
+    }
+}

--- a/service/src/main/java/org/grnet/cat/services/arcc/g069/UserInfo.java
+++ b/service/src/main/java/org/grnet/cat/services/arcc/g069/UserInfo.java
@@ -1,19 +1,44 @@
 package org.grnet.cat.services.arcc.g069;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import lombok.Getter;
+import lombok.Setter;
 
 import java.util.List;
 
+@Getter
+@Setter
 public class UserInfo {
 
     @JsonProperty("entitlements")
     private List<String> entitlements;
 
-    public List<String> getEntitlements() {
-        return entitlements;
-    }
+    @JsonProperty("family_name")
+    private String familyName;
 
-    public void setEntitlements(List<String> entitlements) {
-        this.entitlements = entitlements;
-    }
+    @JsonProperty("given_name")
+    private String givenName;
+
+    @JsonProperty("name")
+    private String name;
+
+    @JsonProperty("email")
+    private String email;
+
+    @JsonProperty("sub")
+    private String sub;
+
+    @JsonProperty("voperson_id")
+    @JsonDeserialize(using = StringOrArrayDeserializer.class)
+    private List<String> vopersonId;
+
+    @JsonProperty("schac_home_organization")
+    private String organizationDomain;
+
+    @JsonProperty("voperson_external_affiliation")
+    private List<String> affiliationWithHomeOrganization;
+
+    @JsonProperty("organization_name")
+    private String organizationName;
 }

--- a/service/src/main/java/org/grnet/cat/services/registry/MotivationService.java
+++ b/service/src/main/java/org/grnet/cat/services/registry/MotivationService.java
@@ -144,7 +144,7 @@ public class MotivationService {
                     actor.setLodMTV(motivationId);
                 }
 
-                motivation.addActor(Panache.getEntityManager().getReference(RegistryActor.class, req.actorId), Panache.getEntityManager().getReference(Relation.class, req.relation), motivation.getId(), 1, userId, Timestamp.from(Instant.now()));
+                motivation.addActor(Panache.getEntityManager().getReference(RegistryActor.class, req.actorId), Panache.getEntityManager().getReference(Relation.class, req.relation), motivation.getId(), 1, userId, Timestamp.from(Instant.now()), req.automatedGroupTest);
                 resultMessages.add("Actor with id :: " + req.actorId + " successfully added to motivation.");
             } else {
                 resultMessages.add("Actor with id :: " + req.actorId + " already exists to motivation.");


### PR DESCRIPTION
A new test method named `Fully-Automated-Validation` has been created, which is used by all tests that are executed in a fully automated manner. In addition, the following tests have been created. These are responsible for validating the `name` and `given_name` attributes in the Naco response, and are linked to the above test method:

```
INSERT INTO p_Test (
  lodTES, TES, lodTME, testparams, labelTest, descTest, 
  lodMTV, lodTES_V, version, labeltestdefinition, paramtype, testquestion, tooltip
) VALUES (
  'pid_graph:056489G8', 'Userinfo-Name-Claim-Available', 'pid_graph:G0A5FWLC',
  'name_user_info', 'Name claim available in Userinfo endpoint.',
  'This test verifies that the name claim is available at the Userinfo endpoint of an AARC-compliant Identity Provider.',
  null, 1, 1, 'Automated confirmation of AARC-G056 compliance', 'String',
  'Does the OpenID Connect UserInfo endpoint of the AAI service return Display Name information within the name claim as required by AARC-G056?',
  'Automatically checks if the required claim is released in compliance with the AARC-G056 specification, with no manual steps involved.'
);
```

```
INSERT INTO p_Test (
  lodTES, TES, lodTME, testparams, labelTest, descTest,
  lodMTV, lodTES_V, version, labeltestdefinition, paramtype, testquestion, tooltip
) VALUES (
  'pid_graph:890489L8', 'Userinfo-Given-Name-Claim-Available', 'pid_graph:G0A5FWLC',
  'given_name_user_info', 'Given name claim available in Userinfo endpoint.',
  'This test verifies that the given name claim is available at the Userinfo endpoint of an AARC-compliant Identity Provider.',
  null, 1, 1, 'Automated confirmation of AARC-G056 compliance', 'String',
  'Does the OpenID Connect UserInfo endpoint of the AAI service return Given Name information within the given_name claim as required by AARC-G056?',
  'Automatically checks if the required claim is released in compliance with the AARC-G056 specification, with no manual steps involved.'
);
```
The `testparams` field in each of these tests contains the parameter name that the UI should search for in the response of the `/v1/automated/aarc-g056` API, in order to determine whether the test was successful. Here is an example of the corresponding API response:

```
{
  "test_status": {
    "code": 200,
    "is_valid": true,
    "message": "All validations were executed successfully during the test run."
  },
  "last_run": "2025-05-29T10:48:58.576529+03:00",
  "additional_info": {
    "given_name_user_info": {
      "is_valid": true,
      "message": "given_name found in user_info."
    },
    "name_user_info": {
      "is_valid": true,
      "message": "name found in user_info."
    }
  }
}
```
Furthermore, a new field named `automated_group_test` has been added to the **Motivation–Actor relation**. This field contains all the necessary information for an assessment to execute all **Fully-Automated-Validation type tests** completely automatically.  This information can be added via the **POST /v1/registry/motivations/{id}/actors endpoint**. Example:

```
[
  {
    "actor_id": "pid_graph:0E00C332",
    "relation": "maintainedBy",
    "automated_group_test": [
      {
        "test_method": "Fully-Automated-Validation",
        "endpoint": "v1/automated/aarc-g056",
        "params": [
          {
            "name": "aai_provider_id",
            "assessment_ref": "organisation.id"
          }
        ]
      }
    ]
  }
]
```

The automated_group_test field is returned as part of the registry template, so the UI can automatically execute all the tests declared in that field. Example registry template:

```
{
  "name": "",
  "published": false,
  "timestamp": "",
  "actor": {
    "id": "pid_graph:0E00C332",
    "name": "PID Scheme (Component)"
  },
  "organisation": {
    "id": "",
    "name": ""
  },
  "subject": {
    "id": "",
    "name": "",
    "type": "",
    "db_id": null
  },
  "result": {
    "compliance": null,
    "ranking": null
  },
  "principles": [],
  "assessment_type": {
    "id": "pid_graph:3E109BBA",
    "name": "EOSC PID Policy"
  },
  "automated_group_test": [
    {
      "params": [
        {
          "name": "aai_provider_id",
          "assessment_ref": "organisation.id"
        }
      ],
      "endpoint": "v1/automated/aarc-g056",
      "test_method": "Fully-Automated-Validation"
    }
  ]
}
```



