### PR TITLE
CAT-902 Missing description in 'String-Auto' testmethod prevents update

### DIFF
--- a/entity/src/main/resources/db/migration/tables/registry/V1.77__test_method_update.sql
+++ b/entity/src/main/resources/db/migration/tables/registry/V1.77__test_method_update.sql
@@ -1,0 +1,8 @@
+-- ------------------------------------------------
+-- Version: v1.77
+--
+-- Description: Migration that updates the description of 'String-Auto' Test Method
+-- -------------------------------------------------
+UPDATE t_TestMethod
+SET descTestMethod = 'A test is executed automatically, returning a string value as a result'
+WHERE lodtme = 'pid_graph:03615660';


### PR DESCRIPTION
The descTestMethod field was missing (null), which violates the @NotNull constraint on the entity. This caused the update operation to fail with a ConstraintViolationException during Hibernate’s validation phase.