### PR TITLE
CAT-1026 Fix: Ensure test fields are correctly updated in Test update method

### DIFF
--- a/service/src/main/java/org/grnet/cat/services/registry/TestService.java
+++ b/service/src/main/java/org/grnet/cat/services/registry/TestService.java
@@ -127,6 +127,8 @@ public class TestService {
                 testMethodRepository.findByIdOptional(request.testMethodId).orElseThrow(()-> new NotFoundException("There is no Test Method with the following id: "+request.testMethodId));
                 test.setTestMethod(Panache.getEntityManager().getReference(TestMethod.class, request.testMethodId));
                 test.setTestQuestion(request.testQuestion);
+                test.setTestParams(request.testParams);
+                test.setToolTip(request.tooltip);
             }
         }
 


### PR DESCRIPTION
### Fix: Ensure test fields are correctly updated in Test update method
During Test update operations, the mapper did not correctly update certain fields (testParams, testQuestion, and tooltip), causing previous values to persist unexpectedly.

### Changes:
#### Explicitly set:
* test.setTestQuestion(...)
* test.setTestParams(...)
* test.setToolTip(...)