### PR TITLE
CAT-891 Publishing to Zenodo New Version

### DIFF
--- a/api/src/test/java/org/grnet/cat/api/ZenodoEndpointTest.java
+++ b/api/src/test/java/org/grnet/cat/api/ZenodoEndpointTest.java
@@ -304,6 +304,65 @@ public class ZenodoEndpointTest extends KeycloakTest {
         String expectedMessage = "Invalid PDF file format.";
         assertEquals(expectedMessage, response.message);
     }
+    @Test
+    @Execution(ExecutionMode.CONCURRENT)
+    public void testVersionPublishedZenodo() throws  IOException {
+        var originalAssessment = createRegistryPublicAssessment(validatedToken);
+
+        var pdf = generateValidPdf();
+
+        var responseOriginal = given()
+                .auth()
+                .oauth2(validatedToken)
+                .body(pdf)
+                .contentType("application/octet-stream")
+                .post("/publish/assessment/{id}", originalAssessment.id)
+                .then()
+                .assertThat()
+                .statusCode(200)
+                .extract()
+                .as(InformativeResponse.class);
+
+        var zenodoAssessmentInfoOriginal = given()
+                .auth()
+                .oauth2(validatedToken)
+                .get("/assessment/{id}", originalAssessment.id)
+                .then()
+                .assertThat()
+                .statusCode(200)
+                .extract()
+                .as(ZenodoAssessmentInfoResponse.class);
+
+        var childAssessment = createRegistryPublicAssessment(validatedToken);
+
+        childAssessment.parentAssessmentId = originalAssessment.parentAssessmentId;
+
+        var responseChild = given()
+                .auth()
+                .oauth2(validatedToken)
+                .body(pdf)
+                .contentType("application/octet-stream")
+                .post("/publish/assessment/{id}", childAssessment.id)
+                .then()
+                .assertThat()
+                .statusCode(200)
+                .extract()
+                .as(InformativeResponse.class);
+
+        var zenodoAssessmentInfoChild = given()
+                .auth()
+                .oauth2(validatedToken)
+                .get("/assessment/{id}", childAssessment.id)
+                .then()
+                .assertThat()
+                .statusCode(200)
+                .extract()
+                .as(ZenodoAssessmentInfoResponse.class);
+
+
+
+        assertEquals(ZenodoState.PROCESS_COMPLETED.getType(), zenodoAssessmentInfoChild.getZenodoState());
+    }
 
     private RegistryAssessmentDto makeRegistryJsonDoc() throws IOException {
 

--- a/data-transfer-object/src/main/java/org/grnet/cat/dtos/assessment/AssessmentResponse.java
+++ b/data-transfer-object/src/main/java/org/grnet/cat/dtos/assessment/AssessmentResponse.java
@@ -67,4 +67,13 @@ public class AssessmentResponse {
     )
     @JsonProperty("published")
     public Boolean published;
+
+    @Schema(
+            type = SchemaType.STRING,
+            implementation = String.class,
+            description = "The parent of the assessment",
+            example = "c242e43f-9869-4fb0-b881-631bc5746ec0"
+    )
+    @JsonProperty("parent_assessment_id")
+    public String parentAssessmentId;
 }

