### PR TITLE
CAT-837 Tests in assessment should appear in an ascending order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,8 +41,8 @@ According to [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) , the `Unr
 - [#482](https://github.com/FC4E-CAT/fc4e-cat-api/pull/482) CAT-867: Update Auto-AAI-Check-Entitlements tests parameters
 - [#488](https://github.com/FC4E-CAT/fc4e-cat-api/pull/488) CAT-875: Merge Test and Test Definition Entities
 - [#499](https://github.com/FC4E-CAT/fc4e-cat-api/pull/499) CAT-894 ServiceConfigurationError during Async Zenodo Publishing
-
 - [#508](https://github.com/FC4E-CAT/fc4e-cat-api/pull/508) CAT-904 automated_group_test Not Persisted, Causing "Fully-Automated-Validation" Button to not appear on Edit
+- [#511](https://github.com/FC4E-CAT/fc4e-cat-api/pull/511) CAT-837 Tests in assessment should appear in an ascending order
 
 ## 2.0.0 - 2025-03-31
 ---

--- a/service/src/main/java/org/grnet/cat/services/assessment/JsonAssessmentService.java
+++ b/service/src/main/java/org/grnet/cat/services/assessment/JsonAssessmentService.java
@@ -117,8 +117,7 @@ public class JsonAssessmentService {
             jsonNode.put("id", assessment.getId());
             jsonNode.put("version", "v1");
             jsonNode.put("automated_group_test", objectMapper.valueToTree(request.assessmentDoc.automatedGroupTest));
-
-
+            sortTestsInAssessmentDoc(jsonNode);
             assessment.setAssessmentDoc(objectMapper.writeValueAsString(jsonNode));
         } catch (JsonProcessingException e) {
             throw new RuntimeException(e);
@@ -176,6 +175,7 @@ public class JsonAssessmentService {
         try {
             var docWithId = (ObjectNode) objectMapper.readTree(newAssessment.getAssessmentDoc());
             docWithId.put("id", newAssessment.getId());
+            sortTestsInAssessmentDoc(docNode);
             newAssessment.setAssessmentDoc(objectMapper.writeValueAsString(docWithId));
         } catch (Exception e) {
         }
@@ -367,6 +367,14 @@ public class JsonAssessmentService {
     public UserJsonRegistryAssessmentResponse getRegistryDtoAssessment(String assessmentId) {
 
         var assessment = motivationAssessmentRepository.findById(assessmentId);
+
+        try {
+            ObjectNode doc = (ObjectNode) objectMapper.readTree(assessment.getAssessmentDoc());
+            sortTestsInAssessmentDoc(doc); // Sort tests inside the assessment JSON
+            assessment.setAssessmentDoc(objectMapper.writeValueAsString(doc));
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException("Failed to sort tests in assessmentDoc", e);
+        }
 
         return AssessmentMapper.INSTANCE.userRegistryAssessmentToJsonAssessment(assessment);
     }
@@ -811,6 +819,33 @@ public class JsonAssessmentService {
         assessment.setPublished(publish);
         return String.format("Assessment is %s successfully", publish ? "published" : "unpublished");
 
+    }
+
+
+    private void sortTestsInAssessmentDoc(ObjectNode assessmentDoc) {
+        var principles = (ArrayNode) assessmentDoc.get("principles");
+        if (principles == null) return;
+
+        for (JsonNode principleNode : principles) {
+            var criteria = (ArrayNode) principleNode.get("criteria");
+            if (criteria == null) continue;
+
+            for (JsonNode criterionNode : criteria) {
+                var metric = (ObjectNode) criterionNode.get("metric");
+                if (metric == null) continue;
+
+                var tests = (ArrayNode) metric.get("tests");
+                if (tests == null) continue;
+
+                List<JsonNode> sorted = new ArrayList<>();
+                tests.forEach(sorted::add);
+
+                sorted.sort(Comparator.comparing(n -> n.get("id").asText()));
+
+                var sortedTests = metric.putArray("tests");
+                sorted.forEach(sortedTests::add);
+            }
+        }
     }
 
 }


### PR DESCRIPTION
This PR introduces a sorting mechanism that ensures the list of tests under each metric in the assessmentDoc JSON is consistently ordered. The sorting is based on the id(TES) field of each test.

### Changes:
* New method sortTestsInAssessmentDoc(ObjectNode assessmentDoc) in JsonAssessmentService
* Sorts the tests array in each metric by their "id" field

### Applied sorting in:
- createV2Assessment() → before persisting new assessments
- getRegistryDtoAssessment() → before mapping to DTO and returning

------ 
### How to test locally (Example)
1. **Temporarily comment out** the sorting logic in createV2Assessment() 
   _(We temporarily comment out the sorting logic on creation to verify that the sorting also applies correctly to assessments that are already drafted or published in the devel environment. )_
3. **Create a Motivation Actor**:
    PID Onwner:
      - P9 -> C21 -> MTR -> {T2,5 , T2,4}
      - P10 -> C6 ->  MTR1 -> {T13,2, T13,1}                    (we create our metrics on the spot)
4. **Publish the actor**
5. **Validate** your user for PID Owner (Role) (if you dont have one)
6. **Create an assessment**  similar to this (put the tests in the "wrong" order):

```
{
  "assessment_doc": {
    "name": "NOSORTREQUESTNOSORT",
    "version": "v1",
    "status": "",
    "published": false,
    "timestamp": "2025-06-23 16:09:23.720066",
    "actor": {
      "id": "pid_graph:B5CC396B",
      "name": "PID Owner (Role)"
    },
    "organisation": {
      "id": "05tcasm11",
      "name": "National Infrastructures for Research and Technology -  GRNET S.A"
    },
    "subject": {
      "id": "test-id",
      "name": "test-name",
      "type": "test",
      "db_id": 1000
    },
    "result": {
      "compliance": null,
      "ranking": null
    },
    "principles": [
      {
        "id": "P9",
        "name": "Resolution",
        "description": "There is a need for a generic, global PID resolution system across all PID systems and service providers.",
        "criteria": [
          {
            "id": "C21",
            "name": "RI Integration",
            "description": "Services SHOULD allow integration with European Research Infrastructures.",
            "imperative": "SHOULD",
            "metric": {
              "id": "MTR",
              "name": "MTR",
              "type": "Binary-Binary",
              "benchmark_value": 2,
              "value": null,
              "result": null,
              "tests": [
                                {
                  "id": "T2,5",
                  "name": "Secure - Authentication",
                  "description": "Sensitive PID Kernel Metadata requires users to be authenticated - evidence is provided.",
                  "type": "Binary-Manual-Evidence",
                  "text": "Does access to Sensitive PID Kernel Metadata require user authentication?|Provide evidence of this provision via a link to a specification, user guide, or API definition.",
                  "params": "user_authentication|evidence",
                  "value": null,
                  "result": null,
                  "tool_tip": "Users need to be authenticated and requisite permissions must apply for access to sensitive metadata|A document, web page, or publication describing provisions",
                  "evidence_url": []
                },
{
                  "id": "T2,4",
                  "name": "Secure - Access",
                  "description": "Sensitive PID Kernel Metadata requires access to be granted - evidence is provided.",
                  "type": "Binary-Manual",
                  "text": "Is access to Sensitive PID Kernel Metadata password protected?",
                  "params": "pwNeeded",
                  "value": null,
                  "result": null,
                  "tool_tip": "Users need to sign in to view sensitive metadata"
                }
              ],
              "label_algorithm_type": "Simple Sum",
              "label_type_metric": "Binary"
            }
          }
        ]
      },
      {
        "id": "P10",
        "name": "Governed",
        "description": "PID Service Providers should apply appropriate community governance to ensure that their PID Services and Systems adhere to these policies, and are agile and responsive to the needs of research, Open Science and EOSC.",
        "criteria": [
          {
            "id": "C6",
            "name": "Ownership Transfer",
            "description": "The PID manager SHOULD provide policies and contractual arrangements for transfer of ownership should the owner no longer be able to assume responsibilities in compliance with the policy.",
            "imperative": "SHOULD",
            "metric": {
              "id": "MTR2",
              "name": "MTR2",
              "type": "String-Binary",
              "benchmark_value": 4,
              "value": null,
              "result": null,
              "tests": [
                                {
                  "id": "T13,2",
                  "name": "PID Persistence - Service - Auto Evidence",
                  "description": "An inventory of PIDs issued by the Authority on behalf of the Service a is compared to the inventory of PIDs published by the service s and the ratio is larger than a benchmark b determined by the community.",
                  "type": "Ratio-Manual",
                  "text": "Provide the number of PIDs recorded to date by the Authority on behalf of your provider service (A)|Provide the number of PIDs recorded to date by your Service (S)",
                  "params": "numerator|denominator",
                  "value": null,
                  "result": null,
                  "tool_tip": "The ratio of S/A will be compared with the community expectation, reflecting that a large percentage of PIDs registered with the authority is used and maintained by the service."
                },
{
                  "id": "T13,1",
                  "name": "PID Persistence - Service - Evidence",
                  "description": "Public evidence is provided by the Provider (Service) that PIDs cannot be deleted.",
                  "type": "Binary-Manual-Evidence",
                  "text": "Do you ensure that the PID will never be deleted?|Can you provide public evidence of this?",
                  "params": "neverDelete|evidence",
                  "value": null,
                  "result": null,
                  "tool_tip": "PIDs must always remain registered in the PID Stack, usually with the Authority and/ or Provider|A document, web page, or publication describing measures taken",
                  "evidence_url": []
                }
              ],
              "label_algorithm_type": "Simple Sum",
              "label_type_metric": "Binary"
            }
          }
        ]
      }
    ],
    "id": "69d94551-59b2-4f28-ba2e-c71c4f3eb33f",
    "assessment_type": {
      "id": "pid_graph:ACD29D88",
      "name": "tetsdt"
    },
    "automated_group_test": []
}
}
```
7. Fetch the assessment. The output JSON should now look sorted even though we inserted them unsorted.