### PR TITLE
CAT-931: Update Metric Creation Request to Include Criterion Reference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ According to [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) , the `Unr
 - [#503](https://github.com/FC4E-CAT/fc4e-cat-api/pull/503) CAT-898 Validation Request - add list of AAI providers
 - [#507](https://github.com/FC4E-CAT/fc4e-cat-api/pull/507) CAT-903 Add "enabled" Column to Types Related to Metric Table and Support Enable/Disable Functionality via API
 - [#514](https://github.com/FC4E-CAT/fc4e-cat-api/pull/514) CAT-928: Create AssessmentType template
+- [#516](https://github.com/FC4E-CAT/fc4e-cat-api/pull/516) CAT-931 Update Metric Creation Request to Include Criterion Reference
 
 
 ### Fix
@@ -47,6 +48,7 @@ According to [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) , the `Unr
 - [#492](https://github.com/FC4E-CAT/fc4e-cat-api/pull/492) CAT-882 Merge Metric with Definition
 - [#511](https://github.com/FC4E-CAT/fc4e-cat-api/pull/511) CAT-837 Tests in assessment should appear in an ascending order
 - [#512](https://github.com/FC4E-CAT/fc4e-cat-api/pull/512) CAT-909 NACO list information
+- [#515](https://github.com/FC4E-CAT/fc4e-cat-api/pull/515) CAT-930 Add Original Motivation per Criterion and Retrieve Associated Principles
 
 
 ## 2.0.0 - 2025-03-31

--- a/api/src/main/java/org/grnet/cat/api/endpoints/registry/MotivationEndpoint.java
+++ b/api/src/main/java/org/grnet/cat/api/endpoints/registry/MotivationEndpoint.java
@@ -2374,11 +2374,12 @@ public class MotivationEndpoint {
             @Valid
             @NotFoundEntity(repository = MotivationRepository.class, message = "There is no Motivation with the following id:")
             @CheckPublished(repository = MotivationRepository.class, message = "No action permitted for published Motivation with the following id:", isPublishedPermitted = false)
-            String id, @Valid @NotNull(message = "The request body is empty.") MetricRequestDto request) {
+            String id, @Valid @NotNull(message = "The request body is empty.") MetricRequestDto request, UriInfo uriInfo) {
 
         var response = motivationService.createMetricForMotivation(id, request, utility.getUserUniqueIdentifier());
+        var serverInfo = new CatServiceUriInfo(serverUrl.concat(uriInfo.getPath()));
 
-        return Response.status(response.code).entity(response).build();
+        return Response.created(serverInfo.getAbsolutePathBuilder().path(String.valueOf(response.id)).build()).entity(response).build();
     }
 
     @Tag(name = "Motivation")

--- a/api/src/test/java/org/grnet/cat/api/registry/MetricEndpointTest.java
+++ b/api/src/test/java/org/grnet/cat/api/registry/MetricEndpointTest.java
@@ -162,7 +162,7 @@ public class MetricEndpointTest extends KeycloakTest {
                 .post("/")
                 .then()
                 .assertThat()
-                .statusCode(409) // Assuming 409 Conflict for duplicate MTR
+                .statusCode(409)
                 .extract()
                 .as(InformativeResponse.class);
 

--- a/api/src/test/java/org/grnet/cat/api/registry/MotivationEndpointTest.java
+++ b/api/src/test/java/org/grnet/cat/api/registry/MotivationEndpointTest.java
@@ -11,6 +11,7 @@ import org.grnet.cat.dtos.registry.criterion.CriterionActorRequest;
 import org.grnet.cat.dtos.registry.criterion.CriterionRequest;
 import org.grnet.cat.dtos.registry.criterion.CriterionResponse;
 import org.grnet.cat.dtos.registry.metric.MetricRequestDto;
+import org.grnet.cat.dtos.registry.metric.MetricResponseDto;
 import org.grnet.cat.dtos.registry.metric.MetricVersionRequestDto;
 import org.grnet.cat.dtos.registry.motivation.MotivationRequest;
 import org.grnet.cat.dtos.registry.motivation.MotivationResponse;
@@ -965,71 +966,6 @@ public class MotivationEndpointTest extends KeycloakTest {
                 .as(InformativeResponse.class);
 
         assertEquals("A principle with the identifier '" + principleRequestDto.pri + "' already exists.", errorResponse.message);
-    }
-
-
-    @Test
-    @Execution(ExecutionMode.CONCURRENT)
-    public void createMetricForMotivationAlreadyExist() {
-
-        //register("admin");
-
-        var motivationRequest = new MotivationRequest();
-        motivationRequest.mtv = ("mtv" + UUID.randomUUID()).toUpperCase();
-        motivationRequest.label = "testLabelMotivation";
-        motivationRequest.description = "testDecMotivation";
-        motivationRequest.motivationTypeId = "pid_graph:8882700E";
-
-        var motivationResponse = given()
-                .auth()
-                .oauth2(adminToken)
-                .body(motivationRequest)
-                .contentType(ContentType.JSON)
-                .post()
-                .then()
-                .assertThat()
-                .statusCode(201)
-                .extract()
-                .as(MotivationResponse.class);
-
-        var metricRequest = new MetricRequestDto();
-        metricRequest.MTR = ("MTR" + UUID.randomUUID()).toUpperCase();
-        metricRequest.labelMetric = "Performance Metric";
-        metricRequest.descrMetric = "This metric measures performance.";
-        metricRequest.urlMetric = "http://example.com/metric";
-        metricRequest.typeAlgorithmId = "pid_graph:2050775C";
-        metricRequest.typeMetricId = "pid_graph:35966E2B";
-        metricRequest.typeBenchmarkId = "pid_graph:0917EC0D";
-        metricRequest.valueBenchmark = "3";
-
-        var informativeResponse = given()
-                .auth()
-                .oauth2(getAccessToken("admin"))
-                .body(metricRequest)
-                .contentType(ContentType.JSON)
-                .post("/{id}/metric", motivationResponse.id)
-                .then()
-                .assertThat()
-                .statusCode(200)
-                .extract()
-                .as(InformativeResponse.class);
-
-        assertEquals(200, informativeResponse.code);
-
-        var errorResponse = given()
-                .auth()
-                .oauth2(getAccessToken("admin"))
-                .body(metricRequest)
-                .contentType(ContentType.JSON)
-                .post("/{id}/metric", motivationResponse.id)
-                .then()
-                .assertThat()
-                .statusCode(409)
-                .extract()
-                .as(InformativeResponse.class);
-
-        assertEquals(409, errorResponse.code);
-        assertEquals("A metric with the identifier '" + metricRequest.MTR + "' already exists.", errorResponse.message);
     }
 
     @Test

--- a/data-transfer-object/src/main/java/org/grnet/cat/dtos/registry/metric/MetricRequestDto.java
+++ b/data-transfer-object/src/main/java/org/grnet/cat/dtos/registry/metric/MetricRequestDto.java
@@ -2,6 +2,7 @@ package org.grnet.cat.dtos.registry.metric;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.validation.constraints.NotEmpty;
+import lombok.EqualsAndHashCode;
 import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
 import org.grnet.cat.constraints.NotFoundEntity;
@@ -97,4 +98,14 @@ public class MetricRequestDto {
     @NotEmpty(message = "value_benchmark may not be empty.")
     @JsonProperty("value_benchmark")
     public String valueBenchmark;
+
+    @Schema(
+            type = SchemaType.STRING,
+            implementation = String.class,
+            description = "The id of the related Criterion .",
+            example = "pid_graph:D0339C6A"
+    )
+    @JsonProperty("criterion_id")
+    @EqualsAndHashCode.Include
+    public String criterion_id;
 }

--- a/mapper/src/main/java/org/grnet/cat/mappers/registry/metric/MetricMapper.java
+++ b/mapper/src/main/java/org/grnet/cat/mappers/registry/metric/MetricMapper.java
@@ -45,8 +45,8 @@ public interface MetricMapper {
     Metric metricToEntity(MetricRequestDto request);
 
     @Mapping(target = "MTR", expression = "java(StringUtils.isNotEmpty(request.MTR) ? request.MTR : metric.getMTR())")
-    @Mapping(target = "labelMetric", expression = "java(StringUtils.isNotEmpty(request.labelMetric) ? request.labelMetric : metric.getLabelMetric())")
-    @Mapping(target = "descrMetric", expression = "java(StringUtils.isNotEmpty(request.descrMetric) ? request.descrMetric : metric.getDescrMetric())")
+    //@Mapping(target = "labelMetric", expression = "java(StringUtils.isNotEmpty(request.labelMetric) ? request.labelMetric : metric.getLabelMetric())")
+    //@Mapping(target = "descrMetric", expression = "java(StringUtils.isNotEmpty(request.descrMetric) ? request.descrMetric : metric.getDescrMetric())")
     @Mapping(target = "urlMetric", expression = "java(StringUtils.isNotEmpty(request.urlMetric) ? request.urlMetric : metric.getUrlMetric())")
     @Mapping(target = "lastTouch", expression = "java(Timestamp.from(Instant.now()))")
     @Mapping(target = "typeAlgorithm", ignore = true)

--- a/repository/src/main/java/org/grnet/cat/repositories/registry/metric/MetricRepository.java
+++ b/repository/src/main/java/org/grnet/cat/repositories/registry/metric/MetricRepository.java
@@ -15,6 +15,7 @@ import org.grnet.cat.repositories.Repository;
 
 import java.util.HashMap;
 import java.util.List;
+import java.util.Optional;
 import java.util.StringJoiner;
 
 @ApplicationScoped
@@ -69,7 +70,8 @@ public class MetricRepository implements Repository<Metric, String> {
 
         joiner.add("select DISTINCT met FROM Metric met")
                 .add("where (exists (select 1 from CriterionMetricJunction cm where cm.metric.id = met.id and cm.motivation.id = :motivationId)")
-                .add("or exists (select 1 from MetricTestJunction mt where mt.metric.id = met.id and mt.motivation.id = :motivationId))");
+                .add("or exists (select 1 from MetricTestJunction mt where mt.metric.id = met.id and mt.motivation.id = :motivationId)")
+                .add("or met.lodMTV = :motivationId)");
 
 
         var map = new HashMap<String, Object>();
@@ -151,6 +153,18 @@ public class MetricRepository implements Repository<Metric, String> {
         return query.getResultList();
     }
 
+
+    public Optional<Metric> fetchMetricByTypesCombinations(String typeAlgorithmId, String typeBenchmarkId, String typeMetricId) {
+        return find("FROM Metric m " +
+                        "WHERE m.typeAlgorithm.id = ?1 " +
+                        "AND m.typeBenchmark.id = ?2 " +
+                        "AND m.typeMetric.id = ?3" +
+                        "ORDER BY m.lastTouch ASC",
+                typeAlgorithmId, typeBenchmarkId, typeMetricId)
+                .firstResultOptional();
+    }
+
+
     /**
      * Checks if the specified value for a given field in the Metric entity is not unique.
      *
@@ -164,5 +178,17 @@ public class MetricRepository implements Repository<Metric, String> {
                 .setParameter(1, value)
                 .getSingleResult();
         return count > 0;
+    }
+
+    public int getNextAvailableMtrNumber() {
+        String sql = "SELECT MAX(CAST(SUBSTRING(m.mtr, 2) AS INTEGER)) " +
+                "FROM p_Metric m " +
+                "WHERE m.mtr ~ '^M[0-9]+'";
+
+        Integer max = (Integer) getEntityManager()
+                .createNativeQuery(sql)
+                .getSingleResult();
+
+        return max != null ? max + 1 : 1;
     }
 }

--- a/service/src/main/java/org/grnet/cat/services/registry/MotivationService.java
+++ b/service/src/main/java/org/grnet/cat/services/registry/MotivationService.java
@@ -83,6 +83,9 @@ public class MotivationService {
     @Inject
     MetricService metricService;
 
+    @Inject
+    CriterionRepository criterionRepository;
+
     /**
      * Creates a new Motivation.
      *
@@ -598,44 +601,51 @@ public class MotivationService {
     }
 
     @Transactional
-    public InformativeResponse createMetricForMotivation(String id, MetricRequestDto request, String userId) {
+    public MetricResponseDto createMetricForMotivation(String id, MetricRequestDto request, String userId) {
 
-        var response = new InformativeResponse();
+        if (metricRepository.notUnique("MTR", request.MTR.toUpperCase())) {
+            throw new UniqueConstraintViolationException("MTR", request.MTR.toUpperCase());
+        }
+        var metric = MetricMapper.INSTANCE.metricToEntity(request);
 
-        if (!metricRepository.notUnique("MTR", request.MTR.toUpperCase())) {
+        metric.setLodMTV(id);
+        metric.setPopulatedBy(userId);
+        metric.setVersion(1);
 
-            var metricRequest = new MetricRequestDto();
-            metricRequest.MTR = request.MTR;
-            metricRequest.urlMetric = request.urlMetric;
-            metricRequest.typeMetricId = request.typeMetricId;
-            metricRequest.typeAlgorithmId = request.typeAlgorithmId;
-            metricRequest.labelMetric = request.labelMetric;
-            metricRequest.descrMetric = request.descrMetric;
-            metricRequest.typeBenchmarkId = request.typeBenchmarkId;
-            metricRequest.valueBenchmark = request.valueBenchmark;
+        var typeAlgorithm = Panache.getEntityManager().getReference(TypeAlgorithm.class, request.typeAlgorithmId);
+        var typeBenchmark = Panache.getEntityManager().getReference(TypeBenchmark.class, request.typeBenchmarkId);
+        var typeMetric = Panache.getEntityManager().getReference(TypeMetric.class, request.typeMetricId);
 
-            var metric = MetricMapper.INSTANCE.metricToEntity(metricRequest);
+        metric.setTypeAlgorithm(typeAlgorithm);
+        metric.setTypeBenchmark(typeBenchmark);
+        metric.setTypeMetric(typeMetric);
 
-            metric.setLodMTV(id);
-            metric.setPopulatedBy(userId);
-            metric.setTypeAlgorithm(Panache.getEntityManager().getReference(TypeAlgorithm.class, metricRequest.typeAlgorithmId));
-            metric.setTypeMetric(Panache.getEntityManager().getReference(TypeMetric.class, metricRequest.typeMetricId));
-            metric.setTypeBenchmark(Panache.getEntityManager().getReference(TypeBenchmark.class, metricRequest.typeBenchmarkId));
-            metric.setPopulatedBy(userId);
-            metric.setVersion(1);
-            metricRepository.persist(metric);
+        metric.setMTR("M" + metricRepository.getNextAvailableMtrNumber());
 
-            metric.setLodMTRV(metric.getId());
+        if (request.criterion_id != null) {
+            var criterion = criterionRepository.findById(request.criterion_id);
+            var similarMetricOpt = metricRepository.fetchMetricByTypesCombinations(
+                    typeAlgorithm.getId(),
+                    typeBenchmark.getId(),
+                    typeMetric.getId()
+            );
 
-            response.code = 200;
-            response.message = "A Metric successfully created with identifier: " + metric.getId();
-        } else {
-            response.code = 409;
-            response.message = "A metric with the identifier '" + request.MTR.toUpperCase() + "' already exists.";
+            if (similarMetricOpt.isPresent()) {
+                var similarMetric = similarMetricOpt.get();
+                metric.setLabelMetric(similarMetric.getLabelMetric());
+                metric.setDescrMetric(similarMetric.getDescrMetric());
+            } else {
+                metric.setLabelMetric(criterion.getLabel() + (" Metric"));
+                metric.setDescrMetric("Metric created for " + motivationRepository.findById(id).getLabel() + " and used by criterion " + criterion.getCri() + ".");
+            }
         }
 
-        return response;
+        metricRepository.persist(metric);
+        metric.setLodMTRV(metric.getId());
+
+        return MetricMapper.INSTANCE.metricToDto(metric);
     }
+
 
     @Transactional
     public InformativeResponse createMetricVersionForMotivation(String motivationId, String metricId, MetricVersionRequestDto request, String userId) {

--- a/service/src/main/java/org/grnet/cat/services/registry/metric/MetricService.java
+++ b/service/src/main/java/org/grnet/cat/services/registry/metric/MetricService.java
@@ -22,12 +22,12 @@ import org.grnet.cat.mappers.registry.MotivationMapper;
 import org.grnet.cat.mappers.registry.metric.MetricMapper;
 
 import org.grnet.cat.repositories.registry.CriterionMetricRepository;
+import org.grnet.cat.repositories.registry.CriterionRepository;
 import org.grnet.cat.repositories.registry.TypeBenchmarkRepository;
 import org.grnet.cat.repositories.registry.metric.MetricRepository;
 import org.grnet.cat.repositories.registry.metric.TypeAlgorithmRepository;
 import org.grnet.cat.repositories.registry.metric.TypeMetricRepository;
 import org.jboss.logging.Logger;
-
 import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
@@ -48,6 +48,10 @@ public class MetricService {
     TypeBenchmarkRepository typeBenchmarkRepository;
     @Inject
     CriterionMetricRepository criterionMetricRepository;
+
+    @Inject
+    CriterionRepository criterionRepository;
+
     private static final Logger LOG = Logger.getLogger(MetricService.class);
 
     /**
@@ -273,5 +277,4 @@ public class MetricService {
                 })
                 .collect(Collectors.toList());
     }
-
 }


### PR DESCRIPTION
### Reuse of Label/Description from Similar Metrics

- Added support for passing a criterion_id in MetricRequestDto.
- When a metric with the same combination of types (typeAlgorithm, typeBenchmark, typeMetric) already exists:
    - The label and description of that existing metric are reused.
- If no metric exists and a criterion_id is provided:
    - The label and description are generated using the criterion:
        - label: "Metric for " + criterion.getLabel()
        - description: "A metric evaluating how " + criterion.getDescription()