--- a/entity/src/main/java/org/grnet/cat/entities/MotivationAssessment.java
+++ b/entity/src/main/java/org/grnet/cat/entities/MotivationAssessment.java
@@ -75,6 +75,9 @@ public class MotivationAssessment {
     @Column
     private Boolean  published;
 
+    @Column(name = "parent_assessment_id")
+    private String parentAssessmentId;
+
     public Boolean getPublished() {
         return published;
     }

--- a/entity/src/main/resources/db/migration/tables/assessment/V1.74__add_parent_assessment_id.sql
+++ b/entity/src/main/resources/db/migration/tables/assessment/V1.74__add_parent_assessment_id.sql
@@ -1,0 +1,11 @@
+-- ------------------------------------------------
+-- Version: v1.74
+--
+-- Description: Migration that introduces the parent_assessment_id column in MotivationAssessment table
+-- ------------------------------------------------
+
+-- Add the column
+ALTER TABLE MotivationAssessment ADD COLUMN parent_assessment_id VARCHAR(255);
+
+-- Set each assessment to be its own parent for now
+UPDATE MotivationAssessment SET parent_assessment_id = id;

--- a/repository/src/main/java/org/grnet/cat/repositories/MotivationAssessmentRepository.java
+++ b/repository/src/main/java/org/grnet/cat/repositories/MotivationAssessmentRepository.java
@@ -148,7 +148,7 @@ public class MotivationAssessmentRepository implements Repository<MotivationAsse
 
         var em = Panache.getEntityManager();
 
-        var query = em.createNativeQuery("SELECT a.id, a.assessment_doc, a.validation_id, a.created_on, a.updated_on, a.subject_id, a.updated_by, a.shared, a.motivation_id , a.published FROM MotivationAssessment a INNER JOIN Validation v ON a.validation_id = v.id INNER JOIN t_Motivation m ON a.motivation_id = m.lodMTV where v.registry_actor_id = :actorId and m.lodMTV = :motivationId AND a.published = :published ORDER BY a.created_on DESC", MotivationAssessment.class)
+        var query = em.createNativeQuery("SELECT a.id, a.assessment_doc, a.validation_id, a.created_on, a.updated_on, a.subject_id, a.updated_by, a.shared, a.motivation_id , a.published, a.parent_assessment_id FROM MotivationAssessment a INNER JOIN Validation v ON a.validation_id = v.id INNER JOIN t_Motivation m ON a.motivation_id = m.lodMTV where v.registry_actor_id = :actorId and m.lodMTV = :motivationId AND a.published = :published ORDER BY a.created_on DESC", MotivationAssessment.class)
                 .setParameter("actorId", actorId)
                 .setParameter("published", true)
                 .setParameter("motivationId", motivationId);
@@ -160,7 +160,7 @@ public class MotivationAssessmentRepository implements Repository<MotivationAsse
 
         if (StringUtils.isNotEmpty(subjectName) && StringUtils.isNotEmpty(subjectType)) {
 
-            query = em.createNativeQuery("SELECT a.id, a.assessment_doc, a.validation_id, a.created_on, a.updated_on, a.subject_id, a.updated_by, a.shared, a.motivation_id , a.published FROM MotivationAssessment a INNER JOIN Validation v ON a.validation_id = v.id INNER JOIN t_Motivation m ON a.motivation_id = m.lodMTV where v.registry_actor_id = :actorId and m.lodMTV = :motivationId AND a.published = :published AND a.assessment_doc->'subject'->>'name' = :name AND a.assessment_doc->'subject'->>'type' = :type ORDER BY a.created_on DESC", MotivationAssessment.class)
+            query = em.createNativeQuery("SELECT a.id, a.assessment_doc, a.validation_id, a.created_on, a.updated_on, a.subject_id, a.updated_by, a.shared, a.motivation_id , a.published , a.parent_assessment_id FROM MotivationAssessment a INNER JOIN Validation v ON a.validation_id = v.id INNER JOIN t_Motivation m ON a.motivation_id = m.lodMTV where v.registry_actor_id = :actorId and m.lodMTV = :motivationId AND a.published = :published AND a.assessment_doc->'subject'->>'name' = :name AND a.assessment_doc->'subject'->>'type' = :type ORDER BY a.created_on DESC", MotivationAssessment.class)
                     .setParameter("actorId", actorId)
                     .setParameter("published", true)
                     .setParameter("motivationId", motivationId)
@@ -177,7 +177,7 @@ public class MotivationAssessmentRepository implements Repository<MotivationAsse
 
         } else if (StringUtils.isNotEmpty(subjectName)) {
 
-            query = em.createNativeQuery("SELECT a.id, a.assessment_doc, a.validation_id, a.created_on, a.updated_on, a.subject_id, a.updated_by, a.shared, a.motivation_id , a.published FROM MotivationAssessment a INNER JOIN Validation v ON a.validation_id = v.id INNER JOIN t_Motivation m ON a.motivation_id = m.lodMTV where v.registry_actor_id = :actorId and m.lodMTV = :motivationId AND a.published :published AND a.assessment_doc->'subject'->>'name' = :name ORDER BY a.created_on DESC", MotivationAssessment.class)
+            query = em.createNativeQuery("SELECT a.id, a.assessment_doc, a.validation_id, a.created_on, a.updated_on, a.subject_id, a.updated_by, a.shared, a.motivation_id , a.published , a.parent_assessment_id FROM MotivationAssessment a INNER JOIN Validation v ON a.validation_id = v.id INNER JOIN t_Motivation m ON a.motivation_id = m.lodMTV where v.registry_actor_id = :actorId and m.lodMTV = :motivationId AND a.published :published AND a.assessment_doc->'subject'->>'name' = :name ORDER BY a.created_on DESC", MotivationAssessment.class)
                     .setParameter("actorId", actorId)
                     .setParameter("published", true)
                     .setParameter("motivationId", motivationId)
@@ -191,7 +191,7 @@ public class MotivationAssessmentRepository implements Repository<MotivationAsse
 
         } else if (StringUtils.isNotEmpty(subjectType)) {
 
-            query = em.createNativeQuery("SELECT a.id, a.assessment_doc, a.validation_id, a.created_on, a.updated_on, a.subject_id, a.updated_by, a.shared, a.motivation_id , a.published FROM MotivationAssessment a INNER JOIN Validation v ON a.validation_id = v.id INNER JOIN t_Motivation m ON a.motivation_id = m.lodMTV where v.registry_actor_id = :actorId and m.lodMTV = :motivationId AND (a.published = :published AND a.assessment_doc->'subject'->>'type' = :type ORDER BY a.created_on DESC", MotivationAssessment.class)
+            query = em.createNativeQuery("SELECT a.id, a.assessment_doc, a.validation_id, a.created_on, a.updated_on, a.subject_id, a.updated_by, a.shared, a.motivation_id , a.published , a.parent_assessment_id FROM MotivationAssessment a INNER JOIN Validation v ON a.validation_id = v.id INNER JOIN t_Motivation m ON a.motivation_id = m.lodMTV where v.registry_actor_id = :actorId and m.lodMTV = :motivationId AND (a.published = :published AND a.assessment_doc->'subject'->>'type' = :type ORDER BY a.created_on DESC", MotivationAssessment.class)
                     .setParameter("actorId", actorId)
                     .setParameter("published", true)
                     .setParameter("motivationId", motivationId)

--- a/service/src/main/java/org/grnet/cat/services/assessment/JsonAssessmentService.java
+++ b/service/src/main/java/org/grnet/cat/services/assessment/JsonAssessmentService.java
@@ -108,6 +108,8 @@ public class JsonAssessmentService {
         assessment.setAssessmentDoc(objectMapper.writeValueAsString(request.assessmentDoc));
 
         motivationAssessmentRepository.persist(assessment);
+        assessment.setParentAssessmentId(assessment.getId());
+
         var doc = assessment.getAssessmentDoc();
         ObjectNode jsonNode = null;
         try {

--- a/service/src/main/java/org/grnet/cat/services/zenodo/ZenodoClient.java
+++ b/service/src/main/java/org/grnet/cat/services/zenodo/ZenodoClient.java
@@ -43,4 +43,12 @@ public interface ZenodoClient {
     @Path("/api/deposit/depositions/{id}")
     Map<String, Object> getDeposit(@HeaderParam("Authorization") String token, @PathParam("id") String id) throws WebApplicationException, ProcessingException;
 
+    @POST
+    @Path("/api/deposit/depositions/{id}/actions/newversion")
+    Map<String, Object> createNewVersion(@HeaderParam("Authorization") String token, @PathParam("id") String parentDepositId) throws WebApplicationException, ProcessingException;
+
+    @PUT
+    @Path("/api/deposit/depositions/{id}")
+    @Consumes(MediaType.APPLICATION_JSON)
+    Map<String, Object> updateDeposit(@HeaderParam("Authorization") String accessToken, @PathParam("id") String depositionId, Map<String, Object> metadata);
 }

--- a/service/src/main/java/org/grnet/cat/services/zenodo/ZenodoService.java
+++ b/service/src/main/java/org/grnet/cat/services/zenodo/ZenodoService.java
@@ -39,6 +39,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.sql.Timestamp;
 import java.time.Instant;
+import java.time.LocalDate;
 import java.util.*;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
@@ -102,10 +103,22 @@ public class ZenodoService {
                 ShareableEntityType.ASSESSMENT.getValue().concat(ENTITLEMENTS_DELIMITER).concat(assessment.getId())
         );
 
+        // Check parent to decide if a new version should be created
+        Optional<ZenodoAssessmentInfo> parentZenodoOpt = Optional.empty();
+        var parentId = assessment.getParentAssessmentId();
+
+        if (!assessment.getId().equals(parentId)) {
+            parentZenodoOpt = zenodoAssessmentInfoRepository.getAssessmentByAsessmentId(parentId);
+            if (parentZenodoOpt.isPresent() && !parentZenodoOpt.get().getIsPublished()) {
+                // if parent is unpublished, ignore it
+                parentZenodoOpt = Optional.empty();
+            }
+        }
+
+        Optional<ZenodoAssessmentInfo> finalParentZenodoOpt = parentZenodoOpt;
         CompletableFuture.runAsync(() -> {
             try {
-                // Call the method to run the steps asynchronously
-                runStepsInSequence(assessment, binaryContent, activeUser, sharedUserIds)
+                runStepsInSequence(assessment, binaryContent, activeUser, sharedUserIds, finalParentZenodoOpt)
                         .join(); // Ensures the process completes in the background
             } catch (Exception e) {
                 // Log the error but do not affect the user response
@@ -308,7 +321,7 @@ public class ZenodoService {
 
     }
 
-    public CompletableFuture<Void> runStepsInSequence(MotivationAssessment assessment, byte[] binaryContent, User activeUser, List<String> sharedUsersIds) {
+    public CompletableFuture<Void> runStepsInSequence(MotivationAssessment assessment, byte[] binaryContent, User activeUser, List<String> sharedUsersIds, Optional<ZenodoAssessmentInfo> parentZenodoOpt) {
         final AtomicReference<ZenodoState> state = new AtomicReference<>(ZenodoState.PROCESS_INIT);
         final AtomicReference<String> depositIdRef = new AtomicReference<>(null);
         final AtomicReference<ZenodoAssessmentInfo> zenodoAssessmentInfoRef = new AtomicReference<>(null);
@@ -318,13 +331,36 @@ public class ZenodoService {
                     // Step 1: Preparation of assessment for Zenodo
                     System.out.println("Step 1: Preparing assessment for Zenodo...");
                     var metadata = createMetadata(assessment, activeUser, sharedUsersIds);
-                    var response = createDeposit(metadata);
-                    var depositId = response.get("id");
-                    if (depositId == null) {
-                        throw new RuntimeException("Failed to create deposit in Zenodo for assessment ID: " + assessment.getId());
+                    Map<String, Object> response;
+
+                    if (parentZenodoOpt.isPresent() && parentZenodoOpt.get().getIsPublished()) {
+                        String parentDepositId = parentZenodoOpt.get().getId().getDepositId();
+                        System.out.println("Creating new version from parent deposit: " + parentDepositId);
+                        response = zenodoClient.createNewVersion(getAccessToken(), parentDepositId);
+
+                        var links = (Map<String, Object>) response.get("links");
+                        String latestDraftUrl = (String) links.get("latest_draft");
+                        String extractedId = extractIdFromUrl(latestDraftUrl);
+
+                        if (extractedId == null) {
+                            throw new RuntimeException("Failed to extract draft deposit ID from Zenodo response.");
+                        }
+
+                        zenodoClient.updateDeposit(getAccessToken(), extractedId, metadata); // full payload including "metadata" key
+
+                        depositIdRef.set(extractedId);
+                    }  else {
+                        System.out.println("Creating new deposit from scratch");
+                        response = createDeposit(metadata);
+
+                        var depositId = response.get("id");
+                        if (depositId == null) {
+                            throw new RuntimeException("Failed to create deposit in Zenodo for assessment ID: " + assessment.getId());
+                        }
+                        depositIdRef.set(String.valueOf(depositId));
                     }
-                    depositIdRef.set(String.valueOf(depositId));
-                    return depositId;
+
+                    return depositIdRef.get();
                 }, executorService)
                 .thenApply(depositId -> {
                     // Step 2: Upload to Zenodo
@@ -363,7 +399,9 @@ public class ZenodoService {
                 .thenApply(depositId -> {
                     // Step 4: Publish deposit only after DB write succeeds
                     System.out.println("Step 4: Publishing deposit...");
+                    System.out.println("Calling publishDeposit for depositId: " + depositIdRef.get());
                     publishDeposit(depositIdRef.get());
+
                     return depositId;
                 })
                 .thenAccept(depositId -> {
@@ -535,7 +573,9 @@ public class ZenodoService {
                 "title", title,
                 "upload_type", uploadType,
                 "description", description,
-                "creators", creators));
+                "creators", creators,
+                "publication_date", LocalDate.now().toString(),
+                "access_right", "open"));
         if (!contributors.isEmpty()) {
             metadata.put("contributors", contributors);
         }
@@ -562,5 +602,11 @@ public class ZenodoService {
         return dbAssessmentToJson.assessmentDoc.name + "/"
                 + dbAssessmentToJson.assessmentDoc.organisation.name + "/"
                 + dbAssessmentToJson.assessmentDoc.actor.getName();
+    }
+
+    private String extractIdFromUrl(String url) {
+        if (url == null) return null;
+        String[] parts = url.split("/");
+        return parts.length > 0 ? parts[parts.length - 1] : null;
     }
 }


### PR DESCRIPTION
# CAT-891 Publishing to Zenodo New Version

This PR adds support for publishing a **new version** to an existing **published deposit** to Zenodo, using Zenodo’s versioning API.

## ACTIONS
  - Added a column `parent_assessment_id` on **motivationassessment** talbe
  - Reuses the existing endpoint:  `POST /publish/assessment/{id}`
  - If the given assessment's `parent_assessment_id` is already published to Zenodo:
    - A new version is created using:
      ```
      POST /api/deposit/depositions/{id}/actions/newversion
      ```
    - The `latest_draft` link is used to extract the new deposit ID.
    - Metadata is updated and the new PDF is uploaded.
    - The draft is then published as a new version.
  - If the assessment is not a version or the parent is unpublished:
    - A new deposit is created and published as usual.