### PR TITLE
CAT-809 Should not be able to edit published assessment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,7 @@ According to [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) , the `Unr
 - [#546](https://github.com/FC4E-CAT/fc4e-cat-api/pull/546) CAT-1007: Avoid unecessary role checks while approving validation
 - [#547](https://github.com/FC4E-CAT/fc4e-cat-api/pull/547) CAT-1008: Encrypt/Decrypt Sensitive Setting Values and Add Info Column 
 - [#551](https://github.com/FC4E-CAT/fc4e-cat-api/pull/551) CAT-1017 Add Run Report Functionality
+- [#510](https://github.com/FC4E-CAT/fc4e-cat-api/pull/510) CAT-809 Should not be able to edit published assessment
 
 ### Fix
 - [#502](https://github.com/FC4E-CAT/fc4e-cat-api/pull/502) CAT-1026 Fix: Ensure test fields are correctly updated in Test update method

--- a/api/src/main/java/org/grnet/cat/api/endpoints/AssessmentsV2Endpoint.java
+++ b/api/src/main/java/org/grnet/cat/api/endpoints/AssessmentsV2Endpoint.java
@@ -22,6 +22,7 @@ import org.eclipse.microprofile.openapi.annotations.security.SecurityRequirement
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
 import org.grnet.cat.api.filters.Registration;
 import org.grnet.cat.api.utils.CatServiceUriInfo;
+import org.grnet.cat.constraints.CheckPublished;
 import org.grnet.cat.constraints.NotFoundEntity;
 import org.grnet.cat.dtos.InformativeResponse;
 import org.grnet.cat.dtos.assessment.registry.AdminJsonRegistryAssessmentResponse;
@@ -334,7 +335,8 @@ public class AssessmentsV2Endpoint {
                                              example = "c242e43f-9869-4fb0-b881-631bc5746ec0",
                                              schema = @Schema(type = SchemaType.STRING))
                                      @PathParam("id")
-                                     @Valid @NotFoundEntity(repository = MotivationAssessmentRepository.class, message = "There is no assessment with the following id:") String id,
+                                     @Valid @NotFoundEntity(repository = MotivationAssessmentRepository.class, message = "There is no assessment with the following id:")
+                                     @CheckPublished(repository = MotivationAssessmentRepository.class, message = "No action permitted for published Assessment with the following id:", isPublishedPermitted = false) String id,
                                      @Valid @NotNull(message = "The request body is empty.") JsonRegistryAssessmentRequest request) {
 
         var assessment = assessmentService.updatePrivateAssessment(id, request);

--- a/api/src/main/resources/application.properties
+++ b/api/src/main/resources/application.properties
@@ -137,7 +137,6 @@ api.name=cat
 quarkus.health.openapi.included=true
 
 quarkus.rest-client."org.grnet.cat.api.health.AAIProxyClient".url=${QUARKUS_OIDC_AUTH_SERVER_URL:https://login-devel.einfra.grnet.gr/auth/realms/einfra}
-
 quarkus.rest-client."org.grnet.cat.services.zenodo.ZenodoClient".url=https://sandbox.zenodo.org
 
 quarkus.rest-client.naco-service.url=https://cvs.data.kit.edu

--- a/api/src/test/java/org/grnet/cat/api/AssessmentsEndpointTest.java
+++ b/api/src/test/java/org/grnet/cat/api/AssessmentsEndpointTest.java
@@ -824,4 +824,59 @@ public class AssessmentsEndpointTest extends KeycloakTest {
                 .as(UserJsonRegistryAssessmentResponse.class);
         assertEquals(assessment.id, publicAssessment.id);
     }
+
+    @Test
+    public void editPublishedAssessment() throws IOException {
+
+        //register("validated");
+        //register("admin");
+        //register("evald");
+
+        //makeValidation("validated", "pid_graph:B5CC396B");
+
+        var requestAssessment = new JsonRegistryAssessmentRequest();
+        requestAssessment.assessmentDoc = makeRegistryJsonDoc();
+
+        var assessment = given()
+                .auth()
+                .oauth2(validatedToken)
+                .basePath("/v2/assessments")
+                .body(requestAssessment)
+                .contentType(ContentType.JSON)
+                .post()
+                .then()
+                .assertThat()
+                .statusCode(201)
+                .extract()
+                .as(UserJsonRegistryAssessmentResponse.class);
+
+        var response = given()
+                .auth()
+                .oauth2(validatedToken)
+                .basePath("/v2/assessments/")
+                .put("/{id}/publish", assessment.id)
+                .then()
+                .assertThat()
+                .statusCode(200)
+                .extract()
+                .as(InformativeResponse.class);
+
+        var response1 = given()
+                .auth()
+                .oauth2(validatedToken)
+                .basePath("/v2/assessments/")
+                .body(requestAssessment)
+                .contentType(ContentType.JSON)
+                .put("/{id}", assessment.id)
+                .then()
+                .assertThat()
+                .statusCode(400)
+                .extract()
+                .as(InformativeResponse.class);
+
+        assertEquals(400, response1.code);
+        assertEquals("No action permitted for published Assessment with the following id: "+assessment.id, response1.message);
+
+        }
+
 }

--- a/validator/src/main/java/org/grnet/cat/validators/CheckPublishedValidator.java
+++ b/validator/src/main/java/org/grnet/cat/validators/CheckPublishedValidator.java
@@ -5,8 +5,11 @@ import jakarta.validation.ConstraintValidator;
 import jakarta.validation.ConstraintValidatorContext;
 import org.apache.commons.lang3.StringUtils;
 import org.grnet.cat.constraints.CheckPublished;
+import org.grnet.cat.entities.MotivationAssessment;
 import org.grnet.cat.entities.registry.Motivation;
+import org.grnet.cat.repositories.MotivationAssessmentRepository;
 import org.grnet.cat.repositories.Repository;
+import org.grnet.cat.repositories.registry.MotivationRepository;
 
 import java.util.Objects;
 
@@ -30,13 +33,26 @@ public class CheckPublishedValidator implements ConstraintValidator<CheckPublish
         }
 
         Repository repository = CDI.current().select(this.repository).get();
-        Motivation motivation = (Motivation) repository.findById(value);
-        // If motivation is found and is published, the action is not permitted
-
         boolean isPermitted = true;
-        if (motivation != null && motivation.getPublished() != isPublishedPermitted) {
-            isPermitted = false;
+
+        if (repository instanceof MotivationRepository) {
+
+            Motivation motivation = (Motivation) repository.findById(value);
+            // If motivation is found and is published, the action is not permitted
+
+            if (motivation != null && motivation.getPublished() != isPublishedPermitted) {
+                isPermitted = false;
+            }
+        } else if (repository instanceof MotivationAssessmentRepository) {
+
+            MotivationAssessment assessment = (MotivationAssessment) repository.findById(value);
+            // If motivation is found and is published, the action is not permitted
+
+            if (assessment != null && assessment.getPublished() != isPublishedPermitted) {
+                isPermitted = false;
+            }
         }
+
         StringBuilder builder = new StringBuilder();
 
         builder.append(message);


### PR DESCRIPTION
a validator is added to not permit editing published assessments. 
this pr should be merged after ui enables the versions in assessments