### PR TITLE
CAT-964: Create PUT Endpoint for Updating Metrics Inside Motivation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ According to [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) , the `Unr
 - [#524](https://github.com/FC4E-CAT/fc4e-cat-api/pull/524) CAT-957 Add support for updating user information via access token
 - [#525](https://github.com/FC4E-CAT/fc4e-cat-api/pull/525) CAT-956 Remove Character Length Validation for Organisation Query
 - [#528](https://github.com/FC4E-CAT/fc4e-cat-api/pull/528) CAT-963: Add info for Actor-Criterion Assignment in used_by_motivation
+- [#529](https://github.com/FC4E-CAT/fc4e-cat-api/pull/529) CAT-964: Create PUT Endpoint for Updating Metrics Inside Motivation
 
 ### Fix
 - [#482](https://github.com/FC4E-CAT/fc4e-cat-api/pull/482) CAT-867: Update Auto-AAI-Check-Entitlements tests parameters

--- a/api/src/main/java/org/grnet/cat/api/endpoints/registry/MotivationEndpoint.java
+++ b/api/src/main/java/org/grnet/cat/api/endpoints/registry/MotivationEndpoint.java
@@ -2384,6 +2384,78 @@ public class MotivationEndpoint {
 
     @Tag(name = "Motivation")
     @Operation(
+            summary = "Update a Metric for a Motivation.",
+            description = "Update a Metric for a single motivation.")
+    @APIResponse(
+            responseCode = "200",
+            description = "Metric successfully updated for the motivation.",
+            content = @Content(schema = @Schema(
+                    type = SchemaType.OBJECT,
+                    implementation = InformativeResponse.class)))
+    @APIResponse(
+            responseCode = "400",
+            description = "Invalid request payload.",
+            content = @Content(schema = @Schema(
+                    type = SchemaType.OBJECT,
+                    implementation = InformativeResponse.class)))
+    @APIResponse(
+            responseCode = "401",
+            description = "User has not been authenticated.",
+            content = @Content(schema = @Schema(
+                    type = SchemaType.OBJECT,
+                    implementation = InformativeResponse.class)))
+    @APIResponse(
+            responseCode = "403",
+            description = "Not permitted.",
+            content = @Content(schema = @Schema(
+                    type = SchemaType.OBJECT,
+                    implementation = InformativeResponse.class)))
+    @APIResponse(
+            responseCode = "409",
+            description = "Unique constraint violation.",
+            content = @Content(schema = @Schema(
+                    type = SchemaType.OBJECT,
+                    implementation = InformativeResponse.class)))
+    @APIResponse(
+            responseCode = "500",
+            description = "Internal Server Error.",
+            content = @Content(schema = @Schema(
+                    type = SchemaType.OBJECT,
+                    implementation = InformativeResponse.class)))
+    @SecurityRequirement(name = "Authentication")
+    @PUT
+    @Path("/{id}/metric/{metric-id}")
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response updateMetric(
+            @Parameter(
+                    description = "The ID of the Motivation to create a metric for.",
+                    required = true,
+                    example = "pid_graph:3E109BBA",
+                    schema = @Schema(type = SchemaType.STRING))
+            @PathParam("id")
+            @Valid
+            @NotFoundEntity(repository = MotivationRepository.class, message = "There is no Motivation with the following id:")
+            @CheckPublished(repository = MotivationRepository.class, message = "No action permitted for published Motivation with the following id:", isPublishedPermitted = false)
+            String id,
+            @Parameter(
+                    description = "The ID of the Motivation to create a metric for.",
+                    required = true,
+                    example = "pid_graph:3E109BBA",
+                    schema = @Schema(type = SchemaType.STRING))
+            @PathParam("metric-id")
+            @Valid
+            @NotFoundEntity(repository = MetricRepository.class, message = "There is no Metric with the following id:")
+            String metricId,
+            @Valid @NotNull(message = "The request body is empty.") MotivationMetricUpdateRequest request) {
+
+        var response = motivationService.updateMetricForMotivation(metricId, request);
+
+        return Response.ok(response).build();
+
+    }
+
+    @Tag(name = "Motivation")
+    @Operation(
             summary = "Get a list of metrics of a motivation.",
             description = "Get a list of metric.")
     @APIResponse(

--- a/api/src/test/java/org/grnet/cat/api/registry/MotivationEndpointTest.java
+++ b/api/src/test/java/org/grnet/cat/api/registry/MotivationEndpointTest.java
@@ -13,6 +13,7 @@ import org.grnet.cat.dtos.registry.criterion.CriterionResponse;
 import org.grnet.cat.dtos.registry.metric.MetricRequestDto;
 import org.grnet.cat.dtos.registry.metric.MetricResponseDto;
 import org.grnet.cat.dtos.registry.metric.MetricVersionRequestDto;
+import org.grnet.cat.dtos.registry.metric.MotivationMetricUpdateRequest;
 import org.grnet.cat.dtos.registry.motivation.MotivationRequest;
 import org.grnet.cat.dtos.registry.motivation.MotivationResponse;
 import org.grnet.cat.dtos.registry.motivation.MotivationVersionRequest;
@@ -24,19 +25,13 @@ import org.grnet.cat.dtos.registry.principle.PrincipleResponseDto;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.parallel.Execution;
 import org.junit.jupiter.api.parallel.ExecutionMode;
-import org.junit.jupiter.api.parallel.Execution;
-import org.junit.jupiter.api.parallel.ExecutionMode;
 
-import java.time.LocalDate;
 import java.util.HashSet;
-import java.util.UUID;
 import java.util.UUID;
 
 import static io.restassured.RestAssured.given;
-import static org.hibernate.validator.internal.util.Contracts.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.params.shadow.com.univocity.parsers.conversions.Conversions.toUpperCase;
 
 @QuarkusTest
 @TestHTTPEndpoint(MotivationEndpoint.class)
@@ -1012,6 +1007,73 @@ public class MotivationEndpointTest extends KeycloakTest {
                 .as(InformativeResponse.class);
 
         assertEquals(200, newVersionResponse.code);
+    }
+
+    @Test
+    @Execution(ExecutionMode.CONCURRENT)
+    public void createAndUpdateMetricForMotivation() {
+        // Step 1: Create Motivation
+        var motivationRequest = new MotivationRequest();
+        motivationRequest.mtv = ("mtv" + UUID.randomUUID()).toUpperCase();
+        motivationRequest.label = "Test Motivation";
+        motivationRequest.description = "Test Motivation Description";
+        motivationRequest.motivationTypeId = "pid_graph:8882700E";
+
+        var motivationResponse = given()
+                .auth()
+                .oauth2(adminToken)
+                .body(motivationRequest)
+                .contentType(ContentType.JSON)
+                .post()
+                .then()
+                .assertThat()
+                .statusCode(201)
+                .extract()
+                .as(MotivationResponse.class);
+
+        // Step 2: Create Metric for the Motivation
+        var createMetric = new MetricRequestDto();
+        createMetric.MTR = " ";
+        createMetric.labelMetric = "Performance Metric";
+        createMetric.descrMetric = "This metric measures performance.";
+        createMetric.urlMetric = "http://example.com/metric";
+        createMetric.typeAlgorithmId = "pid_graph:2050775C";
+        createMetric.typeMetricId = "pid_graph:35966E2B";
+        createMetric.typeBenchmarkId = "pid_graph:0917EC0D";
+        createMetric.valueBenchmark = "3";
+
+        var createMetricResponse = given()
+                .auth()
+                .oauth2(adminToken)
+                .body(createMetric)
+                .contentType(ContentType.JSON)
+                .post("/{id}/metric/", motivationResponse.id)
+                .then()
+                .assertThat()
+                .statusCode(201)
+                .extract()
+                .as(MetricResponseDto.class);
+
+        // Step 3: Update Metric for the Motivation
+        var metricRequest = new MotivationMetricUpdateRequest();
+        metricRequest.typeAlgorithmId = "pid_graph:2050775C";
+        metricRequest.typeBenchmarkId = "pid_graph:0917EC0D";
+        metricRequest.valueBenchmark = "6";
+
+        var metricResponse = given()
+                .auth()
+                .oauth2(adminToken)
+                .body(metricRequest)
+                .contentType(ContentType.JSON)
+                .put("/{id}/metric/{metric-id}", motivationResponse.id, createMetricResponse.id)
+                .then()
+                .assertThat()
+                .statusCode(200)
+                .extract()
+                .as(InformativeResponse.class);
+
+        assertEquals(200, metricResponse.code);
+        assertEquals(metricResponse.message, "Metric was successfully updated with identifier: " + createMetricResponse.id);
     }
 
 

--- a/data-transfer-object/src/main/java/org/grnet/cat/dtos/registry/metric/MetricRequestDto.java
+++ b/data-transfer-object/src/main/java/org/grnet/cat/dtos/registry/metric/MetricRequestDto.java
@@ -1,5 +1,6 @@
 package org.grnet.cat.dtos.registry.metric;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.validation.constraints.NotEmpty;
 import lombok.EqualsAndHashCode;
@@ -106,6 +107,6 @@ public class MetricRequestDto {
             example = "pid_graph:D0339C6A"
     )
     @JsonProperty("criterion_id")
-    @EqualsAndHashCode.Include
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     public String criterion_id;
 }

--- a/data-transfer-object/src/main/java/org/grnet/cat/dtos/registry/metric/MotivationMetricUpdateRequest.java
+++ b/data-transfer-object/src/main/java/org/grnet/cat/dtos/registry/metric/MotivationMetricUpdateRequest.java
@@ -12,58 +12,12 @@ public class MotivationMetricUpdateRequest {
     @Schema(
             type = SchemaType.STRING,
             implementation = String.class,
-            description = "The unique identifier for the metric",
-            example = "MTR001"
-    )
-    @JsonProperty("mtr")
-    public String MTR;
-
-    @Schema(
-            type = SchemaType.STRING,
-            implementation = String.class,
-            description = "Label for the metric",
-            example = "Performance Metric"
-    )
-    @JsonProperty("label")
-    public String labelMetric;
-
-    @Schema(
-            type = SchemaType.STRING,
-            implementation = String.class,
-            description = "Description of the metric",
-            example = "This metric measures performance."
-    )
-    @JsonProperty("description")
-    public String descrMetric;
-
-    @Schema(
-            type = SchemaType.STRING,
-            implementation = String.class,
-            description = "URL for more information about the metric",
-            example = "http://example.com/metric"
-    )
-    @JsonProperty("url")
-    public String urlMetric;
-
-    @Schema(
-            type = SchemaType.STRING,
-            implementation = String.class,
             description = "The ID of the Type Algorithm associated with this metric",
             example = "pid_graph:2050775C"
     )
     @NotFoundEntity(repository = TypeAlgorithmRepository.class, message = "There is no Algorithm Type with the following id:")
     @JsonProperty("type_algorithm_id")
     public String typeAlgorithmId;
-
-    @Schema(
-            type = SchemaType.STRING,
-            implementation = String.class,
-            description = "The ID of the Type Metric associated with this metric",
-            example = "pid_graph:35966E2B"
-    )
-    @NotFoundEntity(repository = TypeMetricRepository.class, message = "There is no Metric Type with the following id:")
-    @JsonProperty("type_metric_id")
-    public String typeMetricId;
 
     @Schema(
             type = SchemaType.STRING,

--- a/mapper/src/main/java/org/grnet/cat/mappers/registry/metric/MetricMapper.java
+++ b/mapper/src/main/java/org/grnet/cat/mappers/registry/metric/MetricMapper.java
@@ -1,10 +1,7 @@
 package org.grnet.cat.mappers.registry.metric;
 
 import org.apache.commons.lang3.StringUtils;
-import org.grnet.cat.dtos.registry.metric.MetricRequestDto;
-import org.grnet.cat.dtos.registry.metric.MetricResponseDto;
-import org.grnet.cat.dtos.registry.metric.MetricUpdateDto;
-import org.grnet.cat.dtos.registry.metric.MetricVersionRequestDto;
+import org.grnet.cat.dtos.registry.metric.*;
 import org.grnet.cat.entities.registry.metric.Metric;
 import org.mapstruct.*;
 import org.mapstruct.factory.Mappers;
@@ -58,6 +55,24 @@ public interface MetricMapper {
     @Mapping(target = "dataType", ignore = true)
     @Mapping(target = "criteria", ignore = true)
     void updateMetricFromDto(MetricUpdateDto request, @MappingTarget Metric metric);
+
+
+//    @Mapping(target = "MTR", expression = "java(StringUtils.isNotEmpty(request.MTR) ? request.MTR : metric.getMTR())")
+//    @Mapping(target = "labelMetric", expression = "java(StringUtils.isNotEmpty(request.labelMetric) ? request.labelMetric : metric.getLabelMetric())")
+//    @Mapping(target = "descrMetric", expression = "java(StringUtils.isNotEmpty(request.descrMetric) ? request.descrMetric : metric.getDescrMetric())")
+//    @Mapping(target = "urlMetric", expression = "java(StringUtils.isNotEmpty(request.urlMetric) ? request.urlMetric : metric.getUrlMetric())")
+//    @Mapping(target = "lastTouch", expression = "java(Timestamp.from(Instant.now()))")
+//    @Mapping(target = "typeAlgorithm", ignore = true)
+//    @Mapping(target = "typeMetric", expression = "java(StringUtils.isNotEmpty(request.typeMetric) ? request.typeMetric : metric.getTypeMetric())")
+//    @Mapping(target = "populatedBy", ignore = true)
+//    @Mapping(target = "id", ignore = true)
+//    @Mapping(target = "lodMTV", ignore = true)
+//    @Mapping(target = "upload", ignore = true)
+//    @Mapping(target = "dataType", ignore = true)
+//    @Mapping(target = "criteria", ignore = true)
+    void updateMotivationMetricFromDto(MotivationMetricUpdateRequest request, @MappingTarget Metric metric);
+
+
 
 
     @Named("versionMetric")

--- a/service/src/main/java/org/grnet/cat/services/registry/MotivationService.java
+++ b/service/src/main/java/org/grnet/cat/services/registry/MotivationService.java
@@ -27,7 +27,6 @@ import org.grnet.cat.entities.registry.metric.Metric;
 import org.grnet.cat.entities.registry.metric.TypeAlgorithm;
 import org.grnet.cat.entities.registry.metric.TypeMetric;
 import org.grnet.cat.exceptions.UniqueConstraintViolationException;
-import org.grnet.cat.mappers.registry.*;
 import org.grnet.cat.mappers.registry.MotivationActorMapper;
 import org.grnet.cat.mappers.registry.MotivationMapper;
 import org.grnet.cat.mappers.registry.PrincipleCriterionMapper;
@@ -35,7 +34,6 @@ import org.grnet.cat.mappers.registry.PrincipleMapper;
 import org.grnet.cat.mappers.registry.metric.MetricMapper;
 import org.grnet.cat.repositories.registry.*;
 import org.grnet.cat.repositories.registry.metric.MetricRepository;
-import org.grnet.cat.services.registry.metric.MetricService;
 import org.grnet.cat.utils.TestParamsTransformer;
 
 import java.sql.Timestamp;
@@ -79,9 +77,6 @@ public class MotivationService {
 
     @Inject
     MetricTestRepository metricTestRepository;
-
-    @Inject
-    MetricService metricService;
 
     @Inject
     CriterionRepository criterionRepository;
@@ -646,6 +641,28 @@ public class MotivationService {
         return MetricMapper.INSTANCE.metricToDto(metric);
     }
 
+    @Transactional
+    public InformativeResponse updateMetricForMotivation(String metricId, MotivationMetricUpdateRequest request) {
+
+        var response = new InformativeResponse();
+
+        var metric = metricRepository.findById(metricId);
+        var typeAlgorithm = Panache.getEntityManager().getReference(TypeAlgorithm.class, request.typeAlgorithmId);
+        var typeBenchmark = Panache.getEntityManager().getReference(TypeBenchmark.class, request.typeBenchmarkId);
+
+        metric.setTypeAlgorithm(typeAlgorithm);
+        metric.setTypeBenchmark(typeBenchmark);
+        metric.setValueBenchmark(request.valueBenchmark);
+
+        MetricMapper.INSTANCE.updateMotivationMetricFromDto(request, metric);
+
+        metricRepository.persist(metric);
+
+        response.code = 200;
+        response.message = "Metric was successfully updated with identifier: " + metric.getId();
+
+        return response;
+    }
 
     @Transactional
     public InformativeResponse createMetricVersionForMotivation(String motivationId, String metricId, MetricVersionRequestDto request, String userId) {


### PR DESCRIPTION
### Description
- Created a new PUT endpoint for updating metrics associated with a motivation in the system: /v1/registry/motivations/{id}/metric/{metric-id}
- The endpoint allows updating a metric by specifying the motivationId and metricId, and modifying fields such as typeAlgorithmId, typeBenchmarkId, and valueBenchmark.

### Example Request 
```
with path param id and metric-id

{
    "typeAlgorithmId": "pid_graph:2050775C",
    "typeBenchmarkId": "pid_graph:0917EC0D",
    "valueBenchmark": "6"
}
````