### PR TITLE
CAT-904 automated_group_test Not Persisted, Causing "Fully-Automated-Validation" Button to not appear on Edit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,9 @@ According to [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) , the `Unr
 - [#482](https://github.com/FC4E-CAT/fc4e-cat-api/pull/482) CAT-867: Update Auto-AAI-Check-Entitlements tests parameters
 - [#488](https://github.com/FC4E-CAT/fc4e-cat-api/pull/488) CAT-875: Merge Test and Test Definition Entities
 - [#499](https://github.com/FC4E-CAT/fc4e-cat-api/pull/499) CAT-894 ServiceConfigurationError during Async Zenodo Publishing
+
+- [#508](https://github.com/FC4E-CAT/fc4e-cat-api/pull/508) CAT-904 automated_group_test Not Persisted, Causing "Fully-Automated-Validation" Button to not appear on Edit
+
 ## 2.0.0 - 2025-03-31
 ---
 

--- a/data-transfer-object/src/main/java/org/grnet/cat/dtos/assessment/registry/RegistryAssessmentDto.java
+++ b/data-transfer-object/src/main/java/org/grnet/cat/dtos/assessment/registry/RegistryAssessmentDto.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.validation.Valid;
 import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
+import org.grnet.cat.dtos.AutomatedTestResponse;
 import org.grnet.cat.dtos.registry.template.RegistryTemplateActorDto;
 import org.grnet.cat.dtos.registry.template.RegistryTemplateMotivationDto;
 import org.grnet.cat.dtos.template.TemplateOrganisationDto;
@@ -12,7 +13,9 @@ import org.grnet.cat.dtos.template.TemplateResultDto;
 import org.grnet.cat.dtos.template.TemplateSubjectDto;
 import org.junit.Ignore;
 
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 @Schema(name = "RegistryAssessmentDto", description = "This object represents a Registry Assessment Dto.")
 public class RegistryAssessmentDto {
@@ -55,4 +58,8 @@ public class RegistryAssessmentDto {
     public TemplateResultDto result;
 
     public List<PriNodeDto> principles;
+
+    @JsonProperty(value = "automated_group_test")
+    public List<Map<String, Object>> automatedGroupTest;
+
 }

--- a/service/src/main/java/org/grnet/cat/services/assessment/JsonAssessmentService.java
+++ b/service/src/main/java/org/grnet/cat/services/assessment/JsonAssessmentService.java
@@ -106,7 +106,6 @@ public class JsonAssessmentService {
         assessment.setShared(Boolean.FALSE);
         assessment.setPublished(request.assessmentDoc.published);
         assessment.setAssessmentDoc(objectMapper.writeValueAsString(request.assessmentDoc));
-
         motivationAssessmentRepository.persist(assessment);
         assessment.setParentAssessmentId(assessment.getId());
 
@@ -117,6 +116,7 @@ public class JsonAssessmentService {
 
             jsonNode.put("id", assessment.getId());
             jsonNode.put("version", "v1");
+            jsonNode.put("automated_group_test", objectMapper.valueToTree(request.assessmentDoc.automatedGroupTest));
 
 
             assessment.setAssessmentDoc(objectMapper.writeValueAsString(jsonNode));


### PR DESCRIPTION
added automated_group_test to the RegistryAssessmentDto  to pass in the request of creating assessment
and put the field in the json