### PR TITLE
CAT-939: Configure Instance-Specific Logo for Email Templates in CAT

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,8 @@ According to [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) , the `Unr
 - [#514](https://github.com/FC4E-CAT/fc4e-cat-api/pull/514) CAT-928: Create AssessmentType template
 - [#516](https://github.com/FC4E-CAT/fc4e-cat-api/pull/516) CAT-931 Update Metric Creation Request to Include Criterion Reference
 - [#518](https://github.com/FC4E-CAT/fc4e-cat-api/pull/518) CAT-940 Update NACO Integration to Handle New /list_entries Response Format
+- [#519](https://github.com/FC4E-CAT/fc4e-cat-api/pull/519) CAT-939: Configure Instance-Specific Logo for Email Templates in CAT
+
 - [#522](https://github.com/FC4E-CAT/fc4e-cat-api/pull/522) CAT-938 Public Assessments: Retrive all Motivations an Actor participates in assessments
 - [#523](https://github.com/FC4E-CAT/fc4e-cat-api/pull/523) CAT-937 API Call to Retrieve All Public Objects by Actor (No Motivation Restriction) 
 

--- a/api/src/main/resources/application.properties
+++ b/api/src/main/resources/application.properties
@@ -146,3 +146,9 @@ quarkus.rest-client.naco-service.url=https://cvs.data.kit.edu
 quarkus.rest-client.naco-service.scope=jakarta.inject.Singleton
 
 naco.service.key = naco_service_key
+
+
+# Email Branding Configuration for Local Testing
+# app.logo.url=https://example.org/assets/logo.svg
+# app.title=Compliance Assessment Toolkit
+# app.partners.hide=true

--- a/api/src/main/resources/templates/admin_created_validation.html
+++ b/api/src/main/resources/templates/admin_created_validation.html
@@ -312,7 +312,7 @@
                     <!-- START MAIN CONTENT AREA -->
                     <tr>
                         <td class="wrapper">
-                            <p><img src="{image}"></p>
+                            <p><img src="{logoUrl}" alt="Logo" height="60px"></p>
                             <p>&nbsp;</p>
                             <p><h3>Dear {userrole},</h3></p>
                             <p>This is to inform you that your action is requested to evaluate a new validation request.</p>
@@ -334,8 +334,8 @@
                                 </tbody>
                             </table>
                             <p></p>
-                            <p>Thank you
-                                <br/>The FAIRCORE4EOSC Compliance Assessment Toolkit - CAT Team.</p>
+                            <p>Thank you<br/>{title} Team.</p>
+                            {#if !hidePartners}
                             <p><h4>Partners</h4></p>
                             <p>
                                 <img src="{image2}" alt="GRNET" height="40px">
@@ -343,6 +343,7 @@
                                 <img src="{image4}" alt="gwdg" height="30px">
                                 <img src="{image3}" alt="DATACITE" height="30px">
                             </p>
+                            {/if}
 
                         </td>
                     </tr>
@@ -355,7 +356,7 @@
                     <table role="presentation" border="0" cellpadding="0" cellspacing="0" style="color:#DCDCDC">
                         <tr>
                             <td class="content-block">
-                                <span class="apple-link">The FAIRCORE4EOSC Compliance Assessment Toolkit - CAT Team</span>
+                                <span class="apple-link">{title} Team</span>
                                 <br> You need more information ? You can contact us at <a href="mailto:{contactMail}">Info</a>.
                             </td>
                         </tr>

--- a/api/src/main/resources/templates/shared_assessment_notification.html
+++ b/api/src/main/resources/templates/shared_assessment_notification.html
@@ -247,7 +247,7 @@
                     <!-- START MAIN CONTENT AREA -->
                     <tr>
                         <td class="wrapper">
-                            <p><img src="{image}"></p>
+                            <p><img src="{logoUrl}" alt="Logo" height="60px"></p>
                             <p>&nbsp;</p>
                             <p><h3>Dear {name},</h3></p>
                             <p> This is to inform you that an assessment has been shared with you.
@@ -270,7 +270,8 @@
                                 </tbody>
                             </table>
                             <br>
-                            <p>Thank you, <br/>The FAIRCORE4EOSC Compliance Assessment Toolkit - CAT Team.</p>
+                            <p>Thank you<br/>{title} Team.</p>
+                            {#if !hidePartners}
                             <p><h4>Partners</h4></p>
                             <p>
                                 <img src="{image2}" alt="GRNET" height="40px">
@@ -278,6 +279,7 @@
                                 <img src="{image4}" alt="gwdg" height="30px">
                                 <img src="{image3}" alt="DATACITE" height="30px">
                             </p>
+                            {/if}
                         </td>
                     </tr>
                     <!-- END MAIN CONTENT AREA -->
@@ -287,7 +289,7 @@
                     <table role="presentation" border="0" cellpadding="0" cellspacing="0" style="color:#DCDCDC">
                         <tr>
                             <td class="content-block">
-                                <span class="apple-link">The FAIRCORE4EOSC Compliance Assessment Toolkit - CAT Team</span>
+                                <span class="apple-link">{title} Team</span>
                                 <br> Need more information? Contact us at <a href="mailto:{contactMail}">Info</a>.
                             </td>
                         </tr>

--- a/api/src/main/resources/templates/user_created_validation.html
+++ b/api/src/main/resources/templates/user_created_validation.html
@@ -313,7 +313,7 @@
                     <tr>
                         <td class="wrapper">
 <!--                            <p><img src="https://api.cat.devel.argo.grnet.gr/v1/images/logo.png"></p>-->
-                            <p><img src="{image}"></p>
+                            <p><img src="{logoUrl}" alt="Logo" height="60px"></p>
 
                             <p>&nbsp;</p>
                             <p><h3>Dear {userrole},</h3></p>
@@ -336,8 +336,8 @@
                                 </tbody>
                             </table>
                             <p></p>
-                            <p>Thank you
-                                <br/>The FAIRCORE4EOSC Compliance Assessment Toolkit - CAT Team.</p>
+                            <p>Thank you<br/>{title} Team.</p>
+                            {#if !hidePartners}
                             <p><h4>Partners</h4></p>
                             <p>
                                 <img src="{image2}" alt="GRNET" height="40px">
@@ -345,6 +345,7 @@
                                 <img src="{image4}" alt="gwdg" height="30px">
                                 <img src="{image3}" alt="DATACITE" height="30px">
                             </p>
+                            {/if}
 
                         </td>
                     </tr>
@@ -357,7 +358,7 @@
                     <table role="presentation" border="0" cellpadding="0" cellspacing="0" style="color:#DCDCDC">
                         <tr>
                             <td class="content-block">
-                                <span class="apple-link">The FAIRCORE4EOSC Compliance Assessment Toolkit - CAT Team</span>
+                                <span class="apple-link">{title} Team</span>
                                 <br> You need more information ? You can contact us at <a href="mailto:{contactMail}">Info</a>.
                             </td>
                         </tr>

--- a/api/src/main/resources/templates/validation_status_updated.html
+++ b/api/src/main/resources/templates/validation_status_updated.html
@@ -312,7 +312,7 @@
                     <!-- START MAIN CONTENT AREA -->
                     <tr>
                         <td class="wrapper">
-                            <p><img src="{image}"></p>
+                            <p><img src="{logoUrl}" alt="Logo" height="60px"></p>
                             <p>&nbsp;</p>
                             <p><h3>Dear {userrole},</h3></p>
                             <p>This is to inform you that the status of your validation request with <strong>id: {valId}</strong> for the organization <strong>{organization}</strong> and the actor <strong>{actor}</strong> has changed.</p>
@@ -335,8 +335,8 @@
                                 </tbody>
                             </table>
                             <p></p>
-                            <p>Thank you
-                                <br/>The FAIRCORE4EOSC Compliance Assessment Toolkit - CAT Team.</p>
+                            <p>Thank you<br/>{title} Team.</p>
+                            {#if !hidePartners}
                             <p><h4>Partners</h4></p>
                             <p>
                                 <img src="{image2}" alt="GRNET" height="40px">
@@ -344,6 +344,7 @@
                                 <img src="{image4}" alt="gwdg" height="30px">
                                 <img src="{image3}" alt="DATACITE" height="30px">
                             </p>
+                            {/if}
 
                         </td>
                     </tr>
@@ -356,7 +357,7 @@
                     <table role="presentation" border="0" cellpadding="0" cellspacing="0" style="color:#DCDCDC">
                         <tr>
                             <td class="content-block">
-                                <span class="apple-link">The FAIRCORE4EOSC Compliance Assessment Toolkit - CAT Team</span>
+                                <span class="apple-link">{title} Team</span>
                                 <br> You need more information ? You can contact us at <a href="mailto:{contactMail}">Info</a>.
                             </td>
                         </tr>

--- a/api/src/main/resources/templates/zenodo_completed_publish_process_notification.html
+++ b/api/src/main/resources/templates/zenodo_completed_publish_process_notification.html
@@ -247,7 +247,7 @@
           <!-- START MAIN CONTENT AREA -->
           <tr>
             <td class="wrapper">
-              <p><img src="{image}"></p>
+              <p><img src="{logoUrl}" alt="Logo" height="60px"></p>
               <p>&nbsp;</p>
               <p><h3>Dear {name},</h3></p>
               <p> This is to inform you that an assessment :<strong> {assessmentName} </strong> with id:  <strong>{assessmentId}</strong>   has been published to Zenodo under deposit <strong>{depositId}</strong>.
@@ -269,7 +269,8 @@
                 </tbody>
               </table>
               <br>
-              <p>Thank you, <br/>The FAIRCORE4EOSC Compliance Assessment Toolkit - CAT Team.</p>
+              <p>Thank you<br/>{title} Team.</p>
+              {#if !hidePartners}
               <p><h4>Partners</h4></p>
               <p>
                 <img src="{image2}" alt="GRNET" height="40px">
@@ -277,6 +278,7 @@
                 <img src="{image4}" alt="gwdg" height="30px">
                 <img src="{image3}" alt="DATACITE" height="30px">
               </p>
+              {/if}
             </td>
           </tr>
           <!-- END MAIN CONTENT AREA -->
@@ -286,7 +288,7 @@
           <table role="presentation" border="0" cellpadding="0" cellspacing="0" style="color:#DCDCDC">
             <tr>
               <td class="content-block">
-                <span class="apple-link">The FAIRCORE4EOSC Compliance Assessment Toolkit - CAT Team</span>
+                <span class="apple-link">{title} Team</span>
                 <br> Need more information? Contact us at <a href="mailto:{contactMail}">Info</a>.
               </td>
             </tr>

--- a/api/src/main/resources/templates/zenodo_draft_deposit_notification.html
+++ b/api/src/main/resources/templates/zenodo_draft_deposit_notification.html
@@ -247,7 +247,7 @@
                     <!-- START MAIN CONTENT AREA -->
                     <tr>
                         <td class="wrapper">
-                            <p><img src="{image}"></p>
+                            <p><img src="{logoUrl}" alt="Logo" height="60px"></p>
                             <p>&nbsp;</p>
                             <p>
                             <h3>Dear {name},</h3></p>
@@ -255,7 +255,8 @@
                                 <strong>{assessmentId}</strong> has been published to Zenodo under deposit <strong>{depositId}</strong>
                             <p>but the deposit is not yet published. Please try to publish deposit.</p>
                             <br>
-                            <p>Thank you, <br/>The FAIRCORE4EOSC Compliance Assessment Toolkit - CAT Team.</p>
+                            <p>Thank you<br/>{title} Team.</p>
+                            {#if !hidePartners}
                             <p><h4>Partners</h4></p>
                             <p>
                                 <img src="{image2}" alt="GRNET" height="40px">
@@ -263,6 +264,7 @@
                                 <img src="{image4}" alt="gwdg" height="30px">
                                 <img src="{image3}" alt="DATACITE" height="30px">
                             </p>
+                            {/if}
                         </td>
                     </tr>
                     <!-- END MAIN CONTENT AREA -->
@@ -272,7 +274,7 @@
                     <table role="presentation" border="0" cellpadding="0" cellspacing="0" style="color:#DCDCDC">
                         <tr>
                             <td class="content-block">
-                                <span class="apple-link">The FAIRCORE4EOSC Compliance Assessment Toolkit - CAT Team</span>
+                                <span class="apple-link">{title} Team</span>
                                 <br> Need more information? Contact us at <a href="mailto:{contactMail}">Info</a>.
                             </td>
                         </tr>

--- a/api/src/main/resources/templates/zenodo_failed_publish_deposit_notification.html
+++ b/api/src/main/resources/templates/zenodo_failed_publish_deposit_notification.html
@@ -247,7 +247,7 @@
                     <!-- START MAIN CONTENT AREA -->
                     <tr>
                         <td class="wrapper">
-                            <p><img src="{image}"></p>
+                            <p><img src="{logoUrl}" alt="Logo" height="60px"></p>
                             <p>&nbsp;</p>
                             <p><h3>Dear {name},</h3></p>
 
@@ -270,7 +270,8 @@
                                 </tbody>
                             </table>
                             <br>
-                            <p>Thank you, <br/>The FAIRCORE4EOSC Compliance Assessment Toolkit - CAT Team.</p>
+                            <p>Thank you<br/>{title} Team.</p>
+                            {#if !hidePartners}
                             <p><h4>Partners</h4></p>
                             <p>
                                 <img src="{image2}" alt="GRNET" height="40px">
@@ -278,6 +279,7 @@
                                 <img src="{image4}" alt="gwdg" height="30px">
                                 <img src="{image3}" alt="DATACITE" height="30px">
                             </p>
+                            {/if}
                         </td>
                     </tr>
                     <!-- END MAIN CONTENT AREA -->
@@ -287,7 +289,7 @@
                     <table role="presentation" border="0" cellpadding="0" cellspacing="0" style="color:#DCDCDC">
                         <tr>
                             <td class="content-block">
-                                <span class="apple-link">The FAIRCORE4EOSC Compliance Assessment Toolkit - CAT Team</span>
+                                <span class="apple-link">{title} Team</span>
                                 <br> Need more information? Contact us at <a href="mailto:{contactMail}">Info</a>.
                             </td>
                         </tr>

--- a/api/src/main/resources/templates/zenodo_failed_publish_process_notification.html
+++ b/api/src/main/resources/templates/zenodo_failed_publish_process_notification.html
@@ -247,13 +247,14 @@
                     <!-- START MAIN CONTENT AREA -->
                     <tr>
                         <td class="wrapper">
-                            <p><img src="{image}"></p>
+                            <p><img src="{logoUrl}" alt="Logo" height="60px"></p>
                             <p>&nbsp;</p>
                             <p><h3>Dear {name},</h3></p>
                             <p> This is to inform you that an assessment :<strong> {assessmentName} </strong> with id:  <strong>{assessmentId}</strong>  failed to be published to Zenodo.
                             <p>Please try again.</p>
                             <br>
-                            <p>Thank you, <br/>The FAIRCORE4EOSC Compliance Assessment Toolkit - CAT Team.</p>
+                            <p>Thank you<br/>{title} Team.</p>
+                            {#if !hidePartners}
                             <p><h4>Partners</h4></p>
                             <p>
                                 <img src="{image2}" alt="GRNET" height="40px">
@@ -261,6 +262,7 @@
                                 <img src="{image4}" alt="gwdg" height="30px">
                                 <img src="{image3}" alt="DATACITE" height="30px">
                             </p>
+                            {/if}
                         </td>
                     </tr>
                     <!-- END MAIN CONTENT AREA -->
@@ -270,7 +272,7 @@
                     <table role="presentation" border="0" cellpadding="0" cellspacing="0" style="color:#DCDCDC">
                         <tr>
                             <td class="content-block">
-                                <span class="apple-link">The FAIRCORE4EOSC Compliance Assessment Toolkit - CAT Team</span>
+                                <span class="apple-link">{title} Team</span>
                                 <br> Need more information? Contact us at <a href="mailto:{contactMail}">Info</a>.
                             </td>
                         </tr>

--- a/api/src/main/resources/templates/zenodo_publish_assessment_notification.html
+++ b/api/src/main/resources/templates/zenodo_publish_assessment_notification.html
@@ -247,7 +247,7 @@
                     <!-- START MAIN CONTENT AREA -->
                     <tr>
                         <td class="wrapper">
-                            <p><img src="{image}"></p>
+                            <p><img src="{logoUrl}" alt="Logo" height="60px"></p>
                             <p>&nbsp;</p>
                             <p><h3>Dear {name},</h3></p>
                             <p> This is to inform you that an assessment :<strong> {assessmentName} </strong> with id:  <strong>{assessmentId}</strong>   has been published to Zenodo under deposit <strong>{depositId}</strong>
@@ -270,7 +270,8 @@
                                 </tbody>
                             </table>
                             <br>
-                            <p>Thank you, <br/>The FAIRCORE4EOSC Compliance Assessment Toolkit - CAT Team.</p>
+                            <p>Thank you<br/>{title} Team.</p>
+                            {#if !hidePartners}
                             <p><h4>Partners</h4></p>
                             <p>
                                 <img src="{image2}" alt="GRNET" height="40px">
@@ -278,6 +279,7 @@
                                 <img src="{image4}" alt="gwdg" height="30px">
                                 <img src="{image3}" alt="DATACITE" height="30px">
                             </p>
+                            {/if}
                         </td>
                     </tr>
                     <!-- END MAIN CONTENT AREA -->
@@ -287,7 +289,7 @@
                     <table role="presentation" border="0" cellpadding="0" cellspacing="0" style="color:#DCDCDC">
                         <tr>
                             <td class="content-block">
-                                <span class="apple-link">The FAIRCORE4EOSC Compliance Assessment Toolkit - CAT Team</span>
+                                <span class="apple-link">{title} Team</span>
                                 <br> Need more information? Contact us at <a href="mailto:{contactMail}">Info</a>.
                             </td>
                         </tr>

--- a/api/src/main/resources/templates/zenodo_publish_deposit_draft_in_db_notification.html
+++ b/api/src/main/resources/templates/zenodo_publish_deposit_draft_in_db_notification.html
@@ -247,7 +247,7 @@
                     <!-- START MAIN CONTENT AREA -->
                     <tr>
                         <td class="wrapper">
-                            <p><img src="{image}"></p>
+                            <p><img src="{logoUrl}" alt="Logo" height="60px"></p>
                             <p>&nbsp;</p>
                             <p><h3>Dear {name},</h3></p>
                             <p> This is to inform you that an deposit with id:  <strong>{depositId}</strong>   has been published to Zenodo
@@ -270,7 +270,8 @@
                                 </tbody>
                             </table>
                             <br>
-                            <p>Thank you, <br/>The FAIRCORE4EOSC Compliance Assessment Toolkit - CAT Team.</p>
+                            <p>Thank you<br/>{title} Team.</p>
+                            {#if !hidePartners}
                             <p><h4>Partners</h4></p>
                             <p>
                                 <img src="{image2}" alt="GRNET" height="40px">
@@ -278,6 +279,7 @@
                                 <img src="{image4}" alt="gwdg" height="30px">
                                 <img src="{image3}" alt="DATACITE" height="30px">
                             </p>
+                            {/if}
                         </td>
                     </tr>
                     <!-- END MAIN CONTENT AREA -->
@@ -287,7 +289,7 @@
                     <table role="presentation" border="0" cellpadding="0" cellspacing="0" style="color:#DCDCDC">
                         <tr>
                             <td class="content-block">
-                                <span class="apple-link">The FAIRCORE4EOSC Compliance Assessment Toolkit - CAT Team</span>
+                                <span class="apple-link">{title} Team</span>
                                 <br> Need more information? Contact us at <a href="mailto:{contactMail}">Info</a>.
                             </td>
                         </tr>

--- a/api/src/main/resources/templates/zenodo_publish_deposit_notification.html
+++ b/api/src/main/resources/templates/zenodo_publish_deposit_notification.html
@@ -247,7 +247,7 @@
                     <!-- START MAIN CONTENT AREA -->
                     <tr>
                         <td class="wrapper">
-                            <p><img src="{image}"></p>
+                            <p><img src="{logoUrl}" alt="Logo" height="60px"></p>
                             <p>&nbsp;</p>
                             <p><h3>Dear {name},</h3></p>
                             <p> This is to inform you that the deposit with id:  <strong>{depositId}</strong> has been published to Zenodo.
@@ -269,7 +269,8 @@
                                 </tbody>
                             </table>
                             <br>
-                            <p>Thank you, <br/>The FAIRCORE4EOSC Compliance Assessment Toolkit - CAT Team.</p>
+                            <p>Thank you<br/>{title} Team.</p>
+                            {#if !hidePartners}
                             <p><h4>Partners</h4></p>
                             <p>
                                 <img src="{image2}" alt="GRNET" height="40px">
@@ -277,6 +278,7 @@
                                 <img src="{image4}" alt="gwdg" height="30px">
                                 <img src="{image3}" alt="DATACITE" height="30px">
                             </p>
+                            {/if}
                         </td>
                     </tr>
                     <!-- END MAIN CONTENT AREA -->
@@ -286,7 +288,7 @@
                     <table role="presentation" border="0" cellpadding="0" cellspacing="0" style="color:#DCDCDC">
                         <tr>
                             <td class="content-block">
-                                <span class="apple-link">The FAIRCORE4EOSC Compliance Assessment Toolkit - CAT Team</span>
+                                <span class="apple-link">{title} Team</span>
                                 <br> Need more information? Contact us at <a href="mailto:{contactMail}">Info</a>.
                             </td>
                         </tr>

--- a/enum/src/main/java/org/grnet/cat/enums/MailType.java
+++ b/enum/src/main/java/org/grnet/cat/enums/MailType.java
@@ -10,10 +10,10 @@ public enum MailType {
 
 
     ADMIN_ALERT_NEW_VALIDATION() {
-        public MailTemplate execute(Template emailTemplate, HashMap<String, String> templateParams) {
+        public MailTemplate execute(Template emailTemplate, HashMap<String, Object> templateParams) {
 
             URL url;
-            String urlString = templateParams.get("valUrl");
+            String urlString = (String) templateParams.get("valUrl");
             try {
                 url = new URL(urlString);
             } catch (MalformedURLException e) {
@@ -21,6 +21,9 @@ public enum MailType {
             }
 
             String body = emailTemplate.data("urlpath", url.toString())
+                    .data("logoUrl", templateParams.get("logoUrl"))
+                    .data("title", templateParams.get("title"))
+                    .data("hidePartners", templateParams.get("hidePartners"))
                     .data("valId", templateParams.get("valId"))
                     .data("image", templateParams.get("image"))
                     .data("image1", templateParams.get("image1"))
@@ -38,9 +41,9 @@ public enum MailType {
     },
 
     VALIDATED_ALERT_CHANGE_VALIDATION_STATUS {
-        public MailTemplate execute(Template emailTemplate, HashMap<String, String> templateParams) {
+        public MailTemplate execute(Template emailTemplate, HashMap<String, Object> templateParams) {
             URL url;
-            String urlString = templateParams.get("valUrl");
+            String urlString = (String) templateParams.get("valUrl");
             try {
                 url = new URL(urlString);
             } catch (MalformedURLException e) {
@@ -50,12 +53,15 @@ public enum MailType {
             //String rejectionReason = templateParams.get("rejectionReason");
             var rejectionReason = "";
 
-            if ("REJECTED".equalsIgnoreCase(templateParams.get("status"))) {
+            if ("REJECTED".equalsIgnoreCase((String) templateParams.get("status"))) {
                 rejectionReason = "Reason for Rejection: " + (templateParams.get("rejectionReason") != null
                         ? templateParams.get("rejectionReason") : "N/A");
             }
 
             String body = emailTemplate.data("urlpath", url.toString())
+                    .data("logoUrl", templateParams.get("logoUrl"))
+                    .data("title", templateParams.get("title"))
+                    .data("hidePartners", templateParams.get("hidePartners"))
                     .data("valId", templateParams.get("valId"))
                     .data("image", templateParams.get("image"))
                     .data("image1", templateParams.get("image1"))
@@ -75,9 +81,9 @@ public enum MailType {
 
     },
     VALIDATED_ALERT_CREATE_VALIDATION {
-        public MailTemplate execute(Template emailTemplate, HashMap<String, String> templateParams) {
+        public MailTemplate execute(Template emailTemplate, HashMap<String, Object> templateParams) {
             URL url;
-            String urlString = templateParams.get("valUrl");
+            String urlString = (String) templateParams.get("valUrl");
             try {
                 url = new URL(urlString);
             } catch (MalformedURLException e) {
@@ -85,6 +91,9 @@ public enum MailType {
             }
 
             String body = emailTemplate.data("urlpath", url.toString())
+                    .data("logoUrl", templateParams.get("logoUrl"))
+                    .data("title", templateParams.get("title"))
+                    .data("hidePartners", templateParams.get("hidePartners"))
                     .data("valId", templateParams.get("valId"))
                     .data("image", templateParams.get("image"))
                     .data("image1", templateParams.get("image1"))
@@ -101,10 +110,10 @@ public enum MailType {
 
     },
     USER_ALERT_SHARED_ASSESSMENT {
-        public MailTemplate execute(Template emailTemplate, HashMap<String, String> templateParams) {
+        public MailTemplate execute(Template emailTemplate, HashMap<String, Object> templateParams) {
 
             URL url;
-            String urlString = templateParams.get("assessmentUrl");
+            String urlString = (String) templateParams.get("assessmentUrl");
             try {
                 url = new URL(urlString);
             } catch (MalformedURLException e) {
@@ -112,6 +121,9 @@ public enum MailType {
             }
 
             String body = emailTemplate.data("urlpath", url.toString())
+                    .data("logoUrl", templateParams.get("logoUrl"))
+                    .data("title", templateParams.get("title"))
+                    .data("hidePartners", templateParams.get("hidePartners"))
                     .data("assessmentUrl", templateParams.get("assessmentUrl"))
                     .data("assessmentName", templateParams.get("assessmentName"))
                     .data("assessmentId", templateParams.get("assessmentId"))
@@ -130,10 +142,10 @@ public enum MailType {
         }
         },
     ZENODO_COMPLETED_PUBLISH_PROCESS {
-        public MailTemplate execute(Template emailTemplate, HashMap<String, String> templateParams) {
+        public MailTemplate execute(Template emailTemplate, HashMap<String, Object> templateParams) {
 
             URL url;
-            String urlString = templateParams.get("depositUrl");
+            String urlString = (String) templateParams.get("depositUrl");
             try {
                 url = new URL(urlString);
             } catch (MalformedURLException e) {
@@ -141,9 +153,11 @@ public enum MailType {
             }
 
             String body = emailTemplate.data("depositUrl", url.toString())
+                    .data("logoUrl", templateParams.get("logoUrl"))
+                    .data("title", templateParams.get("title"))
+                    .data("hidePartners", templateParams.get("hidePartners"))
                     .data("depositId", templateParams.get("depositId"))
                     .data("assessmentName", templateParams.get("assessmentName"))
-
                     .data("assessmentId", templateParams.get("assessmentId"))
                     .data("image", templateParams.get("image"))
                     .data("image1", templateParams.get("image1"))
@@ -158,10 +172,10 @@ public enum MailType {
         }
     },
     ZENODO_DRAFT_DEPOSIT {
-        public MailTemplate execute(Template emailTemplate, HashMap<String, String> templateParams) {
+        public MailTemplate execute(Template emailTemplate, HashMap<String, Object> templateParams) {
 
             URL url;
-            String urlString = templateParams.get("depositUrl");
+            String urlString = (String) templateParams.get("depositUrl");
             try {
                 url = new URL(urlString);
             } catch (MalformedURLException e) {
@@ -169,9 +183,11 @@ public enum MailType {
             }
 
             String body = emailTemplate.data("depositUrl", url.toString())
+                    .data("logoUrl", templateParams.get("logoUrl"))
+                    .data("title", templateParams.get("title"))
+                    .data("hidePartners", templateParams.get("hidePartners"))
                     .data("depositId", templateParams.get("depositId"))
                     .data("assessmentName", templateParams.get("assessmentName"))
-
                     .data("assessmentId", templateParams.get("assessmentId"))
                     .data("image", templateParams.get("image"))
                     .data("image1", templateParams.get("image1"))
@@ -186,10 +202,10 @@ public enum MailType {
         }
     },
         ZENODO_PUBLISH_ASSESSMENT {
-            public MailTemplate execute(Template emailTemplate, HashMap<String, String> templateParams) {
+            public MailTemplate execute(Template emailTemplate, HashMap<String, Object> templateParams) {
 
                 URL url;
-                String urlString = templateParams.get("depositUrl");
+                String urlString = (String) templateParams.get("depositUrl");
                 try {
                     url = new URL(urlString);
                 } catch (MalformedURLException e) {
@@ -197,9 +213,11 @@ public enum MailType {
                 }
 
                 String body = emailTemplate.data("depositUrl", url.toString())
+                        .data("logoUrl", templateParams.get("logoUrl"))
+                        .data("title", templateParams.get("title"))
+                        .data("hidePartners", templateParams.get("hidePartners"))
                         .data("depositId", templateParams.get("depositId"))
                         .data("assessmentName", templateParams.get("assessmentName"))
-
                         .data("assessmentId", templateParams.get("assessmentId"))
                         .data("image", templateParams.get("image"))
                         .data("image1", templateParams.get("image1"))
@@ -214,10 +232,10 @@ public enum MailType {
             }
     },
     ZENODO_PUBLISH_DEPOSIT {
-        public MailTemplate execute(Template emailTemplate, HashMap<String, String> templateParams) {
+        public MailTemplate execute(Template emailTemplate, HashMap<String, Object> templateParams) {
 
             URL url;
-            String urlString = templateParams.get("depositUrl");
+            String urlString = (String) templateParams.get("depositUrl");
             try {
                 url = new URL(urlString);
             } catch (MalformedURLException e) {
@@ -225,6 +243,9 @@ public enum MailType {
             }
 
             String body = emailTemplate.data("depositUrl", url.toString())
+                    .data("logoUrl", templateParams.get("logoUrl"))
+                    .data("title", templateParams.get("title"))
+                    .data("hidePartners", templateParams.get("hidePartners"))
                     .data("depositId", templateParams.get("depositId"))
                     .data("image", templateParams.get("image"))
                     .data("image1", templateParams.get("image1"))
@@ -239,12 +260,14 @@ public enum MailType {
         }
     },
     ZENODO_FAILED_PUBLISH_PROCESS {
-        public MailTemplate execute(Template emailTemplate, HashMap<String, String> templateParams) {
+        public MailTemplate execute(Template emailTemplate, HashMap<String, Object> templateParams) {
 
 
             String body = emailTemplate
+                    .data("logoUrl", templateParams.get("logoUrl"))
+                    .data("title", templateParams.get("title"))
+                    .data("hidePartners", templateParams.get("hidePartners"))
                     .data("assessmentName", templateParams.get("assessmentName"))
-
                     .data("assessmentId", templateParams.get("assessmentId"))
                     .data("image", templateParams.get("image"))
                     .data("image1", templateParams.get("image1"))
@@ -259,10 +282,10 @@ public enum MailType {
         }
     },
     ZENODO_FAILED_PUBLISH_DEPOSIT {
-        public MailTemplate execute(Template emailTemplate, HashMap<String, String> templateParams) {
+        public MailTemplate execute(Template emailTemplate, HashMap<String, Object> templateParams) {
 
             URL url;
-            String urlString = templateParams.get("depositUrl");
+            String urlString = (String) templateParams.get("depositUrl");
             try {
                 url = new URL(urlString);
             } catch (MalformedURLException e) {
@@ -270,6 +293,9 @@ public enum MailType {
             }
 
             String body = emailTemplate.data("depositUrl", url.toString())
+                    .data("logoUrl", templateParams.get("logoUrl"))
+                    .data("title", templateParams.get("title"))
+                    .data("hidePartners", templateParams.get("hidePartners"))
                     .data("depositId", templateParams.get("depositId"))
                     .data("image", templateParams.get("image"))
                     .data("image1", templateParams.get("image1"))
@@ -284,10 +310,10 @@ public enum MailType {
         }
     },
     ZENODO_PUBLISH_DEPOSIT_DRAFT_IN_DB {
-        public MailTemplate execute(Template emailTemplate, HashMap<String, String> templateParams) {
+        public MailTemplate execute(Template emailTemplate, HashMap<String, Object> templateParams) {
 
             URL url;
-            String urlString = templateParams.get("depositUrl");
+            String urlString = (String) templateParams.get("depositUrl");
             try {
                 url = new URL(urlString);
             } catch (MalformedURLException e) {
@@ -295,6 +321,9 @@ public enum MailType {
             }
 
             String body = emailTemplate.data("depositUrl", url.toString())
+                    .data("logoUrl", templateParams.get("logoUrl"))
+                    .data("title", templateParams.get("title"))
+                    .data("hidePartners", templateParams.get("hidePartners"))
                     .data("depositId", templateParams.get("depositId"))
                     .data("image", templateParams.get("image"))
                     .data("image1", templateParams.get("image1"))
@@ -310,7 +339,7 @@ public enum MailType {
     };
 
 
-    public abstract MailTemplate execute(Template mailTemplate, HashMap<String, String> templateParams);
+    public abstract MailTemplate execute(Template mailTemplate, HashMap<String, Object> templateParams);
 
 
     public class MailTemplate {

--- a/service/src/main/java/org/grnet/cat/services/EmailBrandingConfig.java
+++ b/service/src/main/java/org/grnet/cat/services/EmailBrandingConfig.java
@@ -1,0 +1,26 @@
+package org.grnet.cat.services;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import lombok.Getter;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+
+import java.util.Optional;
+
+@ApplicationScoped
+public class EmailBrandingConfig {
+
+    @Getter
+    @ConfigProperty(name = "app.logo.url", defaultValue = "")
+    Optional<String> logoUrl;
+
+    @Getter
+    @ConfigProperty(name = "app.title", defaultValue = "FAIRCORE4EOSC Compliance Assessment Toolkit")
+    String title;
+
+    @ConfigProperty(name = "app.partners.hide", defaultValue = "false")
+    boolean hidePartners;
+
+    public boolean shouldHidePartners() {
+        return hidePartners;
+    }
+}

--- a/service/src/main/java/org/grnet/cat/services/MailerService.java
+++ b/service/src/main/java/org/grnet/cat/services/MailerService.java
@@ -5,6 +5,7 @@ import io.quarkus.mailer.Mail;
 import io.quarkus.mailer.Mailer;
 import io.quarkus.qute.Location;
 import io.quarkus.qute.Template;
+import jakarta.annotation.PostConstruct;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.context.control.ActivateRequestContext;
 import jakarta.inject.Inject;
@@ -85,6 +86,8 @@ public class MailerService {
     Template zenodoPublishDepositDraftInDB;
 
     @Inject
+    EmailBrandingConfig emailBrandingConfig;
+    @Inject
     KeycloakAdminRepository keycloakAdminRepository;
     @ConfigProperty(name = "api.keycloak.user.id")
     String attribute;
@@ -103,20 +106,21 @@ public class MailerService {
 
     public void sendMails(Validation val, MailType type, List<String> mailAddrs) {
 
-        HashMap<String, String> templateParams = new HashMap();
+        HashMap<String, Object> templateParams = new HashMap();
         templateParams.put("contactMail", contactMail);
         templateParams.put("status", val.getStatus().name());
-        templateParams.put("image", serviceUrl + "/v1/images/logo.png");
+        templateParams.put("logoUrl", emailBrandingConfig.getLogoUrl().orElse(serviceUrl + "/v1/images/logo.png"));
         templateParams.put("image1", serviceUrl + "/v1/images/logo-dans.png");
         templateParams.put("image2", serviceUrl + "/v1/images/logo-grnet.png");
         templateParams.put("image3", serviceUrl + "/v1/images/logo-datacite.png");
         templateParams.put("image4", serviceUrl + "/v1/images/logo-gwdg.png");
         templateParams.put("cat", uiBaseUrl);
         templateParams.put("valId", String.valueOf(val.getId()));
-        templateParams.put("title", apiName.toUpperCase());
+        templateParams.put("title", emailBrandingConfig.getTitle());
         templateParams.put("actor", val.getRegistryActor().getLabelActor());
         templateParams.put("organization", val.getOrganisationName());
         templateParams.put("rejectionReason", val.getStatus() == ValidationStatus.REJECTED ? val.getRejectionReason() : null);
+        templateParams.put("hidePartners", emailBrandingConfig.shouldHidePartners());
 
 
         switch (type) {
@@ -142,15 +146,16 @@ public class MailerService {
 
     public void sendMails(MotivationAssessment assessment, String name, MailType type, List<String> mailAddrs) {
 
-        HashMap<String, String> templateParams = new HashMap<>();
+        HashMap<String, Object> templateParams = new HashMap<>();
         templateParams.put("contactMail", contactMail);
-        templateParams.put("image", serviceUrl + "/v1/images/logo.png");
+        templateParams.put("logoUrl", emailBrandingConfig.getLogoUrl().orElse(serviceUrl + "/v1/images/logo.png"));
         templateParams.put("image1", serviceUrl + "/v1/images/logo-dans.png");
         templateParams.put("image2", serviceUrl + "/v1/images/logo-grnet.png");
         templateParams.put("image3", serviceUrl + "/v1/images/logo-datacite.png");
         templateParams.put("image4", serviceUrl + "/v1/images/logo-gwdg.png");
         templateParams.put("cat", uiBaseUrl);
-        templateParams.put("title", apiName.toUpperCase());
+        templateParams.put("title", emailBrandingConfig.getTitle());
+        templateParams.put("hidePartners", String.valueOf(emailBrandingConfig.shouldHidePartners()));
 
         switch (type) {
             case USER_ALERT_SHARED_ASSESSMENT:
@@ -168,15 +173,17 @@ public class MailerService {
 
     public void sendMails(MotivationAssessment assessment,String depositId, String name,MailType type, List<String> mailAddrs) {
 
-        HashMap<String, String> templateParams = new HashMap<>();
+        HashMap<String, Object> templateParams = new HashMap<>();
         templateParams.put("contactMail", contactMail);
-        templateParams.put("image", serviceUrl + "/v1/images/logo.png");
-        templateParams.put("image1", serviceUrl + "/v1/images/logo-dans.png");
+        templateParams.put("logoUrl", emailBrandingConfig.getLogoUrl().orElse(serviceUrl + "/v1/images/logo.png"))
+        ;templateParams.put("image1", serviceUrl + "/v1/images/logo-dans.png");
         templateParams.put("image2", serviceUrl + "/v1/images/logo-grnet.png");
         templateParams.put("image3", serviceUrl + "/v1/images/logo-datacite.png");
         templateParams.put("image4", serviceUrl + "/v1/images/logo-gwdg.png");
         templateParams.put("name", name);
-        templateParams.put("title", apiName.toUpperCase());
+        templateParams.put("title", emailBrandingConfig.getTitle());
+        templateParams.put("hidePartners", String.valueOf(emailBrandingConfig.shouldHidePartners()));
+
 
         switch (type) {
             case ZENODO_DRAFT_DEPOSIT:
@@ -246,7 +253,7 @@ public class MailerService {
         }
     }
 
-    public Mail buildEmail(Template emailTemplate, HashMap<String, String> templateParams, MailType mailType) {
+    public Mail buildEmail(Template emailTemplate, HashMap<String, Object> templateParams, MailType mailType) {
 
         MailType.MailTemplate mailTemplate = mailType.execute(emailTemplate, templateParams);
         Mail mail = new Mail();
@@ -256,7 +263,7 @@ public class MailerService {
     }
 
     private void notifyUser(Template
-                                    emailTemplate, HashMap<String, String> templateParams, List<String> mailAddrs, MailType mailType) {
+                                    emailTemplate, HashMap<String, Object> templateParams, List<String> mailAddrs, MailType mailType) {
 
 
         var mail = buildEmail(emailTemplate, templateParams, mailType);
@@ -271,7 +278,7 @@ public class MailerService {
     }
 
     private void notifyAdmins(Template
-                                      emailTemplate, HashMap<String, String> templateParams, List<String> mailAddrs) {
+                                      emailTemplate, HashMap<String, Object> templateParams, List<String> mailAddrs) {
 
         var mail = buildEmail(emailTemplate, templateParams, MailType.ADMIN_ALERT_NEW_VALIDATION);
         mail.setBcc(mailAddrs);


### PR DESCRIPTION
This PR introduces support for configurable email branding across the CAT platform. Email templates can now display a custom logo and title, and optionally hide the partners section, based on deployment-specific configuration.

### Changes
#### Added support for the following configurable properties (to be set via Ansible):
- **app.logo.url:** URL to a custom logo for email headers
- **app.title:** Title displayed in email templates (default: FAIRCORE4EOSC Compliance Assessment Toolkit)
- **app.partners.hide:** If true, hides the partner logos section in the footer

#### Updated all HTML email templates to:
- Use **{logoUrl}** placeholder for logo (If app.logo.url is not set, the default logo at _**/v1/images/logo.png**_ is used)
- Conditionally render partner section based on **{hidePartners}**
- Apply title via **{title}** placeholder