### PR TITLE
CAT-963: Add info for Actor-Criterion Assignment in used_by_motivation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ According to [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) , the `Unr
 - [#523](https://github.com/FC4E-CAT/fc4e-cat-api/pull/523) CAT-937 API Call to Retrieve All Public Objects by Actor (No Motivation Restriction) 
 - [#524](https://github.com/FC4E-CAT/fc4e-cat-api/pull/524) CAT-957 Add support for updating user information via access token
 - [#525](https://github.com/FC4E-CAT/fc4e-cat-api/pull/525) CAT-956 Remove Character Length Validation for Organisation Query
+- [#528](https://github.com/FC4E-CAT/fc4e-cat-api/pull/528) CAT-963: Add info for Actor-Criterion Assignment in used_by_motivation
 
 ### Fix
 - [#482](https://github.com/FC4E-CAT/fc4e-cat-api/pull/482) CAT-867: Update Auto-AAI-Check-Entitlements tests parameters

--- a/data-transfer-object/src/main/java/org/grnet/cat/dtos/registry/motivation/PartialMotivationResponse.java
+++ b/data-transfer-object/src/main/java/org/grnet/cat/dtos/registry/motivation/PartialMotivationResponse.java
@@ -1,5 +1,6 @@
 package org.grnet.cat.dtos.registry.motivation;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
@@ -33,4 +34,22 @@ public class PartialMotivationResponse {
     )
     @JsonProperty(value = "label")
     public String label;
+
+    @Schema(
+            type = SchemaType.STRING,
+            implementation = String.class,
+            description = "The ID of the Actor to which the criterion was first assigned.",
+            example = "pid_graph:B5CC396B"
+    )
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    @JsonProperty(value = "first_actor_assignment")
+    public String lodActor;
+
+    @Schema(type = SchemaType.STRING,
+            implementation = String.class,
+            description = "Label of the Actor",
+            example = "Compliance Monitoring (Role)")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    @JsonProperty(value="first_actor_assignment_label")
+    public String labelActor;
 }

--- a/mapper/src/main/java/org/grnet/cat/mappers/registry/MotivationMapper.java
+++ b/mapper/src/main/java/org/grnet/cat/mappers/registry/MotivationMapper.java
@@ -2,7 +2,6 @@ package org.grnet.cat.mappers.registry;
 
 import org.apache.commons.lang3.StringUtils;
 import org.grnet.cat.dtos.registry.actor.PartialMotivationActorResponse;
-import org.grnet.cat.dtos.registry.codelist.RegistryActorResponse;
 import org.grnet.cat.dtos.registry.motivation.*;
 import org.grnet.cat.dtos.registry.principle.PrincipleResponseDto;
 import org.grnet.cat.entities.registry.Motivation;
@@ -91,6 +90,7 @@ public interface MotivationMapper {
     @Mapping(target = "id", expression = "java(motivation.getId())")
     @Mapping(target = "mtv", expression = "java(motivation.getMtv())")
     @Mapping(target = "label", expression = "java(motivation.getLabel())")
+    @Mapping(target = "lodActor", ignore = true)
     PartialMotivationResponse mapPartialMotivation(Motivation motivation);
 
     @IterableMapping(qualifiedByName = "mapPartialMotivation")

--- a/repository/src/main/java/org/grnet/cat/repositories/registry/CriterionActorRepository.java
+++ b/repository/src/main/java/org/grnet/cat/repositories/registry/CriterionActorRepository.java
@@ -84,6 +84,7 @@ public class CriterionActorRepository implements Repository<CriterionActorJuncti
         return query.getResultList();
     }
 
+
 //    @Transactional
 //    public boolean existCriterionInStatus(String criterionId,boolean status) {
 //
@@ -135,5 +136,10 @@ public class CriterionActorRepository implements Repository<CriterionActorJuncti
 
     public void deleteByActorId(String motivationId, String actorId) {
         delete("FROM CriterionActorJunction c WHERE c.motivation.id =?1 AND c.id.actorId = ?2", motivationId, actorId);
+    }
+
+    public Optional<CriterionActorJunction> findByCriterionIdAndMotivationId(String motivationId, String criterionId) {
+        return find("FROM CriterionActorJunction c WHERE c.motivation.id = ?1 AND c.criterion.id = ?2", motivationId, criterionId)
+                .firstResultOptional();
     }
 }

--- a/service/src/main/java/org/grnet/cat/services/registry/CriterionService.java
+++ b/service/src/main/java/org/grnet/cat/services/registry/CriterionService.java
@@ -254,7 +254,15 @@ public class CriterionService {
 
         var motivations = principleCriterionRepository.getMotivationIdsByCriterion(criterion.getId());
         var motivationResponses = motivations.stream()
-                .map(MotivationMapper.INSTANCE::mapPartialMotivation)
+                .map(motivation -> {
+                    var firstAssignment = criterionActorRepository.findByCriterionIdAndMotivationId(motivation.getId(), criterion.getId());
+                    var partialMotivation = MotivationMapper.INSTANCE.mapPartialMotivation(motivation);
+                    firstAssignment.ifPresent(assignment -> {
+                        partialMotivation.lodActor = assignment.getActor().getId();
+                        partialMotivation.labelActor = assignment.getActor().getLabelActor();
+                    });
+                    return partialMotivation;
+                })
                 .collect(Collectors.toList());
 
         criterionResponse.setMotivations(motivationResponses);
@@ -284,7 +292,7 @@ public class CriterionService {
             );
 
             var uniqueTestIds = metricNode.getChildren().stream()
-                    .map(child -> ((TestNode) child).getId())
+                    .map(Node::getId)
                     .collect(Collectors.toSet());
 
             if (!uniqueTestIds.contains(row.getTES())) {


### PR DESCRIPTION
#### Description
- Added a first_actor_assignment field to the used_by_motivations list on the registry criterion response: ([/v1/registry/criteria/{id}](http://localhost:8080/swagger-ui/#/Criterion/get_v1_registry_criteria__id_)), which includes the ID of the actor responsible for the first assignment of a criterion.
- Added first_actor_assignment_label to provide the label of the actor who first assigned the criterion to the motivation.

#### Example Response
```
.
.
.
"used_by_motivations": [
    {
        "id": "pid_graph:A05596B7",
        "mtv": "mtvb",
        "label": "mtvb",
        "first_actor_assignment": "pid_graph:E92B9B49",
        "first_actor_assignment_label": "PID Service Provider (Role)"
    },
    {
        "id": "pid_graph:B4D62E13",
        "mtv": "mtvA",
        "label": "mtvA",
        "first_actor_assignment": "pid_graph:B5CC396B",
        "first_actor_assignment_label": "PID Owner (Role)"
    }
]
.
.
.
```