### PR TITLE
CAT-953 Fix NacoEntryResponse to map the response from NACO

### DIFF
--- a/api/src/main/java/org/grnet/cat/api/endpoints/AssessmentsV2Endpoint.java
+++ b/api/src/main/java/org/grnet/cat/api/endpoints/AssessmentsV2Endpoint.java
@@ -810,6 +810,4 @@ public class AssessmentsV2Endpoint {
             this.content = content;
         }
     }
-
-
 }


### PR DESCRIPTION
Changed NacoEntryResponse to map correctly the access_token_info as it is received from naco service