### PR TITLE
[CAT 957] Add support for updating user information via access token

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ According to [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) , the `Unr
 
 - [#522](https://github.com/FC4E-CAT/fc4e-cat-api/pull/522) CAT-938 Public Assessments: Retrive all Motivations an Actor participates in assessments
 - [#523](https://github.com/FC4E-CAT/fc4e-cat-api/pull/523) CAT-937 API Call to Retrieve All Public Objects by Actor (No Motivation Restriction) 
+- [#524](https://github.com/FC4E-CAT/fc4e-cat-api/pull/524) CAT-957 Add support for updating user information via access token
 
 ### Fix
 - [#482](https://github.com/FC4E-CAT/fc4e-cat-api/pull/482) CAT-867: Update Auto-AAI-Check-Entitlements tests parameters

--- a/api/src/main/java/org/grnet/cat/api/endpoints/ValidationsEndpoint.java
+++ b/api/src/main/java/org/grnet/cat/api/endpoints/ValidationsEndpoint.java
@@ -40,6 +40,7 @@ import org.grnet.cat.services.ValidationService;
 import org.grnet.cat.utils.Utility;
 
 import java.util.List;
+import java.util.Objects;
 
 import static org.eclipse.microprofile.openapi.annotations.enums.ParameterIn.QUERY;
 
@@ -135,9 +136,10 @@ public class ValidationsEndpoint {
 
         var userProfile = userService.getUserProfile(utility.getUserUniqueIdentifier());
 
-        if (StringUtils.isEmpty(userProfile.name) || StringUtils.isEmpty(userProfile.surname) || StringUtils.isEmpty(userProfile.email)) {
+        if (Objects.isNull(userProfile.updatedOn)) {
             throw new ForbiddenException("You have to update your profile before requesting a validation.");
         }
+
         Source.valueOf(request.organisationSource).execute(request.organisationId);
 
         var response = userService.validate( utility.getUserUniqueIdentifier(), request);

--- a/api/src/main/resources/application.properties
+++ b/api/src/main/resources/application.properties
@@ -152,3 +152,5 @@ naco.service.key = naco_service_key
 # app.logo.url=https://example.org/assets/logo.svg
 # app.title=Compliance Assessment Toolkit
 # app.partners.hide=true
+
+api.cat.user.info.update.from.token = false

--- a/api/src/main/resources/templates/client.html
+++ b/api/src/main/resources/templates/client.html
@@ -25,7 +25,7 @@
               checkLoginIframe: true,
               checkLoginIframeInterval: 1,
               pkceMethod: 'S256',
-              scope: "voperson_id"
+              scope: "voperson_id email profile"
         };
 
         var keycloak = new Keycloak(

--- a/repository/src/main/java/org/grnet/cat/repositories/KeycloakAdminRepository.java
+++ b/repository/src/main/java/org/grnet/cat/repositories/KeycloakAdminRepository.java
@@ -15,7 +15,9 @@ import org.keycloak.admin.client.Keycloak;
 import org.keycloak.representations.idm.UserRepresentation;
 
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 /**
@@ -117,14 +119,44 @@ public class KeycloakAdminRepository implements RoleRepository {
 
             var userResource = usersResource.get(userRepresentation.getId());
 
-            // Get client level roles
+
             var rolesRepresentations = roles
                     .stream()
                     .map(role -> clientResource.roles().get(role).toRepresentation())
                     .collect(Collectors.toList());
 
-            // Assign client level role to user
+
             userResource.roles().clientLevel(clientRepresentation.getId()).add(rolesRepresentations);
+
+        } catch (Exception e) {
+
+            LOG.error("A communication error occurred while assigning roles to the user.", e);
+            throw new RuntimeException("A communication error occurred while assigning roles to the user.");
+        }
+    }
+
+    @Override
+    public Map<String, String> getUserInformation(String userId) {
+
+        try {
+
+            var map = new HashMap<String, String>();
+
+            var realmResource = keycloak.realm(realm);
+
+            var clientRepresentation = realmResource.clients().findByClientId(clientId).stream().findFirst().get();
+
+            var clientResource = realmResource.clients().get(clientRepresentation.getId());
+
+            var usersResource = realmResource.users();
+
+            var userRepresentation = realmResource.users().searchByAttributes(String.format("%s:%s", attribute, userId)).stream().findFirst().get();
+
+            map.put("email", userRepresentation.getEmail());
+            map.put("name", userRepresentation.getFirstName());
+            map.put("surname", userRepresentation.getLastName());
+
+            return map;
 
         } catch (Exception e) {
 

--- a/repository/src/main/java/org/grnet/cat/repositories/RoleRepository.java
+++ b/repository/src/main/java/org/grnet/cat/repositories/RoleRepository.java
@@ -5,6 +5,7 @@ import org.grnet.cat.entities.Role;
 import org.keycloak.representations.idm.UserRepresentation;
 
 import java.util.List;
+import java.util.Map;
 
 /**
  * The RoleRepository interface provides data access methods for the Role entity.
@@ -60,5 +61,7 @@ public interface RoleRepository {
     List<Role> fetchUserRoles(String userId);
 
     List<UserRepresentation> fetchRolesMembers(String role);
+
+    Map<String, String> getUserInformation(String userId);
 
 }

--- a/service/src/main/java/org/grnet/cat/services/UserService.java
+++ b/service/src/main/java/org/grnet/cat/services/UserService.java
@@ -85,6 +85,9 @@ public class UserService {
     @ConfigProperty(name = "api.cat.validations.approve.auto")
     boolean autoApprove;
 
+    @ConfigProperty(name = "api.cat.user.info.update.from.token")
+    boolean userInfoUpdateFromToken;
+
     @Inject
     Utility utility;
 
@@ -193,6 +196,16 @@ public class UserService {
         identified.setId(id);
         identified.setRegisteredOn(Timestamp.from(Instant.now()));
         identified.setBanned(Boolean.FALSE);
+
+        if(userInfoUpdateFromToken){
+
+            var map = roleRepository.getUserInformation(id);
+
+            identified.setEmail(map.get("email"));
+            identified.setName(map.get("name"));
+            identified.setSurname(map.get("surname"));
+            identified.setUpdatedOn(Timestamp.from(Instant.now()));
+        }
 
         userRepository.persist(identified);
 


### PR DESCRIPTION
A new boolean configuration property is introduced in application.properties **api.cat.user.info.update.from.token = true | false**. By default will be false.
 
When the property is set to true, the application allows user data updates via keycloak.

