### PR TITLE
[CAT-895] Add 'enabled' column to TestMethod and support filtering via API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ According to [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) , the `Unr
 - [#495](https://github.com/FC4E-CAT/fc4e-cat-api/pull/495) CAT-886 Implement Search Functionality for Testmethod
 - [#497](https://github.com/FC4E-CAT/fc4e-cat-api/pull/497) CAT-891 Publishing to Zenodo New Version
 - [#500](https://github.com/FC4E-CAT/fc4e-cat-api/pull/500) CAT-893 Versioning of Existing Assessment
+- [#501](https://github.com/FC4E-CAT/fc4e-cat-api/pull/501) CAT-895 Add "enabled" Column to TestMethod Table and Support Enable/Disable Functionality via API.
 
 
 ### Fix

--- a/api/src/main/java/org/grnet/cat/api/endpoints/registry/TestMethodEndpoint.java
+++ b/api/src/main/java/org/grnet/cat/api/endpoints/registry/TestMethodEndpoint.java
@@ -156,7 +156,7 @@ public class TestMethodEndpoint {
     )
     @APIResponse(
             responseCode = "200",
-            description = "Subject was updated successfully.",
+            description = "TestMethod was updated successfully.",
             content = @Content(schema = @Schema(
                     type = SchemaType.OBJECT,
                     implementation = TestMethodResponseDto.class)))
@@ -331,9 +331,15 @@ public class TestMethodEndpoint {
             @Min(value = 1, message = "Page size must be between 1 and 100.")
             @Max(value = 100, message = "Page size must be between 1 and 100.")
             @QueryParam("size") int size,
+            @Parameter(
+                    description = "Filter Test Methods by enabled status. " +
+                            "Use 'true' to get only enabled Test Methods, 'false' for disabled ones. " +
+                            "If not provided, all Test Methods are returned."
+            )
+            @QueryParam("enabled") Boolean enabled,
             @Context UriInfo uriInfo) {
 
-        var testMethods = testMethodService.getTestMethodListAll(search, page - 1, size, uriInfo);
+        var testMethods = testMethodService.getTestMethodListAll(search, page - 1, size, enabled, uriInfo);
 
         return Response.ok().entity(testMethods).build();
     }

--- a/data-transfer-object/src/main/java/org/grnet/cat/dtos/registry/test/TestMethodRequestDto.java
+++ b/data-transfer-object/src/main/java/org/grnet/cat/dtos/registry/test/TestMethodRequestDto.java
@@ -2,11 +2,8 @@ package org.grnet.cat.dtos.registry.test;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.validation.constraints.NotEmpty;
-import jakarta.validation.constraints.NotNull;
 import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
-import org.grnet.cat.constraints.NotFoundEntity;
-import org.grnet.cat.repositories.registry.TestMethodRepository;
 
 public class TestMethodRequestDto {
 
@@ -87,4 +84,13 @@ public class TestMethodRequestDto {
     )
     @JsonProperty("code_fragment")
     public String codeFragment;
+
+    @Schema(
+            type = SchemaType.BOOLEAN,
+            implementation = Boolean.class,
+            description = "Whether the Test Method is enabled or not. By default this value is 'true'.",
+            example = "true"
+    )
+    @JsonProperty("enabled")
+    public Boolean enabled = Boolean.TRUE;
 }

--- a/data-transfer-object/src/main/java/org/grnet/cat/dtos/registry/test/TestMethodResponseDto.java
+++ b/data-transfer-object/src/main/java/org/grnet/cat/dtos/registry/test/TestMethodResponseDto.java
@@ -1,10 +1,15 @@
 package org.grnet.cat.dtos.registry.test;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Setter;
 import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
+import org.grnet.cat.dtos.registry.motivation.PartialMotivationResponse;
 
 import java.sql.Timestamp;
+import java.util.ArrayList;
+import java.util.List;
 
 public class TestMethodResponseDto {
 
@@ -131,6 +136,21 @@ public class TestMethodResponseDto {
     @JsonProperty("version")
     public String lodTMEV;
 
+    @Schema(
+            type = SchemaType.BOOLEAN,
+            implementation = Boolean.class,
+            description = "Whether the Test Method is enabled or not.",
+            example = "false"
+    )
+    @JsonProperty("enabled")
+    public Boolean enabled;
 
-
+    @Setter
+    @Schema(
+            type = SchemaType.BOOLEAN,
+            implementation = Boolean.class,
+            description = "Whether a Test Method is used in published Motivation or not."
+    )
+    @JsonProperty("used_by_published_motivations")
+    public Boolean usedByPublishedMotivations;
 }

--- a/data-transfer-object/src/main/java/org/grnet/cat/dtos/registry/test/TestMethodUpdateDto.java
+++ b/data-transfer-object/src/main/java/org/grnet/cat/dtos/registry/test/TestMethodUpdateDto.java
@@ -15,7 +15,6 @@ public class TestMethodUpdateDto {
             example = "03615660"
     )
     @JsonProperty("uuid")
-    @NotEmpty(message = "uuid may not be empty.")
     public String UUID;
 
     @Schema(
@@ -25,7 +24,6 @@ public class TestMethodUpdateDto {
             example = "String-Auto"
     )
     @JsonProperty("label")
-    @NotEmpty(message = "label may not be empty.")
     public String labelTestMethod;
 
     @Schema(
@@ -35,7 +33,6 @@ public class TestMethodUpdateDto {
             example = "A test is completed to indicate a duration in months, and converted to decimal years"
     )
     @JsonProperty("description")
-    @NotEmpty(message = "description may not be empty.")
     public String descTestMethod;
 
     @Schema(
@@ -45,7 +42,6 @@ public class TestMethodUpdateDto {
             example = "pid_graph:number"
     )
     @JsonProperty("lod_type_value")
-    @NotEmpty(message = "lod_type_value may not be empty.")
     public String lodTypeValue;
 
     @Schema(
@@ -55,7 +51,6 @@ public class TestMethodUpdateDto {
             example = "pid_graph:manual"
     )
     @JsonProperty("lod_type_process")
-    @NotEmpty(message = "lod_type_process may not be empty.")
     public String lodTypeProcess;
 
     @Schema(
@@ -65,7 +60,6 @@ public class TestMethodUpdateDto {
             example = "1"
     )
     @JsonProperty("num_params")
-    @NotNull(message = "num_params may not be empty.")
     public Integer numParams;
 
     @Schema(
@@ -86,4 +80,13 @@ public class TestMethodUpdateDto {
     )
     @JsonProperty("code_fragment")
     public String codeFragment;
+
+    @Schema(
+            type = SchemaType.BOOLEAN,
+            implementation = Boolean.class,
+            description = "Whether the Test Method is enabled or not.",
+            example = "false"
+    )
+    @JsonProperty("enabled")
+    public Boolean enabled;
 }

--- a/entity/src/main/java/org/grnet/cat/entities/registry/TestMethod.java
+++ b/entity/src/main/java/org/grnet/cat/entities/registry/TestMethod.java
@@ -65,4 +65,7 @@ public class TestMethod {
 
     @Column(name = "lodTME_V")
     private String lodTMEV;
+
+    @Column(name = "enabled")
+    private Boolean enabled;
 }

--- a/entity/src/main/resources/db/migration/tables/registry/V1.75__test_method_enabled.sql
+++ b/entity/src/main/resources/db/migration/tables/registry/V1.75__test_method_enabled.sql
@@ -1,0 +1,11 @@
+-- ------------------------------------------------
+-- Version: v1.75
+--
+-- Description: Migration that adds the enabled column into Test Method table
+-- -------------------------------------------------
+
+-- Add "enabled" column to TestMethod table
+ALTER TABLE t_TestMethod ADD COLUMN enabled BOOLEAN DEFAULT TRUE;
+
+UPDATE t_TestMethod SET enabled = TRUE;
+

--- a/mapper/src/main/java/org/grnet/cat/mappers/registry/TestMethodMapper.java
+++ b/mapper/src/main/java/org/grnet/cat/mappers/registry/TestMethodMapper.java
@@ -10,8 +10,9 @@ import org.mapstruct.factory.Mappers;
 import java.sql.Timestamp;
 import java.time.Instant;
 import java.util.List;
+import java.util.Objects;
 
-@Mapper(imports = {StringUtils.class, Timestamp.class, Instant.class})
+@Mapper(imports = {StringUtils.class, Timestamp.class, Instant.class, Objects.class})
 public interface TestMethodMapper {
 
     TestMethodMapper INSTANCE = Mappers.getMapper(TestMethodMapper.class);
@@ -45,6 +46,7 @@ public interface TestMethodMapper {
     @Mapping(target = "responseFragment", ignore = true)
     @Mapping(target = "lodMTV", ignore = true)
     @Mapping(target = "lodTMEV", ignore = true)
+    @Mapping(target = "enabled", expression = "java(Objects.nonNull(request.enabled) ? request.enabled : testMethod.getEnabled())")
     void updateTestMethodFromDto(TestMethodUpdateDto request, @MappingTarget TestMethod testMethod);
 
 }

--- a/repository/src/main/java/org/grnet/cat/repositories/registry/TestMethodRepository.java
+++ b/repository/src/main/java/org/grnet/cat/repositories/registry/TestMethodRepository.java
@@ -1,16 +1,18 @@
 package org.grnet.cat.repositories.registry;
 
-import io.quarkus.panache.common.Sort;
 import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.transaction.Transactional;
 import org.apache.commons.lang3.StringUtils;
 import org.grnet.cat.entities.Page;
 import org.grnet.cat.entities.PageQuery;
 import org.grnet.cat.entities.PageQueryImpl;
-import org.grnet.cat.entities.registry.Test;
+import org.grnet.cat.entities.registry.Motivation;
 import org.grnet.cat.entities.registry.TestMethod;
 import org.grnet.cat.repositories.Repository;
 
 import java.util.HashMap;
+import java.util.List;
+import java.util.Objects;
 import java.util.StringJoiner;
 
 @ApplicationScoped
@@ -23,18 +25,23 @@ public class TestMethodRepository implements Repository<TestMethod, String> {
      * @param size The maximum number of Metric to include in a page.
      * @return A list of TestMethod objects representing the Metrics in the requested page.
      */
-    public PageQuery<TestMethod> fetchTestMethodByPage(String search, int page, int size){
-
-        //var panache = find("from TestMethod", Sort.by("lastTouch", Sort.Direction.Descending).and("id", Sort.Direction.Ascending)).page(page, size);
+    public PageQuery<TestMethod> fetchTestMethodByPage(String search, int page, int size, Boolean enabled){
 
         var joiner = new StringJoiner(" ");
         joiner.add("from TestMethod tm");
+        joiner.add("where 1=1");
 
         var map = new HashMap<String, Object>();
 
         if (StringUtils.isNotEmpty(search)) {
-            joiner.add("where tm.labelTestMethod ilike :search");
+            joiner.add("and tm.labelTestMethod ilike :search");
             map.put("search", "%" + search + "%");
+        }
+
+        if(!Objects.isNull(enabled)){
+
+            joiner.add("and tm.enabled = :enabled");
+            map.put("enabled", enabled);
         }
 
         joiner.add("order by tm.labelTestMethod ASC, tm.id ASC");
@@ -49,5 +56,18 @@ public class TestMethodRepository implements Repository<TestMethod, String> {
         pageable.page = Page.of(page, size);
 
         return pageable;
+    }
+
+    @Transactional
+    public List<Motivation> getMotivationIdsByTestMethodId(String testMethodId) {
+
+        var db = "SELECT DISTINCT m FROM Motivation m " +
+                "LEFT JOIN MetricTestJunction mt ON mt.motivation.id = m.id " +
+                "WHERE mt.test.testMethod.id = :testMethodId and m.published = :published";
+
+        return getEntityManager().createQuery(db, Motivation.class)
+                .setParameter("testMethodId", testMethodId)
+                .setParameter("published", Boolean.TRUE)
+                .getResultList();
     }
 }

--- a/service/src/main/java/org/grnet/cat/services/registry/TestMethodService.java
+++ b/service/src/main/java/org/grnet/cat/services/registry/TestMethodService.java
@@ -11,7 +11,6 @@ import org.grnet.cat.dtos.registry.test.TestMethodUpdateDto;
 import org.grnet.cat.mappers.registry.TestMethodMapper;
 import org.grnet.cat.repositories.registry.MetricTestRepository;
 import org.grnet.cat.repositories.registry.TestMethodRepository;
-import org.jboss.logging.Logger;
 
 @ApplicationScoped
 public class TestMethodService {
@@ -22,7 +21,6 @@ public class TestMethodService {
 
     @Inject
     MetricTestRepository metricTestRepository;
-    private static final Logger LOG = Logger.getLogger(TestMethodService.class);
 
     /**
      * Retrieves a specific TestMethod item by its ID.
@@ -34,7 +32,11 @@ public class TestMethodService {
 
         var testMethod = testMethodRepository.findById(id);
 
-        return TestMethodMapper.INSTANCE.testMethodToDto(testMethod);
+        var tm =  TestMethodMapper.INSTANCE.testMethodToDto(testMethod);
+
+        tm.usedByPublishedMotivations = metricTestRepository.existTestMethodInStatus(id, Boolean.TRUE);
+
+        return tm;
     }
 
     /**
@@ -101,10 +103,12 @@ public class TestMethodService {
      * @param uriInfo The Uri Info for pagination links.
      * @return A PageResource containing the TestMethod items in the requested page.
      */
-    public PageResource<TestMethodResponseDto> getTestMethodListAll(String search, int page, int size, UriInfo uriInfo) {
+    public PageResource<TestMethodResponseDto> getTestMethodListAll(String search, int page, int size, Boolean enabled, UriInfo uriInfo) {
 
-        var testMethodPage = testMethodRepository.fetchTestMethodByPage(search,page, size);
+        var testMethodPage = testMethodRepository.fetchTestMethodByPage(search, page, size, enabled);
         var testMethodDtos = TestMethodMapper.INSTANCE.testMethodToDtos(testMethodPage.list());
+
+        testMethodDtos.forEach(tm-> tm.usedByPublishedMotivations = metricTestRepository.existTestMethodInStatus(tm.id, Boolean.TRUE));
 
         return new PageResource<>(testMethodPage, testMethodDtos, uriInfo);
     }

--- a/service/src/main/java/org/grnet/cat/services/registry/TestService.java
+++ b/service/src/main/java/org/grnet/cat/services/registry/TestService.java
@@ -219,9 +219,6 @@ public class TestService {
         if (tests.isEmpty()) {
             return new PageResource<>(testPage, List.of(), uriInfo);
         }
-        var testIds = tests.stream()
-                .map(Test::getId)
-                .collect(Collectors.toList());
 
         var dtoList = tests.stream()
                 .map(test -> {


### PR DESCRIPTION
**This PR introduces the following changes:**

➕ Added a new enabled column (boolean, default: true) to the TestMethod table.

🔄 Updated all existing records to have enabled = true.

🔍 Added query parameter support in the API to filter TestMethod entries by enabled status.

📝 Documented the enabled query parameter in the OpenAPI spec using MicroProfile annotations.

**How to test:**

1. Create and update TestMethod entries with enabled = true/false.

1. Call the GET endpoint `v1/registry/tests/test-method` with:

 -   `?enabled=true` → returns only enabled methods

- `?enabled=false` → returns only disabled methods

- `no param` → returns all methods

