### PR TITLE
CAT-930: Add Original Motivation per Criterion and Retrieve Associated Principles

### DIFF
--- a/api/src/test/java/org/grnet/cat/api/registry/CriteriaEndpointTest.java
+++ b/api/src/test/java/org/grnet/cat/api/registry/CriteriaEndpointTest.java
@@ -130,6 +130,7 @@ public class CriteriaEndpointTest extends KeycloakTest {
         request.description = "This metric measures performance.";
         request.imperative = "pid_graph:BED209B9";
         request.typeCriterion = "pid_graph:A2719B92";
+        request.lodMTV = null;
         return request;
     }
 

--- a/data-transfer-object/src/main/java/org/grnet/cat/dtos/registry/criterion/CriterionRequest.java
+++ b/data-transfer-object/src/main/java/org/grnet/cat/dtos/registry/criterion/CriterionRequest.java
@@ -7,6 +7,7 @@ import org.eclipse.microprofile.openapi.annotations.media.Schema;
 import org.grnet.cat.constraints.NotFoundEntity;
 import org.grnet.cat.repositories.registry.CriterionRepository;
 import org.grnet.cat.repositories.registry.ImperativeRepository;
+import org.grnet.cat.repositories.registry.MotivationRepository;
 import org.grnet.cat.repositories.registry.TypeCriterionRepository;
 
 @Schema(name = "CriterionRequest", description = "This object represents the data required to create a Criterion.")
