### PR TITLE
CAT-1030 Update AMR test

### DIFF
--- a/entity/src/main/resources/db/migration/tables/registry/V1.73__update_test_amr.sql
+++ b/entity/src/main/resources/db/migration/tables/registry/V1.73__update_test_amr.sql
@@ -1,0 +1,14 @@
+-- ------------------------------------------------
+-- Version: v1.73
+--
+-- Description: Migration that updates the amr-2.1 test
+-- -------------------------------------------------
+
+-- Update the test
+UPDATE p_Test
+SET paramType = 'onscreen',
+labelTestDefinition = 'AA Operator collected and published the community documents for the benefit of Relying Parties',
+testParams = 'commDocs|evidence',
+testQuestion = 'Has the AA Operator collected and published the community documents for the benefit of Relying Parties?|Provide evidence of that via a URL to a page or to a documentation.' ,
+toolTip = 'Community documents are available for the Relying Parties|A document, web page, or publication describing provisions'
+WHERE lodTES = 'pid_graph:76489E11';


### PR DESCRIPTION
Updating test AMR-2.1 with missing values:
```
{
      "id": "pid_graph:76489E11",
      "tes": "AMR-2.1",
      "label": "Collection and Publication of Community Documents",
      "description": "Has the AA Operator collected and published the community documents for the benefit of Relying Parties.",
      "test_method_id": "pid_graph:8D79984F",
      "label_test_definition": "AA Operator collected and published the community documents for the benefit of Relying Parties",
      "param_type":"onscreen",
      "test_params": "commDocs|evidence",
      "test_question": "Has the AA Operator collected and published the community documents for the benefit of Relying Parties?|Provide evidence of that via a URL to a page or to a documentation.",
      "tool_tip": "Community documents are available for the Relying Parties|A document, web page, or publication describing provisions",
      "motivation_id": "pid_graph:5EB0885A",
      "populated_by": null,
      "last_touch": "2025-05-30T14:22:57.620+00:00",
      "lodTES_V": "pid_graph:76489E11",
      "version": "1",
      "used_by_motivations": [
        {
          "id": "pid_graph:5EB0885A",
          "mtv": "G071",
          "label": "AARC-G071"
        }
      ],
      "test_versions": []
    }
}