### PR TITLE
CAT-893 Versioning of Existing Assessment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ According to [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) , the `Unr
 - [#494](https://github.com/FC4E-CAT/fc4e-cat-api/pull/494) CAT-885: Statistics of the Combination of Types in a Metric
 - [#495](https://github.com/FC4E-CAT/fc4e-cat-api/pull/495) CAT-886 Implement Search Functionality for Testmethod
 - [#497](https://github.com/FC4E-CAT/fc4e-cat-api/pull/497) CAT-891 Publishing to Zenodo New Version
+- [#500](https://github.com/FC4E-CAT/fc4e-cat-api/pull/500) CAT-893 Versioning of Existing Assessment
 
 
 ### Fix

--- a/api/src/main/java/org/grnet/cat/api/endpoints/AssessmentsV2Endpoint.java
+++ b/api/src/main/java/org/grnet/cat/api/endpoints/AssessmentsV2Endpoint.java
@@ -346,6 +346,66 @@ public class AssessmentsV2Endpoint {
 
     @Tag(name = "Assessment")
     @Operation(
+            summary = "Create a version of Registry Assessment Request.",
+            description = "Creates a version of the registry assessment if it belongs or shared to the authenticated user.")
+    @APIResponse(
+            responseCode = "200",
+            description = "Assessment's registry json document versioned successfully.",
+            content = @Content(schema = @Schema(
+                    type = SchemaType.OBJECT,
+                    implementation = AdminJsonRegistryAssessmentResponse.class)))
+    @APIResponse(
+            responseCode = "400",
+            description = "Invalid request payload.",
+            content = @Content(schema = @Schema(
+                    type = SchemaType.OBJECT,
+                    implementation = InformativeResponse.class)))
+    @APIResponse(
+            responseCode = "401",
+            description = "User has not been authenticated.",
+            content = @Content(schema = @Schema(
+                    type = SchemaType.OBJECT,
+                    implementation = InformativeResponse.class)))
+    @APIResponse(
+            responseCode = "403",
+            description = "Not permitted.",
+            content = @Content(schema = @Schema(
+                    type = SchemaType.OBJECT,
+                    implementation = InformativeResponse.class)))
+    @APIResponse(
+            responseCode = "404",
+            description = "Entity Not Found.",
+            content = @Content(schema = @Schema(
+                    type = SchemaType.OBJECT,
+                    implementation = InformativeResponse.class)))
+    @APIResponse(
+            responseCode = "500",
+            description = "Internal Server Error.",
+            content = @Content(schema = @Schema(
+                    type = SchemaType.OBJECT,
+                    implementation = InformativeResponse.class)))
+    @SecurityRequirement(name = "Authentication")
+    @Path("/{id}/version")
+    @POST
+    @Produces(MediaType.APPLICATION_JSON)
+    @Authenticated
+    @Registration
+    public Response createVersionAssessment(
+            @Parameter(
+            description = "The ID of the assessment to version.",
+            required = true,
+            example = "c242e43f-9869-4fb0-b881-631bc5746ec0",
+            schema = @Schema(type = SchemaType.STRING))
+            @PathParam("id")
+            @Valid @NotFoundEntity(repository = MotivationAssessmentRepository.class, message = "There is no assessment with the following id:") String id) {
+
+        var assessment = assessmentService.versionPublishedAssessment(utility.getUserUniqueIdentifier(), id);
+
+        return Response.ok().entity(assessment).build();
+    }
+
+    @Tag(name = "Assessment")
+    @Operation(
             summary = "Get list of public assessment objects created / used by a specific user by type and actor.",
             description = "This endpoint is public and any unauthenticated user can retrieve published assessment objects categorized by motivation and actor, created by all users." +
                     "By default, the first page of 10 public assessment objects will be returned. You can tune the default values by using the query parameters page and size.")

--- a/data-transfer-object/src/main/java/org/grnet/cat/dtos/assessment/AdminPartialJsonAssessmentResponse.java
+++ b/data-transfer-object/src/main/java/org/grnet/cat/dtos/assessment/AdminPartialJsonAssessmentResponse.java
@@ -1,8 +1,12 @@
 package org.grnet.cat.dtos.assessment;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Setter;
 import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
+
+import java.util.List;
 
 @Schema(name = "AdminPartialJsonAssessmentResponse", description = "This object represents an admin partial form of the Json Assessment.")
 public class AdminPartialJsonAssessmentResponse extends AssessmentResponse {
@@ -92,5 +96,15 @@ public class AdminPartialJsonAssessmentResponse extends AssessmentResponse {
     )
     @JsonProperty("shared")
     public Boolean shared;
+
+    @Setter
+    @Schema(
+            type = SchemaType.ARRAY,
+            implementation = AdminPartialJsonAssessmentResponse.class,
+            description = "List of versions of this test."
+    )
+    @JsonProperty("versions")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public List<AdminPartialJsonAssessmentResponse> adminVersions;
 
 }

--- a/data-transfer-object/src/main/java/org/grnet/cat/dtos/assessment/AssessmentResponse.java
+++ b/data-transfer-object/src/main/java/org/grnet/cat/dtos/assessment/AssessmentResponse.java
@@ -76,4 +76,13 @@ public class AssessmentResponse {
     )
     @JsonProperty("parent_assessment_id")
     public String parentAssessmentId;
+
+    @Schema(
+            type = SchemaType.STRING,
+            implementation = String.class,
+            description = "The parent of the assessment",
+            example = "c242e43f-9869-4fb0-b881-631bc5746ec0"
+    )
+    @JsonProperty("assessment_doc_version")
+    public String version;
 }

--- a/data-transfer-object/src/main/java/org/grnet/cat/dtos/assessment/UserPartialJsonAssessmentResponse.java
+++ b/data-transfer-object/src/main/java/org/grnet/cat/dtos/assessment/UserPartialJsonAssessmentResponse.java
@@ -1,8 +1,13 @@
 package org.grnet.cat.dtos.assessment;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Setter;
 import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
+import org.grnet.cat.dtos.registry.motivation.MotivationResponse;
+
+import java.util.List;
 
 @Schema(name = "UserPartialJsonAssessmentResponse", description = "This object represents a user partial form of the Json Assessment.")
 public class UserPartialJsonAssessmentResponse extends AdminPartialJsonAssessmentResponse {
@@ -25,7 +30,18 @@ public class UserPartialJsonAssessmentResponse extends AdminPartialJsonAssessmen
     )
     @JsonProperty("shared_by_user")
     public Boolean sharedByUser;
-//
+
+    @Setter
+    @Schema(
+            type = SchemaType.ARRAY,
+            implementation = UserPartialJsonAssessmentResponse.class,
+            description = "List of versions of this test."
+    )
+    @JsonProperty("versions")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public List<UserPartialJsonAssessmentResponse> userVersions;
+
+    //
 //    @Schema(
 //            type = SchemaType.BOOLEAN,
 //            implementation = Boolean.class,

--- a/data-transfer-object/src/main/java/org/grnet/cat/dtos/assessment/registry/AdminJsonRegistryAssessmentResponse.java
+++ b/data-transfer-object/src/main/java/org/grnet/cat/dtos/assessment/registry/AdminJsonRegistryAssessmentResponse.java
@@ -1,9 +1,15 @@
 package org.grnet.cat.dtos.assessment.registry;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Setter;
 import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
+import org.grnet.cat.dtos.assessment.AdminPartialJsonAssessmentResponse;
 import org.grnet.cat.dtos.assessment.AssessmentResponse;
+import org.grnet.cat.dtos.assessment.UserPartialJsonAssessmentResponse;
+
+import java.util.List;
 
 @Schema(name = "AdminJsonAssessmentV2Response", description = "This object represents the Admin Registry Assessment Json Assessment.")
 public class AdminJsonRegistryAssessmentResponse extends AssessmentResponse {
@@ -24,4 +30,13 @@ public class AdminJsonRegistryAssessmentResponse extends AssessmentResponse {
     @JsonProperty("shared")
     public Boolean shared;
 
+    @Setter
+    @Schema(
+            type = SchemaType.ARRAY,
+            implementation = AdminJsonRegistryAssessmentResponse.class,
+            description = "List of versions of this test."
+    )
+    @JsonProperty("versions")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public List<AdminJsonRegistryAssessmentResponse> adminVersions;
 }

--- a/data-transfer-object/src/main/java/org/grnet/cat/dtos/assessment/registry/UserJsonRegistryAssessmentResponse.java
+++ b/data-transfer-object/src/main/java/org/grnet/cat/dtos/assessment/registry/UserJsonRegistryAssessmentResponse.java
@@ -1,8 +1,12 @@
 package org.grnet.cat.dtos.assessment.registry;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Setter;
 import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
+
+import java.util.List;
 
 @Schema(name = "UserJsonRegistryAssessmentResponse", description = "This object represents the User Json Registry Assessment.")
 public class UserJsonRegistryAssessmentResponse extends AdminJsonRegistryAssessmentResponse {
@@ -24,6 +28,17 @@ public class UserJsonRegistryAssessmentResponse extends AdminJsonRegistryAssessm
     )
     @JsonProperty("shared_by_user")
     public Boolean sharedByUser;
+
+    @Setter
+    @Schema(
+            type = SchemaType.ARRAY,
+            implementation = UserJsonRegistryAssessmentResponse.class,
+            description = "List of versions of this test."
+    )
+    @JsonProperty("versions")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public List<UserJsonRegistryAssessmentResponse> userVersions;
+
 //
 //    @Schema(
 //            type = SchemaType.BOOLEAN,

--- a/mapper/src/main/java/org/grnet/cat/mappers/AssessmentMapper.java
+++ b/mapper/src/main/java/org/grnet/cat/mappers/AssessmentMapper.java
@@ -72,6 +72,7 @@ public interface AssessmentMapper {
     @Mapping(target = "compliance", expression = "java(assessment.assessmentDoc.result.compliance)")
     @Mapping(target = "ranking", expression = "java(assessment.assessmentDoc.result.ranking)")
     @Mapping(target = "shared", expression = "java(assessment.shared)")
+    @Mapping(target = "version", expression = "java(assessment.assessmentDoc.version)")
     AdminPartialJsonAssessmentResponse adminRegistryAssessmentToPartialJsonAssessment(AdminJsonRegistryAssessmentResponse assessment);
 
     @IterableMapping(qualifiedByName = "adminPartialRegistryMapWithExpression")
@@ -91,7 +92,7 @@ public interface AssessmentMapper {
     @Mapping(target = "sharedToUser", expression = "java(isSharedToUser(assessment.getValidation().getUser().getId()))")
     @Mapping(target = "sharedByUser", expression = "java(isRegistryAssessmentSharedByUser(assessment, assessment.getValidation().getUser().getId()))")
     @Mapping(target = "published", source = "assessment.published")
-
+    @Mapping(target = "version", expression = "java(registryStringJsonToDto(assessment.getAssessmentDoc()).version)")
     UserJsonRegistryAssessmentResponse userRegistryAssessmentToJsonAssessment(MotivationAssessment assessment);
 
     @IterableMapping(qualifiedByName = "mapWithRegistryExpression")
@@ -150,7 +151,7 @@ public interface AssessmentMapper {
     @Mapping(target = "sharedToUser", ignore = true)
     @Mapping(target = "sharedByUser", ignore = true)
     @Mapping(target = "published", source = "assessment.published")
-
+    @Mapping(target = "version", expression = "java(registryStringJsonToDto(assessment.getAssessmentDoc()).version)")
     UserJsonRegistryAssessmentResponse publicUserRegistryAssessmentToJsonAssessment(MotivationAssessment assessment);
 
 

--- a/repository/src/main/java/org/grnet/cat/repositories/MotivationAssessmentRepository.java
+++ b/repository/src/main/java/org/grnet/cat/repositories/MotivationAssessmentRepository.java
@@ -177,7 +177,7 @@ public class MotivationAssessmentRepository implements Repository<MotivationAsse
 
         } else if (StringUtils.isNotEmpty(subjectName)) {
 
-            query = em.createNativeQuery("SELECT a.id, a.assessment_doc, a.validation_id, a.created_on, a.updated_on, a.subject_id, a.updated_by, a.shared, a.motivation_id , a.published , a.parent_assessment_id FROM MotivationAssessment a INNER JOIN Validation v ON a.validation_id = v.id INNER JOIN t_Motivation m ON a.motivation_id = m.lodMTV where v.registry_actor_id = :actorId and m.lodMTV = :motivationId AND a.published :published AND a.assessment_doc->'subject'->>'name' = :name ORDER BY a.created_on DESC", MotivationAssessment.class)
+            query = em.createNativeQuery("SELECT a.id, a.assessment_doc, a.validation_id, a.created_on, a.updated_on, a.subject_id, a.updated_by, a.shared, a.motivation_id , a.published , a.parent_assessment_id FROM MotivationAssessment a INNER JOIN Validation v ON a.validation_id = v.id INNER JOIN t_Motivation m ON a.motivation_id = m.lodMTV where v.registry_actor_id = :actorId and m.lodMTV = :motivationId AND a.published =:published AND a.assessment_doc->'subject'->>'name' = :name ORDER BY a.created_on DESC", MotivationAssessment.class)
                     .setParameter("actorId", actorId)
                     .setParameter("published", true)
                     .setParameter("motivationId", motivationId)
@@ -191,7 +191,7 @@ public class MotivationAssessmentRepository implements Repository<MotivationAsse
 
         } else if (StringUtils.isNotEmpty(subjectType)) {
 
-            query = em.createNativeQuery("SELECT a.id, a.assessment_doc, a.validation_id, a.created_on, a.updated_on, a.subject_id, a.updated_by, a.shared, a.motivation_id , a.published , a.parent_assessment_id FROM MotivationAssessment a INNER JOIN Validation v ON a.validation_id = v.id INNER JOIN t_Motivation m ON a.motivation_id = m.lodMTV where v.registry_actor_id = :actorId and m.lodMTV = :motivationId AND (a.published = :published AND a.assessment_doc->'subject'->>'type' = :type ORDER BY a.created_on DESC", MotivationAssessment.class)
+            query = em.createNativeQuery("SELECT a.id, a.assessment_doc, a.validation_id, a.created_on, a.updated_on, a.subject_id, a.updated_by, a.shared, a.motivation_id , a.published , a.parent_assessment_id FROM MotivationAssessment a INNER JOIN Validation v ON a.validation_id = v.id INNER JOIN t_Motivation m ON a.motivation_id = m.lodMTV where v.registry_actor_id = :actorId and m.lodMTV = :motivationId AND a.published = :published AND a.assessment_doc->'subject'->>'type' = :type ORDER BY a.created_on DESC", MotivationAssessment.class)
                     .setParameter("actorId", actorId)
                     .setParameter("published", true)
                     .setParameter("motivationId", motivationId)
@@ -244,7 +244,7 @@ public class MotivationAssessmentRepository implements Repository<MotivationAsse
 
         if (StringUtils.isNotEmpty(subjectName) && StringUtils.isNotEmpty(subjectType)) {
 
-            query = em.createNativeQuery("SELECT a.id, a.assessment_doc, a.validation_id, a.created_on, a.updated_on, a.subject_id, a.updated_by, a.shared, a.motivation_id , a.published , a.parent_assessment_id FROM MotivationAssessment a INNER JOIN Validation v ON a.validation_id = v.id where v.registry_actor_id = :actorId AND a.published = :published AND a.assessment_doc->'subject'->>'name' = :name AND a.assessment_doc->'subject'->>'type' = :type ORDER BY a.created_on DESC", MotivationAssessment.class)
+            query = em.createNativeQuery("SELECT a.id, a.assessment_doc, a.validation_id, a.created_on, a.updated_on, a.subject_id, a.updated_by, a.shared, a.motivation_id , a.published, a.parent_assessment_id FROM MotivationAssessment a INNER JOIN Validation v ON a.validation_id = v.id where v.registry_actor_id = :actorId AND a.published = :published AND a.assessment_doc->'subject'->>'name' = :name AND a.assessment_doc->'subject'->>'type' = :type ORDER BY a.created_on DESC", MotivationAssessment.class)
                     .setParameter("actorId", actorId)
                     .setParameter("published", true)
                     .setParameter("name", subjectName)
@@ -259,7 +259,7 @@ public class MotivationAssessmentRepository implements Repository<MotivationAsse
 
         } else if (StringUtils.isNotEmpty(subjectName)) {
 
-            query = em.createNativeQuery("SELECT a.id, a.assessment_doc, a.validation_id, a.created_on, a.updated_on, a.subject_id, a.updated_by, a.shared, a.motivation_id , a.published , a.parent_assessment_id FROM MotivationAssessment a INNER JOIN Validation v ON a.validation_id = v.id where v.registry_actor_id = :actorId AND a.published =:published AND a.assessment_doc->'subject'->>'name' = :name ORDER BY a.created_on DESC", MotivationAssessment.class)
+            query = em.createNativeQuery("SELECT a.id, a.assessment_doc, a.validation_id, a.created_on, a.updated_on, a.subject_id, a.updated_by, a.shared, a.motivation_id , a.published, a.parent_assessment_id FROM MotivationAssessment a INNER JOIN Validation v ON a.validation_id = v.id where v.registry_actor_id = :actorId AND a.published = :published AND a.assessment_doc->'subject'->>'name' = :name ORDER BY a.created_on DESC", MotivationAssessment.class)
                     .setParameter("actorId", actorId)
                     .setParameter("published", true)
                     .setParameter("name", subjectName);
@@ -271,7 +271,7 @@ public class MotivationAssessmentRepository implements Repository<MotivationAsse
 
         } else if (StringUtils.isNotEmpty(subjectType)) {
 
-            query = em.createNativeQuery("SELECT a.id, a.assessment_doc, a.validation_id, a.created_on, a.updated_on, a.subject_id, a.updated_by, a.shared, a.motivation_id , a.published FROM MotivationAssessment a INNER JOIN Validation v ON a.validation_id = v.id where v.registry_actor_id = :actorId AND (a.published = :published AND a.assessment_doc->'subject'->>'type' = :type ORDER BY a.created_on DESC", MotivationAssessment.class)
+            query = em.createNativeQuery("SELECT a.id, a.assessment_doc, a.validation_id, a.created_on, a.updated_on, a.subject_id, a.updated_by, a.shared, a.motivation_id , a.published, a.parent_assessment_id FROM MotivationAssessment a INNER JOIN Validation v ON a.validation_id = v.id where v.registry_actor_id = :actorId AND a.published = :published AND a.assessment_doc->'subject'->>'type' = :type ORDER BY a.created_on DESC", MotivationAssessment.class)
                     .setParameter("actorId", actorId)
                     .setParameter("published", true)
                     .setParameter("type", subjectType);
@@ -454,6 +454,10 @@ public class MotivationAssessmentRepository implements Repository<MotivationAsse
     public Long countAllAssessmentsByUser(String userId) {
 
         return count("from MotivationAssessment a where a.validation.user.id = ?1", userId);
+    }
+
+    public List<MotivationAssessment> getAllVersions(String parentAssessmentId) {
+        return find("FROM MotivationAssessment ma WHERE ma.parentAssessmentId = ?1 ORDER BY ma.createdOn DESC", parentAssessmentId).list();
     }
 
     @Transactional

--- a/service/src/main/java/org/grnet/cat/services/assessment/JsonAssessmentService.java
+++ b/service/src/main/java/org/grnet/cat/services/assessment/JsonAssessmentService.java
@@ -116,6 +116,8 @@ public class JsonAssessmentService {
             jsonNode = (ObjectNode) objectMapper.readTree(doc);
 
             jsonNode.put("id", assessment.getId());
+            jsonNode.put("version", "v1");
+
 
             assessment.setAssessmentDoc(objectMapper.writeValueAsString(jsonNode));
         } catch (JsonProcessingException e) {
@@ -126,6 +128,85 @@ public class JsonAssessmentService {
 
         keycloakAdminService.addEntitlementsToUser(userId, ShareableEntityType.ASSESSMENT.getValue().concat(ENTITLEMENTS_DELIMITER).concat(assessment.getId()));
         return AssessmentMapper.INSTANCE.userRegistryAssessmentToJsonAssessment(assessment);
+    }
+
+    @Transactional
+    public UserJsonRegistryAssessmentResponse versionPublishedAssessment(String userId, String assessmentId) {
+        var existing = motivationAssessmentRepository.findById(assessmentId);
+        if (existing == null) {
+            throw new NotFoundException("Assessment not found");
+        }
+
+        // Determine the root (original) assessment
+        var parentId = existing.getParentAssessmentId() != null ?
+                existing.getParentAssessmentId() : existing.getId();
+
+        // Count previous versions
+        var countVersions = motivationAssessmentRepository.getAllVersions(parentId).size();
+        int nextVersion = countVersions + 1;
+
+        // Parse & update document
+        ObjectNode docNode;
+        try {
+            docNode = (ObjectNode) objectMapper.readTree(existing.getAssessmentDoc());
+            docNode.put("version", "v" + nextVersion);
+            docNode.put("timestamp", Instant.now().toString());
+            docNode.put("published", false);
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException("Invalid assessmentDoc", e);
+        }
+
+        // Clean answers
+        var cleanedDoc = cleanAssessmentAnswers(docNode);
+
+        // Create versioned assessment
+        var newAssessment = new MotivationAssessment();
+        newAssessment.setValidation(existing.getValidation());
+        newAssessment.setMotivation(existing.getMotivation());
+        newAssessment.setSubject(existing.getSubject());
+        newAssessment.setCreatedOn(Timestamp.from(Instant.now()));
+        newAssessment.setParentAssessmentId(parentId);
+        newAssessment.setAssessmentDoc(cleanedDoc.toString());
+        newAssessment.setShared(false);
+        newAssessment.setPublished(false);
+
+
+        motivationAssessmentRepository.persist(newAssessment);
+
+        try {
+            var docWithId = (ObjectNode) objectMapper.readTree(newAssessment.getAssessmentDoc());
+            docWithId.put("id", newAssessment.getId());
+            newAssessment.setAssessmentDoc(objectMapper.writeValueAsString(docWithId));
+        } catch (Exception e) {
+        }
+
+        keycloakAdminService.addEntitlementsToUser(userId,
+                ShareableEntityType.ASSESSMENT.getValue() + "|" + newAssessment.getId());
+
+        return AssessmentMapper.INSTANCE.userRegistryAssessmentToJsonAssessment(newAssessment);
+    }
+
+    private JsonNode cleanAssessmentAnswers(JsonNode originalDoc) {
+        var copy = originalDoc.deepCopy();
+        ((ObjectNode) copy.path("result")).putNull("compliance");
+        ((ObjectNode) copy.path("result")).putNull("ranking");
+
+        for (var principle : copy.path("principles")) {
+            for (var criterion : principle.path("criteria")) {
+                var metric = (ObjectNode) criterion.path("metric");
+                if (metric != null) {
+                    metric.putNull("value");
+                    metric.putNull("result");
+
+                    for (var test : metric.path("tests")) {
+                        ((ObjectNode) test).putNull("value");
+                        ((ObjectNode) test).putNull("result");
+                        ((ObjectNode) test).set("evidence_url", objectMapper.createArrayNode());
+                    }
+                }
+            }
+        }
+        return copy;
     }
 
     /**
@@ -362,17 +443,45 @@ public class JsonAssessmentService {
      */
     public PageResource<UserPartialJsonAssessmentResponse> getDtoRegistryAssessmentsByUserAndPage(int page, int size, UriInfo uriInfo, String userID, String subjectName, String subjectType, String actorId) {
 
-        var sharableIds = keycloakAdminService
-                .getUserEntitlements(userID)
-                .stream()
-                .map(entitlement -> keycloakAdminService.getLastPartOfEntitlement(entitlement, ENTITLEMENTS_DELIMITER))
+        var sharableIds = keycloakAdminService.getUserEntitlements(userID).stream()
+                .map(ent -> keycloakAdminService.getLastPartOfEntitlement(ent, ENTITLEMENTS_DELIMITER))
                 .collect(Collectors.toList());
 
-        var assessments = motivationAssessmentRepository.fetchRegistryAssessmentsByUserAndPage(page, size, userID, subjectName, subjectType, actorId, sharableIds);
+        var assessments = motivationAssessmentRepository.fetchRegistryAssessmentsByUserAndPage(
+                page, size, userID, subjectName, subjectType, actorId, sharableIds);
 
-        var fullAssessments = AssessmentMapper.INSTANCE.userRegistryAssessmentsToJsonAssessments(assessments.list());
+        var grouped = assessments.list().stream()
+                .collect(Collectors.groupingBy(MotivationAssessment::getParentAssessmentId));
 
-        return new PageResource<>(assessments, AssessmentMapper.INSTANCE.userRegistryAssessmentsToPartialJsonAssessments(fullAssessments), uriInfo);
+        var latestList = new ArrayList<MotivationAssessment>();
+        var latestToPrevious = new HashMap<String, List<MotivationAssessment>>();
+
+        for (var entry : grouped.entrySet()) {
+            var versions = entry.getValue().stream()
+                    .sorted(Comparator.comparing(MotivationAssessment::getCreatedOn).reversed())
+                    .collect(Collectors.toList());
+
+            var latest = versions.get(0);
+            latestList.add(latest);
+
+            var previousVersions = versions.subList(1, versions.size());
+            latestToPrevious.put(latest.getId(), previousVersions);
+        }
+
+        var fullAssessments = latestList.stream()
+                .map(latest -> {
+                    var dto = AssessmentMapper.INSTANCE.userRegistryAssessmentToJsonAssessment(latest);
+
+                    var prevVersions = latestToPrevious.getOrDefault(latest.getId(), List.of()).stream()
+                            .map(AssessmentMapper.INSTANCE::userRegistryAssessmentToJsonAssessment)
+                            .collect(Collectors.toList());
+
+                    dto.setUserVersions(prevVersions);
+                    return AssessmentMapper.INSTANCE.userRegistryAssessmentToPartialJsonAssessment(dto);
+                })
+                .collect(Collectors.toList());
+
+        return new PageResource<>(assessments, fullAssessments, uriInfo);
     }
 
     /**
@@ -387,13 +496,45 @@ public class JsonAssessmentService {
      * @param subjectType  Subject Type to search for.
      * @return A list of PartialJsonAssessmentResponse objects representing the submitted assessments in the requested page.
      */
-    public PageResource<AdminPartialJsonAssessmentResponse> getPublishedAssessmentsByMotivationAndActorAndPage(int page, int size, String motivationId, String actorId, UriInfo uriInfo, String subjectName, String subjectType) {
+    public PageResource<AdminPartialJsonAssessmentResponse> getPublishedAssessmentsByMotivationAndActorAndPage(
+            int page, int size, String motivationId, String actorId, UriInfo uriInfo,
+            String subjectName, String subjectType) {
 
-        var assessments = motivationAssessmentRepository.fetchPublishedAssessmentsByMotivationAndActorAndPage(page, size, motivationId, actorId, subjectName, subjectType);
+        var assessments = motivationAssessmentRepository.fetchPublishedAssessmentsByMotivationAndActorAndPage(
+                page, size, motivationId, actorId, subjectName, subjectType);
 
-        var fullAssessments = AssessmentMapper.INSTANCE.adminRegistryAssessmentsToJsonAssessments(assessments.list());
+        var grouped = assessments.list().stream()
+                .collect(Collectors.groupingBy(MotivationAssessment::getParentAssessmentId));
 
-        return new PageResource<>(assessments, AssessmentMapper.INSTANCE.adminRegistryAssessmentsToPartialJsonAssessments(fullAssessments), uriInfo);
+        var latestList = new ArrayList<MotivationAssessment>();
+        var latestToPrevious = new HashMap<String, List<MotivationAssessment>>();
+
+        for (var entry : grouped.entrySet()) {
+            var versions = entry.getValue().stream()
+                    .sorted(Comparator.comparing(MotivationAssessment::getCreatedOn).reversed())
+                    .collect(Collectors.toList());
+
+            var latest = versions.get(0);
+            latestList.add(latest);
+
+            var previousVersions = versions.subList(1, versions.size());
+            latestToPrevious.put(latest.getId(), previousVersions);
+        }
+
+        var fullAssessments = latestList.stream()
+                .map(latest -> {
+                    var dto = AssessmentMapper.INSTANCE.adminRegistryAssessmentToJsonAssessment(latest);
+
+                    var prevVersions = latestToPrevious.getOrDefault(latest.getId(), List.of()).stream()
+                            .map(AssessmentMapper.INSTANCE::adminRegistryAssessmentToJsonAssessment)
+                            .collect(Collectors.toList());
+
+                    dto.setAdminVersions(prevVersions);
+                    return AssessmentMapper.INSTANCE.adminRegistryAssessmentToPartialJsonAssessment(dto);
+                })
+                .collect(Collectors.toList());
+
+        return new PageResource<>(assessments, fullAssessments, uriInfo);
     }
 
     /**
@@ -411,9 +552,38 @@ public class JsonAssessmentService {
 
         var assessments = motivationAssessmentRepository.fetchPublishedAssessmentsByActorAndPage(page, size, actorId, subjectName, subjectType);
 
-        var fullAssessments = AssessmentMapper.INSTANCE.adminRegistryAssessmentsToJsonAssessments(assessments.list());
+        var grouped = assessments.list().stream()
+                .collect(Collectors.groupingBy(MotivationAssessment::getParentAssessmentId));
 
-        return new PageResource<>(assessments, AssessmentMapper.INSTANCE.adminRegistryAssessmentsToPartialJsonAssessments(fullAssessments), uriInfo);
+        var latestList = new ArrayList<MotivationAssessment>();
+        var latestToPrevious = new HashMap<String, List<MotivationAssessment>>();
+
+        for (var entry : grouped.entrySet()) {
+            var versions = entry.getValue().stream()
+                    .sorted(Comparator.comparing(MotivationAssessment::getCreatedOn).reversed())
+                    .collect(Collectors.toList());
+
+            var latest = versions.get(0);
+            latestList.add(latest);
+
+            var previousVersions = versions.subList(1, versions.size());
+            latestToPrevious.put(latest.getId(), previousVersions);
+        }
+
+        var fullAssessments = latestList.stream()
+                .map(latest -> {
+                    var dto = AssessmentMapper.INSTANCE.adminRegistryAssessmentToJsonAssessment(latest);
+
+                    var prevVersions = latestToPrevious.getOrDefault(latest.getId(), List.of()).stream()
+                            .map(AssessmentMapper.INSTANCE::adminRegistryAssessmentToJsonAssessment)
+                            .collect(Collectors.toList());
+
+                    dto.setAdminVersions(prevVersions);
+                    return AssessmentMapper.INSTANCE.adminRegistryAssessmentToPartialJsonAssessment(dto);
+                })
+                .collect(Collectors.toList());
+
+        return new PageResource<>(assessments, fullAssessments, uriInfo);
     }
 
     /**
@@ -570,9 +740,40 @@ public class JsonAssessmentService {
     public PageResource<AdminPartialJsonAssessmentResponse> getAllAssessmentsByPage(int page, int size, String search, UriInfo uriInfo) {
 
         var assessments = motivationAssessmentRepository.fetchAllAssessmentsByPage(page, size, search);
-        var fullAssessments = AssessmentMapper.INSTANCE.adminRegistryAssessmentsToJsonAssessments(assessments.list());
 
-        return new PageResource<>(assessments, AssessmentMapper.INSTANCE.adminRegistryAssessmentsToPartialJsonAssessments(fullAssessments), uriInfo);
+
+        var grouped = assessments.list().stream()
+                .collect(Collectors.groupingBy(MotivationAssessment::getParentAssessmentId));
+
+        var latestList = new ArrayList<MotivationAssessment>();
+        var latestToPrevious = new HashMap<String, List<MotivationAssessment>>();
+
+        for (var entry : grouped.entrySet()) {
+            var versions = entry.getValue().stream()
+                    .sorted(Comparator.comparing(MotivationAssessment::getCreatedOn).reversed())
+                    .collect(Collectors.toList());
+
+            var latest = versions.get(0);
+            latestList.add(latest);
+
+            var previousVersions = versions.subList(1, versions.size());
+            latestToPrevious.put(latest.getId(), previousVersions);
+        }
+
+        var fullAssessments = latestList.stream()
+                .map(latest -> {
+                    var dto = AssessmentMapper.INSTANCE.adminRegistryAssessmentToJsonAssessment(latest);
+
+                    var prevVersions = latestToPrevious.getOrDefault(latest.getId(), List.of()).stream()
+                            .map(AssessmentMapper.INSTANCE::adminRegistryAssessmentToJsonAssessment)
+                            .collect(Collectors.toList());
+
+                    dto.setAdminVersions(prevVersions);
+                    return AssessmentMapper.INSTANCE.adminRegistryAssessmentToPartialJsonAssessment(dto);
+                })
+                .collect(Collectors.toList());
+
+        return new PageResource<>(assessments, fullAssessments, uriInfo);
     }
 
     @SneakyThrows


### PR DESCRIPTION
### Description:
This PR introduces the ability to create a new version of an existing assessment. The versioning mechanism is based on duplicating the assessment_doc of the original assessment and resetting its evaluation fields to prepare for a new round of compliance assessment.

#### New version creation:
* A new assessment is created using the assessment_doc of a previously completed or published assessment.
* The new assessment has its own id, created_on timestamp, and is linked back to the original using parent_assessment_id.

#### Fields reset in the duplicated assessment_doc:
* result.compliance, result.ranking, all metric.result, metric.value, and test.result, test.value fields are cleared (null or false).
* All evidence_url fields are cleared (empty arrays).
* Status fields such as published and status are reset.