@@ -78,6 +79,15 @@ public class CriterionRequest {
     @JsonProperty("url")
     public String url;
 
+    @Schema(
+            type = SchemaType.STRING,
+            implementation = String.class,
+            description = "The Id of the Motivation.",
+            example = "pid_graph:3E109BBA"
+    )
+    @JsonProperty("motivation_id")
+    @NotFoundEntity(repository = MotivationRepository.class, message = "There is no Motivation with the following id:")
+    public String lodMTV;
     @Schema(
             type = SchemaType.STRING,
             implementation = String.class,

--- a/data-transfer-object/src/main/java/org/grnet/cat/dtos/registry/criterion/CriterionResponse.java
+++ b/data-transfer-object/src/main/java/org/grnet/cat/dtos/registry/criterion/CriterionResponse.java
@@ -4,9 +4,12 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
+import org.grnet.cat.constraints.NotFoundEntity;
 import org.grnet.cat.dtos.registry.metric.MetricResponseDto;
 import org.grnet.cat.dtos.registry.motivation.PartialMotivationResponse;
+import org.grnet.cat.dtos.registry.principle.PrinciplePartialResponse;
 import org.grnet.cat.dtos.registry.template.MetricNode;
+import org.grnet.cat.repositories.registry.MotivationRepository;
 
 import java.util.List;
 
@@ -76,6 +79,17 @@ public class CriterionResponse {
     @JsonProperty("url")
     public String url;
 
+
+    @Schema(
+            type = SchemaType.STRING,
+            implementation = String.class,
+            description = "The Id of the Motivation.",
+            example = "pid_graph:3E109BBA"
+    )
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    @JsonProperty("motivation_id")
+    public String lodMTV;
+
     @Schema(
             type = SchemaType.STRING,
             implementation = String.class,
@@ -113,6 +127,15 @@ public class CriterionResponse {
     public List<PartialMotivationResponse> motivations;
 
 
+    @Schema(
+            type = SchemaType.ARRAY,
+            implementation = PrinciplePartialResponse.class,
+            description = "List of principles related to this criterion."
+    )
+    @JsonProperty("tagged_by_principles")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public List<PrinciplePartialResponse> taggedByPrinciple;
+
 
     @Schema(
             type = SchemaType.ARRAY,
@@ -126,6 +149,8 @@ public class CriterionResponse {
     public void setMotivations(List<PartialMotivationResponse> motivations) {
         this.motivations = motivations;
     }
+
+    public void setTaggedByPrinciple(List<PrinciplePartialResponse> taggedByPrinciple) {this.taggedByPrinciple = taggedByPrinciple;}
 
     public void setMetrics(List<MetricNode> metrics) { this.metrics = metrics;}
 }

--- a/entity/src/main/java/org/grnet/cat/entities/registry/Criterion.java
+++ b/entity/src/main/java/org/grnet/cat/entities/registry/Criterion.java
@@ -72,6 +72,10 @@ public class Criterion extends Registry {
     @NotNull
     private TypeCriterion typeCriterion;
 
+    @Column(name = "lodMTV")
+    private String lodMTV;
+
+
     @Column(name = "lodCRI_V")
     private String lodCriV;
 

--- a/entity/src/main/resources/db/migration/tables/registry/criterion/V1.85__add_column_criterion.sql
+++ b/entity/src/main/resources/db/migration/tables/registry/criterion/V1.85__add_column_criterion.sql
@@ -1,0 +1,7 @@
+-- ------------------------------------------------
+-- Version: v1.83.1
+--
+-- Description: Adds lodMTV column to p_criterion
+-- ------------------------------------------------
+
+ALTER TABLE p_criterion ADD COLUMN lodMTV VARCHAR(255) DEFAULT NULL;

--- a/entity/src/main/resources/db/migration/tables/registry/criterion/V1.86__stored_procedure_populate_lodmtv.sql
+++ b/entity/src/main/resources/db/migration/tables/registry/criterion/V1.86__stored_procedure_populate_lodmtv.sql
@@ -1,0 +1,92 @@
+-- ------------------------------------------------
+-- Version: v1.86
+--
+-- Description: Stored procedure to populate lodmtv field
+-- ------------------------------------------------
+
+CREATE OR REPLACE PROCEDURE PopulateLodMTVOnCriterion()
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    UPDATE p_criterion
+    SET lodMTV = tmp.lodMTV
+    FROM (
+        VALUES
+        ('AI-TEST-CRIT', 'pid_graph:5EB0885A'),
+        ('AMR-1', 'pid_graph:5EB0885A'),
+        ('AMR-2', 'pid_graph:5EB0885A'),
+        ('ASDASD', 'pid_graph:8F59FADD'),
+        ('AUTO-1', 'pid_graph:5EB0885A'),
+        ('AUTO-ARCC-TEST-CRI', 'pid_graph:3EDCB21F'),
+        ('C-TEST', 'pid_graph:FE3A1997'),
+        ('C1', 'pid_graph:3E109BBA'),
+        ('C10', 'pid_graph:3E109BBA'),
+        ('C11', 'pid_graph:3E109BBA'),
+        ('C12', 'pid_graph:3E109BBA'),
+        ('C14', 'pid_graph:3E109BBA'),
+        ('C15', 'pid_graph:3E109BBA'),
+        ('C16', 'pid_graph:3E109BBA'),
+        ('C17', 'pid_graph:3E109BBA'),
+        ('C18', 'pid_graph:D0E19F50'),
+        ('C19', 'pid_graph:3E109BBA'),
+        ('C2', 'pid_graph:3E109BBA'),
+        ('C20', 'pid_graph:3E109BBA'),
+        ('C21', 'pid_graph:D0E19F50'),
+        ('C22', 'pid_graph:3E109BBA'),
+        ('C23', 'pid_graph:3E109BBA'),
+        ('C24', 'pid_graph:3E109BBA'),
+        ('C25', 'pid_graph:3E109BBA'),
+        ('C26', 'pid_graph:D0E19F50'),
+        ('C27', 'pid_graph:3E109BBA'),
+        ('C28', 'pid_graph:3E109BBA'),
+        ('C29', 'pid_graph:3E109BBA'),
+        ('C3', 'pid_graph:3E109BBA'),
+        ('C30', 'pid_graph:3E109BBA'),
+        ('C31', 'pid_graph:3E109BBA'),
+        ('C32', 'pid_graph:D0E19F50'),
+        ('C33', 'pid_graph:3E109BBA'),
+        ('C34', 'pid_graph:3E109BBA'),
+        ('C35', 'pid_graph:3E109BBA'),
+        ('C36', 'pid_graph:D0E19F50'),
+        ('C4', 'pid_graph:3E109BBA'),
+        ('C5', 'pid_graph:3E109BBA'),
+        ('C6', 'pid_graph:3E109BBA'),
+        ('C7', 'pid_graph:3E109BBA'),
+        ('C8', 'pid_graph:3E109BBA'),
+        ('CRITEST', 'pid_graph:95560D23'),
+        ('CRITESTMOT', 'pid_graph:95560D23'),
+        ('DASDAS', 'pid_graph:95C6D0D7'),
+        ('G056-C1.1', 'pid_graph:88398F6D'),
+        ('G056-C2.1', 'pid_graph:88398F6D'),
+        ('G056-C2.2', 'pid_graph:88398F6D'),
+        ('G056-C2.3', 'pid_graph:88398F6D'),
+        ('G056-C3.1', 'pid_graph:88398F6D'),
+        ('G056-C4.1', 'pid_graph:88398F6D'),
+        ('G056-C4.2', 'pid_graph:88398F6D'),
+        ('G056-C5.1', 'pid_graph:88398F6D'),
+        ('G056-C6.1', 'pid_graph:88398F6D'),
+        ('G056-C7.1', 'pid_graph:88398F6D'),
+        ('G056-C8.1', 'pid_graph:88398F6D'),
+        ('G069-C1', 'pid_graph:95C6D0D7'),
+        ('G069-C2', 'pid_graph:95C6D0D7'),
+        ('MD-1', 'pid_graph:5EB0885A'),
+        ('NET-1 CRITERION', 'pid_graph:5EB0885A'),
+        ('NETWORK-CONF-CRI', 'pid_graph:3EDCB21F'),
+        ('NEWCRITEST', 'pid_graph:C08780DD'),
+        ('SITE-1', 'pid_graph:5EB0885A'),
+        ('TEST', 'pid_graph:8F59FADD'),
+        ('TESTCR', 'pid_graph:1216B340')
+    ) AS tmp(cri, lodmtv)
+    JOIN t_motivation m ON m.lodMTV = tmp.lodMTV
+    WHERE p_criterion.cri = tmp.cri;
+
+    RAISE NOTICE 'lodMTV values updated successfully.';
+
+EXCEPTION
+    WHEN OTHERS THEN
+        RAISE EXCEPTION 'Failed to populate lodMTV field in p_criterion: %', SQLERRM;
+END;
+$$;
+
+-- Run the procedure
+CALL PopulateLodMTVOnCriterion();

--- a/mapper/src/main/java/org/grnet/cat/mappers/registry/CriteriaMapper.java
+++ b/mapper/src/main/java/org/grnet/cat/mappers/registry/CriteriaMapper.java
@@ -27,6 +27,7 @@ public interface CriteriaMapper {
     @Mapping(target = "typeCriterion", expression = "java(criterion.getTypeCriterion().getId())")
     @Mapping(target = "motivations", ignore = true)
     @Mapping(target = "metrics", ignore = true)
+    @Mapping(target = "taggedByPrinciple", ignore = true)
     CriterionResponse criteriaToDto(Criterion criterion);
 
     @Mapping(target = "cri", expression = "java(criteriaRequestDto.cri.toUpperCase())")
@@ -55,5 +56,6 @@ public interface CriteriaMapper {
     @Mapping(target = "principles", ignore = true)
     @Mapping(target = "metrics", ignore = true)
     @Mapping(target = "actors", ignore = true)
+    @Mapping(target = "lodMTV", ignore = true)
     void updateCriteria(CriterionUpdate request, @MappingTarget Criterion criterion);
 }

--- a/mapper/src/main/java/org/grnet/cat/mappers/registry/CriterionActorMapper.java
+++ b/mapper/src/main/java/org/grnet/cat/mappers/registry/CriterionActorMapper.java
@@ -22,6 +22,7 @@ import java.util.stream.Collectors;
 public interface CriterionActorMapper {
 
     CriterionActorMapper INSTANCE = Mappers.getMapper(CriterionActorMapper.class);
+
     @Mapping(source = "criterion.id", target = "id")
     @Mapping(source = "criterion.cri", target = "cri")
     @Mapping(source = "criterion.label", target = "label")
@@ -45,7 +46,8 @@ public interface CriterionActorMapper {
     }
 
     @Named("mapPrinciple")
-    @Mapping(target = "id",  expression = "java(principleJunction.getPrinciple().getId())")  // Ignore the id field here as well
+    @Mapping(target = "id", expression = "java(principleJunction.getPrinciple().getId())")
+    // Ignore the id field here as well
     @Mapping(target = "pri", expression = "java(principleJunction.getPrinciple().getPri())")
     @Mapping(target = "label", expression = "java(principleJunction.getPrinciple().getLabel())")
     PrinciplePartialResponse mapPrinciple(PrincipleCriterionJunction principleJunction);
@@ -61,10 +63,16 @@ public interface CriterionActorMapper {
     @Mapping(source = "motivation.mtv", target = "motivationMtv")
     @Mapping(source = "populatedBy", target = "populatedBy")
     @Mapping(source = "lastTouch", target = "lastTouch")
-    @Mapping(target = "principles", source = "criterion.principles", qualifiedByName = "mapPrinciples")
+    @Mapping(target = "principles", expression = "java(filterPrinciplesByMotivation(junction.getCriterion().getPrinciples(), junction.getMotivation().getId()))")
     CriterionActorResponse toCriterionActorResponse(CriterionActorJunction junction);
 
     List<CriterionActorResponse> toCriterionActorResponseList(List<CriterionActorJunction> junctions);
 
+    public default List<PrinciplePartialResponse> filterPrinciplesByMotivation(Set<PrincipleCriterionJunction> principles, String motivationId) {
+        return principles.stream()
+                .filter(principle -> principle.getMotivation().getId().equals(motivationId))
+                .map(this::mapPrinciple)
+                .collect(Collectors.toList());
+    }
 }
 

--- a/mapper/src/main/java/org/grnet/cat/mappers/registry/PrincipleMapper.java
+++ b/mapper/src/main/java/org/grnet/cat/mappers/registry/PrincipleMapper.java
@@ -1,9 +1,11 @@
 package org.grnet.cat.mappers.registry;
 import org.apache.commons.lang3.StringUtils;
+import org.grnet.cat.dtos.registry.principle.PrinciplePartialResponse;
 import org.grnet.cat.dtos.registry.principle.PrincipleRequestDto;
 import org.grnet.cat.dtos.registry.principle.PrincipleResponseDto;
 import org.grnet.cat.dtos.registry.principle.PrincipleUpdateDto;
 import org.grnet.cat.entities.registry.Principle;
+import org.grnet.cat.entities.registry.PrincipleCriterionJunction;
 import org.mapstruct.*;
 import org.mapstruct.factory.Mappers;
 
@@ -46,4 +48,11 @@ public interface PrincipleMapper {
     @Mapping(target = "motivations", ignore = true)
     @Mapping(target = "criteria", ignore = true)
     void updatePrinciple(PrincipleUpdateDto request, @MappingTarget Principle principle);
+
+
+    @Mapping(target = "id",  expression = "java(principle.getId())")  // Ignore the id field here as well
+    @Mapping(target = "pri", expression = "java(principle.getPri())")
+    @Mapping(target = "label", expression = "java(principle.getLabel())")
+    PrinciplePartialResponse mapPartialPrinciple(Principle principle);
+
 }

--- a/repository/src/main/java/org/grnet/cat/repositories/registry/PrincipleCriterionRepository.java
+++ b/repository/src/main/java/org/grnet/cat/repositories/registry/PrincipleCriterionRepository.java
@@ -8,6 +8,7 @@ import org.grnet.cat.entities.Page;
 import org.grnet.cat.entities.PageQuery;
 import org.grnet.cat.entities.PageQueryImpl;
 import org.grnet.cat.entities.registry.Motivation;
+import org.grnet.cat.entities.registry.Principle;
 import org.grnet.cat.entities.registry.PrincipleCriterionJunction;
 import org.grnet.cat.repositories.Repository;
 
@@ -136,6 +137,16 @@ public class PrincipleCriterionRepository  implements Repository<PrincipleCriter
         var db = "SELECT DISTINCT pc.motivation FROM PrincipleCriterionJunction pc WHERE pc.criterion.id = :criterionId";
 
         return getEntityManager().createQuery(db, Motivation.class)
+                .setParameter("criterionId", criterionId)
+                .getResultList();
+    }
+
+    @Transactional
+    public List<Principle> getPrinciplesIdsByCriterion(String criterionId) {
+
+        var db = "SELECT DISTINCT pc.principle FROM PrincipleCriterionJunction pc WHERE pc.criterion.id = :criterionId";
+
+        return getEntityManager().createQuery(db, Principle.class)
                 .setParameter("criterionId", criterionId)
                 .getResultList();
     }

--- a/service/src/main/java/org/grnet/cat/services/registry/CriterionService.java
+++ b/service/src/main/java/org/grnet/cat/services/registry/CriterionService.java
@@ -17,6 +17,7 @@ import org.grnet.cat.dtos.registry.criterion.PrincipleCriterionResponse;
 import org.grnet.cat.dtos.registry.template.MetricNode;
 import org.grnet.cat.dtos.registry.template.Node;
 import org.grnet.cat.dtos.registry.template.TestNode;
+import org.grnet.cat.mappers.registry.PrincipleMapper;
 import org.grnet.cat.utils.TestParamsTransformer;
 import org.grnet.cat.entities.registry.*;
 import org.grnet.cat.exceptions.UniqueConstraintViolationException;
@@ -99,6 +100,10 @@ public class CriterionService {
 
         var criteria = CriteriaMapper.INSTANCE.criteriaToEntity(criteriaRequestDto);
 
+        if (!(criteriaRequestDto.lodMTV == null)) {
+            criteria.setLodMTV(criteriaRequestDto.lodMTV);
+        }
+
         criteria.setPopulatedBy(userId);
         criteria.setImperative(Panache.getEntityManager().getReference(Imperative.class, criteriaRequestDto.imperative));
         criteria.setTypeCriterion(Panache.getEntityManager().getReference(TypeCriterion.class, criteriaRequestDto.typeCriterion));
@@ -121,7 +126,7 @@ public class CriterionService {
     public CriterionResponse update(String id, CriterionUpdate criteriaUpdateDto, String userId) {
 
         if(criterionActorRepository.existCriterionInStatus(id, Boolean.TRUE)){
-            throw new ForbiddenException("No action permitted , criterion exists in a published motivation");
+            throw new ForbiddenException("No action permitted , criterion exists in a published assessment type");
         }
 
         var criteria = criteriaRepository.findById(id);
@@ -166,7 +171,7 @@ public class CriterionService {
    public boolean delete(String id) {
 
         if(criterionActorRepository.existCriterionInStatus(id, Boolean.TRUE)){
-            throw new ForbiddenException("No action permitted , criterion exists in a published motivation");
+            throw new ForbiddenException("No action permitted , criterion exists in a published assessment type");
         }
 
         if (principleCriterionRepository.existsByCriterion(id)) {
@@ -253,6 +258,13 @@ public class CriterionService {
                 .collect(Collectors.toList());
 
         criterionResponse.setMotivations(motivationResponses);
+
+        var principles = principleCriterionRepository.getPrinciplesIdsByCriterion(criterion.getId());
+        var principleResponses = principles.stream()
+                .map(PrincipleMapper.INSTANCE::mapPartialPrinciple)
+                .collect(Collectors.toList());
+
+        criterionResponse.setTaggedByPrinciple(principleResponses);
 
         var metrics = criterionMetricRepository.findMetricsByCriterionId(criterion.getId());
 

--- a/service/src/main/java/org/grnet/cat/services/registry/RegistryActorService.java
+++ b/service/src/main/java/org/grnet/cat/services/registry/RegistryActorService.java
@@ -135,7 +135,9 @@ public class RegistryActorService {
 
         var criteriaActor = criterionActorRepository.fetchCriteriaByMotivationAndActorAndPage(motivationId, actorId, page, size);
 
-        return new PageResource<>(criteriaActor, CriterionActorMapper.INSTANCE.toCriterionActorResponseList(criteriaActor.list()), uriInfo);
+        var criAct =  CriterionActorMapper.INSTANCE.toCriterionActorResponseList(criteriaActor.list());
+
+        return new PageResource<>(criteriaActor, criAct, uriInfo);
     }
 
     /**


### PR DESCRIPTION
### Description
This PR introduces a new field lodmtv in the p_criterion table to reflect the original motivation for which each criterion was created.

### Key Changes:
* Added lodmtv column to p_criterion table.
* Created a stored procedure (populate_lodmtv_on_criterion) to populate the field based on motivation assignments.
* Added logic to retrieve the list of distinct principles associated with each criterion.
* Enriched the CriterionRequest during criterion creation to include: 
```
{
  "cri": "C1test1",
  "label": "Minimum Operations",
  "description": "Service providers SHOULD provide a common Application Programming Interface to interact with PIDs, supporting a minimum set of operations (create, resolve and modify PID and PID Kernel Information)",
  "imperative": "pid_graph:34F8B2A9",
  "type_criterion_id": "pid_graph:4A47BB1A",
  "url": "https://criterion.url/",
  "motivation_id": null,
  "criterion_parent_id": null
}
```