### PR TITLE
CAT-962: Add db_id to All Relevant Entities in Assessment Type Template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ According to [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) , the `Unr
 - [#512](https://github.com/FC4E-CAT/fc4e-cat-api/pull/512) CAT-909 NACO list information
 - [#515](https://github.com/FC4E-CAT/fc4e-cat-api/pull/515) CAT-930 Add Original Motivation per Criterion and Retrieve Associated Principles
 - [#520](https://github.com/FC4E-CAT/fc4e-cat-api/pull/520) CAT-953 Fix NacoEntryResponse to map the response from NACO
+- [#527](https://github.com/FC4E-CAT/fc4e-cat-api/pull/527) CAT-962: Add db_id to All Relevant Entities in Assessment Type Template
 
 
 ## 2.0.0 - 2025-03-31

--- a/data-transfer-object/src/main/java/org/grnet/cat/dtos/registry/template/AssessmentTypeCriNode.java
+++ b/data-transfer-object/src/main/java/org/grnet/cat/dtos/registry/template/AssessmentTypeCriNode.java
@@ -1,0 +1,22 @@
+package org.grnet.cat.dtos.registry.template;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import lombok.Getter;
+import lombok.Setter;
+
+@JsonPropertyOrder({ "db_id", "id", "name", "description", "imperative", "metric" })
+@Getter
+@Setter
+public class AssessmentTypeCriNode extends CriNode {
+
+    @JsonProperty("db_id")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private String lodCri;
+
+    public AssessmentTypeCriNode(String lodCri, String id, String name, String description, String imperative) {
+        super(id, name, description, imperative);
+        this.lodCri = lodCri;
+    }
+}

--- a/data-transfer-object/src/main/java/org/grnet/cat/dtos/registry/template/AssessmentTypeMetricNode.java
+++ b/data-transfer-object/src/main/java/org/grnet/cat/dtos/registry/template/AssessmentTypeMetricNode.java
@@ -1,0 +1,39 @@
+package org.grnet.cat.dtos.registry.template;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import lombok.Getter;
+import lombok.Setter;
+
+@JsonPropertyOrder({ "db_id", "id", "name", "type_db_id","type","benchmark_value", "value", "result", "type_algorithm_db_id", "type_algorithm", "type_metric_db_id","type_metric", "tests"  })
+@Getter
+@Setter
+public class AssessmentTypeMetricNode extends TemplateMetricNode {
+
+    @JsonProperty("db_id")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private String lodMTR;
+
+    @JsonProperty("type_db_id")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private String lodTBN;
+
+    @JsonProperty("type_algorithm_db_id")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private String lodTAL;
+
+    @JsonProperty("type_metric_db_id")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private String lodTMT;
+
+    public AssessmentTypeMetricNode(String lodMTR, String id, String name, String lodTBN, String type,
+                                    Number benchmarkValue, String lodTAL, String labelAlgorithmType, String lodTMT, String labelTypeMetric) {
+        super(id, name, type, benchmarkValue, labelAlgorithmType, labelTypeMetric);
+        this.lodMTR = lodMTR;
+        this.lodTAL = lodTAL;
+        this.lodTBN = lodTBN;
+        this.lodTMT = lodTMT;
+    }
+}
+

--- a/data-transfer-object/src/main/java/org/grnet/cat/dtos/registry/template/AssessmentTypePriNode.java
+++ b/data-transfer-object/src/main/java/org/grnet/cat/dtos/registry/template/AssessmentTypePriNode.java
@@ -1,0 +1,22 @@
+package org.grnet.cat.dtos.registry.template;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import lombok.Getter;
+import lombok.Setter;
+
+@JsonPropertyOrder({ "db_id", "id", "name", "description", "criteria" })
+@Getter
+@Setter
+public class AssessmentTypePriNode extends PriNode{
+
+    @JsonProperty("db_id")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private String lodPRI;
+
+    public AssessmentTypePriNode(String lodPRI, String id, String name, String description) {
+        super(id, name, description);
+        this.lodPRI = lodPRI;
+    }
+}

--- a/data-transfer-object/src/main/java/org/grnet/cat/dtos/registry/template/AssessmentTypeTestNode.java
+++ b/data-transfer-object/src/main/java/org/grnet/cat/dtos/registry/template/AssessmentTypeTestNode.java
@@ -1,0 +1,29 @@
+package org.grnet.cat.dtos.registry.template;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.List;
+
+@JsonPropertyOrder({ "db_id", "id", "name", "description", "text", "param", "tooltip", "type_db_id", "type", "value", "result", "evidence_url"})
+@Getter
+@Setter
+public class AssessmentTypeTestNode extends TemplateTestNode{
+
+    @JsonProperty("db_id")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private String lodTES;
+
+    @JsonProperty("type_db_id")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private String lodTME;
+
+    public AssessmentTypeTestNode(String lodTES, String id, String name, String description, String lodTME, String type, List<String> urls, String text, String params, String toolTip) {
+        super(id, name, description, type, urls, text, params, toolTip);
+        this.lodTES = lodTES;
+        this.lodTME = lodTME;
+    }
+}

--- a/entity/src/main/java/org/grnet/cat/entities/registry/AssessmentTypeTemplate.java
+++ b/entity/src/main/java/org/grnet/cat/entities/registry/AssessmentTypeTemplate.java
@@ -26,9 +26,11 @@ public class AssessmentTypeTemplate {
 
     private String lodActor;
 
+    private String lodPri;
     private String labelPrinciple;
     private String descPrinciple;
 
+    private String lodCri;
     private String labelCriterion;
     private String descCriterion;
     private String labelImperative;
@@ -36,15 +38,19 @@ public class AssessmentTypeTemplate {
     private String lodMTR;
     private String MTR;
     private String labelMetric;
+    private String lodTAL;
     private String labelAlgorithmType;
+    private String lodTMT;
     private String labelTypeMetric;
     private String valueBenchmark;
+    private String lodTBN;
     private String labelBenchmarkType;
 
     private String lodTES;
     private String TES;
     private String labelTest;
     private String descTest;
+    private String lodTME;
     private String labelTestMethod;
     private String testQuestion;
     private String testParams;

--- a/entity/src/main/resources/db/migration/tables/registry/V1.88__registry_template_flexible_v2.sql
+++ b/entity/src/main/resources/db/migration/tables/registry/V1.88__registry_template_flexible_v2.sql
@@ -1,0 +1,84 @@
+-- ------------------------------------------------
+-- Version: v1.88
+--
+-- Description: Create registry_templates_flexible view to support partial templates
+-- ------------------------------------------------
+
+DROP VIEW IF EXISTS assessment_type_template;
+
+CREATE VIEW assessment_type_template AS
+SELECT
+    p.lodpri,
+    p.pri,
+    p.labelprinciple,
+    p.descprinciple,
+
+    c,lodcri,
+    c.cri,
+    c.labelcriterion,
+    c.desccriterion,
+
+    m.lodmtr,
+    m.mtr,
+    m.labelmetric,
+
+    ta.lodtal,
+    ta.labelalgorithmtype,
+    ttm.lodtmt,
+    ttm.labeltypemetric,
+
+    t.tes,
+    t.lodtes,
+    t.labeltest,
+    t.desctest,
+    t.testquestion,
+    t.testparams,
+    t.tooltip,
+
+    m.valuebenchmark,
+    tb.lodtbn,
+    tb.labelbenchmarktype,
+
+    pc.motivation_lodmtv AS principle_criterion_motivation_id,
+    ca.actor_lodactor AS lodactor,
+    i.labelimperative,
+
+    tm.lodtme,
+    tm.labeltestmethod,
+
+    mt.motivation_lodmtv AS mt_mtv,
+    cm.motivation_lodmtv AS cm_mtv,
+    ca.motivation_lodmtv AS ca_mtv,
+
+    md5(
+        COALESCE(p.lodpri, '') ||
+        COALESCE(c.lodcri, '') ||
+        COALESCE(m.lodmtr, '') ||
+        COALESCE(t.lodtes, '') ||
+        COALESCE(ca.actor_lodactor, '') ||
+        COALESCE(pc.motivation_lodmtv, '')
+      )::uuid AS lod_id
+
+FROM p_principle_criterion pc
+JOIN p_principle p ON pc.principle_lodpri::text = p.lodpri::text
+JOIN p_criterion c ON pc.criterion_lodcri::text = c.lodcri::text
+JOIN p_criterion_actor ca ON ca.criterion_lodcri::text = c.lodcri::text
+
+LEFT JOIN s_imperative i ON ca.imperative_lodimp::text = i.lodimp::text
+
+LEFT JOIN p_criterion_metric cm
+    ON cm.criterion_lodcri::text = c.lodcri::text
+    AND cm.motivation_lodmtv::text = pc.motivation_lodmtv::text
+
+LEFT JOIN p_metric m ON cm.metric_lodmtr::text = m.lodmtr::text
+LEFT JOIN t_type_benchmark tb ON m.lodtbn::text = tb.lodtbn::text
+LEFT JOIN t_type_algorithm ta ON m.lodtal::text = ta.lodtal::text
+LEFT JOIN t_type_metric ttm ON m.lodtmt::text = ttm.lodtmt::text
+
+LEFT JOIN p_metric_test mt
+    ON mt.metric_lodmtr::text = m.lodmtr::text
+    AND mt.motivation_lodmtv::text = pc.motivation_lodmtv::text
+
+LEFT JOIN p_test t ON mt.test_lodtes::text = t.lodtes::text
+LEFT JOIN t_testmethod tm ON t.lodtme::text = tm.lodtme::text;
+

--- a/service/src/main/java/org/grnet/cat/services/TemplateService.java
+++ b/service/src/main/java/org/grnet/cat/services/TemplateService.java
@@ -195,29 +195,29 @@ public class TemplateService {
 
         var rows = assessmentTypeTemplateRepository.findByActorAndMotivation(actorId, motivationId);
 
-        var priMap = new TreeMap<String, PriNode>();
-        var criMap = new TreeMap<String, CriNode>();
-        var mtrMap = new TreeMap<String, TemplateMetricNode>();
-        var testMap = new TreeMap<String, TemplateTestNode>();
+        var priMap = new TreeMap<String, AssessmentTypePriNode>();
+        var criMap = new TreeMap<String, AssessmentTypeCriNode>();
+        var mtrMap = new TreeMap<String, AssessmentTypeMetricNode>();
+        var testMap = new TreeMap<String, AssessmentTypeTestNode>();
 
         for (var row : rows) {
 
-            Node priNode = priMap.computeIfAbsent(row.getPRI(), k -> new PriNode(k, row.getLabelPrinciple(), row.getDescPrinciple()));
-            Node criNode = criMap.computeIfAbsent(row.getCRI(), k -> new CriNode(k, row.getLabelCriterion(), row.getDescCriterion(), row.getLabelImperative()));
+            Node priNode = priMap.computeIfAbsent(row.getLodPri(), k -> new AssessmentTypePriNode(k, row.getPRI(), row.getLabelPrinciple(), row.getDescPrinciple()));
+            Node criNode = criMap.computeIfAbsent(row.getLodCri(), k -> new AssessmentTypeCriNode(k, row.getCRI(), row.getLabelCriterion(), row.getDescCriterion(), row.getLabelImperative()));
             if (row.getMTR() != null && row.getLabelMetric() != null) {
-                Node mtrNode = mtrMap.computeIfAbsent(row.getMTR(), k -> new TemplateMetricNode(k, row.getLabelMetric().trim(), row.getLabelBenchmarkType().trim(), Double.parseDouble(row.getValueBenchmark()), row.getLabelAlgorithmType(), row.getLabelTypeMetric()));
+                Node mtrNode = mtrMap.computeIfAbsent(row.getLodMTR(), k -> new AssessmentTypeMetricNode(k, row.getMTR(), row.getLabelMetric().trim(), row.getLodTBN(), row.getLabelBenchmarkType().trim(), Double.parseDouble(row.getValueBenchmark()), row.getLodTAL(), row.getLabelAlgorithmType(), row.getLodTMT(), row.getLabelTypeMetric()));
 
-                if (row.getTES() != null && row.getLabelTestMethod() != null) {
-                    Node testNode = testMap.computeIfAbsent(row.getTES(), k -> {
+                if (row.getLodTES() != null && row.getLabelTestMethod() != null) {
+                    Node testNode = testMap.computeIfAbsent(row.getLodTES(), k -> {
 
-                        TemplateTestNode tn;
+                        AssessmentTypeTestNode tn;
 
                         if (row.getLabelTestMethod().contains("Evidence")) {
 
-                            tn = new TemplateTestNode(k, row.getLabelTest().trim(), row.getDescTest().trim(), row.getLabelTestMethod().trim(), new ArrayList<>(), row.getTestQuestion(), TestParamsTransformer.transformTestParams(row.getTestParams()), row.getToolTip());
+                            tn = new AssessmentTypeTestNode(k, row.getTES(), row.getLabelTest().trim(), row.getDescTest().trim(), row.getLodTMT(), row.getLabelTestMethod().trim(), new ArrayList<>(), row.getTestQuestion(), TestParamsTransformer.transformTestParams(row.getTestParams()), row.getToolTip());
                         } else {
 
-                            tn = new TemplateTestNode(k, row.getLabelTest().trim(), row.getDescTest().trim(), row.getLabelTestMethod().trim(), null, row.getTestQuestion(), TestParamsTransformer.transformTestParams(row.getTestParams()), row.getToolTip());
+                            tn = new AssessmentTypeTestNode(k, row.getTES(), row.getLabelTest().trim(), row.getDescTest().trim(), row.getLodTMT(), row.getLabelTestMethod().trim(), null, row.getTestQuestion(), TestParamsTransformer.transformTestParams(row.getTestParams()), row.getToolTip());
                         }
 
                         return tn;


### PR DESCRIPTION
### Description
- We have extended the node classes to include the db_id of the associated entity. 
- This change ensures that each node now carries its db_id along with other relevant properties. This improves the traceability and reference of entities within the system.

#### Example Responce
```
{
    "actor": {
        "id": "pid_graph:B5CC396B",
        "name": "PID Owner (Role)"
    },
    "principles": [
        {
            "db_id": "pid_graph:6DA48AC0",
            "id": "P12",
            "name": "Viable, Trusted",
            "description": "The PID Policy concentrates on principles, desired results and governance which are designed to establish a viable, trusted PID infrastructure suitable for the long-term sustainability of the EOSC.",
            "criteria": [
                {
                    "db_id": "pid_graph:D0339C6A",
                    "id": "C20",
                    "name": "Openly Available",
                    "description": "Services MUST be available to all researchers in the EU.",
                    "imperative": "MUST",
                    "metric": {
                        "db_id": "pid_graph:A87CFC4F",
                        "id": "M20",
                        "name": "Openly Available Services",
                        "type_db_id": "pid_graph:7085006F",
                        "type": "Binary-Binary",
                        "benchmark_value": 1.0,
                        "value": null,
                        "result": null,
                        "type_algorithm_db_id": "pid_graph:7A976659",
                        "type_metric_db_id": "pid_graph:8D79984F",
                        "tests": [
                            {
                                "db_id": "pid_graph:A78D63FF",
                                "id": "T20",
                                "name": "Services are Open",
                                "description": "Services (Providers) need to supply public evidence of open availability of services.",
                                "text": "Can you supply public evidence of open availability of your service?|Link to evidence:",
                                "type_db_id": "pid_graph:8D79984F",
                                "type": "Binary-Manual-Evidence",
                                "value": null,
                                "result": null,
                                "evidence_url": [],
                                "params": "open_data|evidence",
                                "tool_tip": "PID kernel metadata should be openly available, except for sensitive elements|A document, web page, or publication describing the plan"
                            }
                        ],
                        "label_algorithm_type": "Test = Metric",
                        "label_type_metric": "Binary"
                    }
                }
            ]
        }
    ],
    "automatedGroupTest": null,
    "published": false,
    "assessment_type": {
        "id": "pid_graph:3E109BBA",
        "name": "EOSC PID Policy"
    }
}
```