### PR TITLE
CAT-970: Create and Link Metric to Criterion When Assigned to Actor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ According to [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) , the `Unr
 - [#525](https://github.com/FC4E-CAT/fc4e-cat-api/pull/525) CAT-956 Remove Character Length Validation for Organisation Query
 - [#528](https://github.com/FC4E-CAT/fc4e-cat-api/pull/528) CAT-963: Add info for Actor-Criterion Assignment in used_by_motivation
 - [#529](https://github.com/FC4E-CAT/fc4e-cat-api/pull/529) CAT-964: Create PUT Endpoint for Updating Metrics Inside Motivation
+- [#531](https://github.com/FC4E-CAT/fc4e-cat-api/pull/531) CAT-970 Create and Link Metric to Criterion When Assigned to Actor
 
 ### Fix
 - [#482](https://github.com/FC4E-CAT/fc4e-cat-api/pull/482) CAT-867: Update Auto-AAI-Check-Entitlements tests parameters

--- a/api/src/main/java/org/grnet/cat/api/endpoints/registry/MotivationEndpoint.java
+++ b/api/src/main/java/org/grnet/cat/api/endpoints/registry/MotivationEndpoint.java
@@ -35,10 +35,7 @@ import org.grnet.cat.dtos.pagination.PageResource;
 import org.grnet.cat.dtos.registry.*;
 import org.grnet.cat.dtos.registry.actor.MotivationActorRequest;
 import org.grnet.cat.dtos.registry.actor.MotivationActorResponse;
-import org.grnet.cat.dtos.registry.criterion.CriterionActorRequest;
-import org.grnet.cat.dtos.registry.criterion.CriterionActorResponse;
-import org.grnet.cat.dtos.registry.criterion.DetailedCriterionDto;
-import org.grnet.cat.dtos.registry.criterion.PrincipleCriterionResponse;
+import org.grnet.cat.dtos.registry.criterion.*;
 import org.grnet.cat.dtos.registry.metric.*;
 import org.grnet.cat.dtos.registry.motivation.*;
 import org.grnet.cat.dtos.registry.principle.MotivationPrincipleExtendedRequestDto;
@@ -1747,6 +1744,176 @@ public class MotivationEndpoint {
         var informativeResponse = new InformativeResponse();
         informativeResponse.code = 200;
         informativeResponse.message = "Successful unpublish";
+
+        return Response.ok().entity(informativeResponse).build();
+    }
+
+    @Tag(name = "Motivation")
+    @Operation(
+            summary = "Add a Criterion to a Motivation-Actor pair with a predefined Metric.",
+            description = "Creates a new metric with predefined types (benchmark, algorithm, metric type and benchmark value) and links it to the given criterion. " +
+                    "Then, assigns the criterion and metric to the specified motivation-actor pair."
+    )
+    @APIResponse(
+            responseCode = "201",
+            description = "Criterion item added.",
+            content = @Content(schema = @Schema(
+                    type = SchemaType.OBJECT,
+                    implementation = InformativeResponse.class)))
+    @APIResponse(
+            responseCode = "400",
+            description = "Invalid request payload.",
+            content = @Content(schema = @Schema(
+                    type = SchemaType.OBJECT,
+                    implementation = InformativeResponse.class)))
+    @APIResponse(
+            responseCode = "401",
+            description = "User has not been authenticated.",
+            content = @Content(schema = @Schema(
+                    type = SchemaType.OBJECT,
+                    implementation = InformativeResponse.class)))
+    @APIResponse(
+            responseCode = "403",
+            description = "Not permitted.",
+            content = @Content(schema = @Schema(
+                    type = SchemaType.OBJECT,
+                    implementation = InformativeResponse.class)))
+    @APIResponse(
+            responseCode = "409",
+            description = "Unique constraint violation.",
+            content = @Content(schema = @Schema(
+                    type = SchemaType.OBJECT,
+                    implementation = InformativeResponse.class)))
+    @APIResponse(
+            responseCode = "500",
+            description = "Internal Server Error.",
+            content = @Content(schema = @Schema(
+                    type = SchemaType.OBJECT,
+                    implementation = InformativeResponse.class)))
+    @SecurityRequirement(name = "Authentication")
+    @POST
+    @Path("/{id}/actors/{actor-id}/criteria/auto-metric")
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response addCriterionWithAutoMetricToActor(
+            @Parameter(description = "The ID of the Motivation to update.",
+                required = true,
+                example = "1",
+                schema = @Schema(type = SchemaType.STRING))
+            @PathParam("id")
+            @Valid
+            @NotFoundEntity(repository = MotivationRepository.class, message = "There is no Motivation with the following id:")
+            @CheckPublished(repository = MotivationRepository.class, message = "No action permitted for published Motivation with the following id:", isPublishedPermitted = false) String id,
+            @Parameter(description = "The ID of the Actor to add criterion to.",
+                    required = true,
+                    example = "pid_graph:234B60D8",
+                    schema = @Schema(type = SchemaType.STRING))
+            @PathParam("actor-id")
+            @Valid @NotFoundEntity(repository = RegistryActorRepository.class, message = "There is no Actor with the following id:") String actorId,
+            @NotEmpty(message = "List of criteria can not be empty.") Set<@Valid CriterionActorRequest> request,
+            @Context UriInfo uriInfo) {
+
+        var messages = registryActorService.addCriterionWithAutoMetricToActor(id, actorId, request, utility.getUserUniqueIdentifier());
+
+        var informativeResponse = new InformativeResponse();
+
+        informativeResponse.code = 200;
+        var errorMessages = messages.stream()
+                .filter(msg -> msg.contains("is not related to principles"))
+                .collect(Collectors.toSet());
+
+        var successMessages = messages.stream()
+                .filter(msg -> !msg.contains("is not related to principles"))
+                .collect(Collectors.toSet());
+
+        if (!errorMessages.isEmpty()) {
+            informativeResponse.errors = errorMessages;
+        }
+        informativeResponse.message = String.join("\n", successMessages);
+
+        return Response.ok().entity(informativeResponse).build();
+    }
+
+    @Tag(name = "Motivation")
+    @Operation(
+            summary = "Update a Criterion to a Motivation-Actor pair with a predefined Metric.",
+            description = "Updates the criterion list to motivation actor.")
+    @APIResponse(
+            responseCode = "201",
+            description = "Criterion items updated.",
+            content = @Content(schema = @Schema(
+                    type = SchemaType.OBJECT,
+                    implementation = InformativeResponse.class)))
+    @APIResponse(
+            responseCode = "400",
+            description = "Invalid request payload.",
+            content = @Content(schema = @Schema(
+                    type = SchemaType.OBJECT,
+                    implementation = InformativeResponse.class)))
+    @APIResponse(
+            responseCode = "401",
+            description = "User has not been authenticated.",
+            content = @Content(schema = @Schema(
+                    type = SchemaType.OBJECT,
+                    implementation = InformativeResponse.class)))
+    @APIResponse(
+            responseCode = "403",
+            description = "Not permitted.",
+            content = @Content(schema = @Schema(
+                    type = SchemaType.OBJECT,
+                    implementation = InformativeResponse.class)))
+    @APIResponse(
+            responseCode = "409",
+            description = "Unique constraint violation.",
+            content = @Content(schema = @Schema(
+                    type = SchemaType.OBJECT,
+                    implementation = InformativeResponse.class)))
+    @APIResponse(
+            responseCode = "500",
+            description = "Internal Server Error.",
+            content = @Content(schema = @Schema(
+                    type = SchemaType.OBJECT,
+                    implementation = InformativeResponse.class)))
+    @SecurityRequirement(name = "Authentication")
+    @PUT
+    @Path("/{id}/actors/{actor-id}/criteria/auto-metric")
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response updateCriterionWithAutoMetricToActor(
+            @Parameter(description = "The ID of the Motivation to update.",
+                    required = true,
+                    example = "pid_graph:3E109BBA",
+                    schema = @Schema(type = SchemaType.STRING))
+            @PathParam("id")
+            @Valid
+            @NotFoundEntity(repository = MotivationRepository.class, message = "There is no Motivation with the following id:")
+            @CheckPublished(repository = MotivationRepository.class, message = "No action permitted for published Motivation with the following id:", isPublishedPermitted = false) String id,
+            @Parameter(description = "The ID of the Actor to add criterion to.",
+                    required = true,
+                    example = "pid_graph:234B60D8",
+                    schema = @Schema(type = SchemaType.STRING))
+            @PathParam("actor-id")
+            @Valid @NotFoundEntity(repository = RegistryActorRepository.class, message = "There is no Actor with the following id:") String actorId,
+            Set<@Valid CriterionActorRequest> request) {
+
+        if (Objects.isNull(request)) {
+            request = new HashSet<>();
+        }
+
+        var messages = registryActorService.updateCriterionWithAutoMetricToActor(id, actorId, request, utility.getUserUniqueIdentifier());
+
+        var informativeResponse = new InformativeResponse();
+        informativeResponse.code = 200;
+        var errorMessages = messages.stream()
+                .filter(msg -> msg.contains("is not related to principles"))
+                .collect(Collectors.toSet());
+
+        var successMessages = messages.stream()
+                .filter(msg -> !msg.contains("is not related to principles"))
+                .collect(Collectors.toSet());
+
+        if (!errorMessages.isEmpty()) {
+            informativeResponse.errors = errorMessages;
+        }
+        informativeResponse.message = String.join("\n", successMessages);
 
         return Response.ok().entity(informativeResponse).build();
     }

--- a/api/src/test/java/org/grnet/cat/api/registry/CriteriaEndpointTest.java
+++ b/api/src/test/java/org/grnet/cat/api/registry/CriteriaEndpointTest.java
@@ -130,7 +130,6 @@ public class CriteriaEndpointTest extends KeycloakTest {
         request.description = "This metric measures performance.";
         request.imperative = "pid_graph:BED209B9";
         request.typeCriterion = "pid_graph:A2719B92";
-        request.lodMTV = null;
         return request;
     }
 

--- a/api/src/test/java/org/grnet/cat/api/registry/MotivationEndpointTest.java
+++ b/api/src/test/java/org/grnet/cat/api/registry/MotivationEndpointTest.java
@@ -670,6 +670,88 @@ public class MotivationEndpointTest extends KeycloakTest {
 
     @Test
     @Execution(ExecutionMode.CONCURRENT)
+    public void addCriterionWithAutoMetric() {
+
+        var motivationRequest = new MotivationRequest();
+        motivationRequest.mtv = "mtv-automtr";
+        motivationRequest.label = "Auto Metric Motivation";
+        motivationRequest.description = "Motivation for testing auto-metric assignment.";
+        motivationRequest.motivationTypeId = "pid_graph:8882700E";
+
+        var motivationResponse = given()
+                .auth()
+                .oauth2(adminToken)
+                .body(motivationRequest)
+                .contentType(ContentType.JSON)
+                .post()
+                .then()
+                .assertThat()
+                .statusCode(201)
+                .extract()
+                .as(MotivationResponse.class);
+
+        var request = new CriterionRequest();
+        request.cri = "AUTO-CRI-001";
+        request.label = "Auto Criterion Label";
+        request.description = "This criterion will be used with automatic metric assignment.";
+        request.imperative = "pid_graph:BED209B9";
+        request.typeCriterion = "pid_graph:A2719B92";
+
+        var criterionResponse = given()
+                .auth()
+                .oauth2(adminToken)
+                .basePath("/v1/registry/criteria")
+                .body(request)
+                .contentType(ContentType.JSON)
+                .post()
+                .then()
+                .assertThat()
+                .statusCode(201)
+                .extract()
+                .as(CriterionResponse.class);
+
+        var motivationActor = new MotivationActorRequest();
+        motivationActor.actorId = "pid_graph:1A718108";
+        motivationActor.relation = "dcterms:isRequiredBy";
+        MotivationActorRequest[] array = new MotivationActorRequest[1];
+        array[0] = motivationActor;
+
+        given()
+                .auth()
+                .oauth2(adminToken)
+                .body(array)
+                .contentType(ContentType.JSON)
+                .post("/{id}/actors", motivationResponse.id)
+                .then()
+                .assertThat()
+                .statusCode(200)
+                .extract()
+                .as(InformativeResponse.class);
+
+        var criterionActor = new CriterionActorRequest();
+        criterionActor.criterionId = criterionResponse.id;
+        criterionActor.imperativeId = "pid_graph:BED209B9";
+        CriterionActorRequest[] array1 = new CriterionActorRequest[1];
+        array1[0] = criterionActor;
+
+        var response = given()
+                .auth()
+                .oauth2(adminToken)
+                .body(array1)
+                .contentType(ContentType.JSON)
+                .post("/{id}/actors/{actor-id}/criteria/auto-metric", motivationResponse.id, "pid_graph:1A718108")
+                .then()
+                .assertThat()
+                .statusCode(200)
+                .extract()
+                .as(InformativeResponse.class);
+
+        assertEquals(response.code, 200);
+    }
+
+
+    @Test
+    @Execution(ExecutionMode.CONCURRENT)
     public void updateCriterionImperativeNotFound() {
 
         var motivationRequest = new MotivationRequest();

--- a/data-transfer-object/src/main/java/org/grnet/cat/dtos/registry/criterion/CriterionRequest.java
+++ b/data-transfer-object/src/main/java/org/grnet/cat/dtos/registry/criterion/CriterionRequest.java
@@ -82,15 +82,6 @@ public class CriterionRequest {
     @Schema(
             type = SchemaType.STRING,
             implementation = String.class,
-            description = "The Id of the Motivation.",
-            example = "pid_graph:3E109BBA"
-    )
-    @JsonProperty("motivation_id")
-    @NotFoundEntity(repository = MotivationRepository.class, message = "There is no Motivation with the following id:")
-    public String lodMTV;
-    @Schema(
-            type = SchemaType.STRING,
-            implementation = String.class,
             description = "The Criterion parent identifier.",
             example = "pid_graph:A8EA1C61"
     )

--- a/service/src/main/java/org/grnet/cat/services/registry/CriterionService.java
+++ b/service/src/main/java/org/grnet/cat/services/registry/CriterionService.java
@@ -100,15 +100,13 @@ public class CriterionService {
 
         var criteria = CriteriaMapper.INSTANCE.criteriaToEntity(criteriaRequestDto);
 
-        if (!(criteriaRequestDto.lodMTV == null)) {
-            criteria.setLodMTV(criteriaRequestDto.lodMTV);
-        }
-
         criteria.setPopulatedBy(userId);
         criteria.setImperative(Panache.getEntityManager().getReference(Imperative.class, criteriaRequestDto.imperative));
         criteria.setTypeCriterion(Panache.getEntityManager().getReference(TypeCriterion.class, criteriaRequestDto.typeCriterion));
 
         criteriaRepository.persist(criteria);
+
+        criteria.setLodCriP(criteria.getId());
 
         return CriteriaMapper.INSTANCE.criteriaToDto(criteria);
     }

--- a/service/src/main/java/org/grnet/cat/services/registry/MotivationService.java
+++ b/service/src/main/java/org/grnet/cat/services/registry/MotivationService.java
@@ -619,20 +619,8 @@ public class MotivationService {
 
         if (request.criterion_id != null) {
             var criterion = criterionRepository.findById(request.criterion_id);
-            var similarMetricOpt = metricRepository.fetchMetricByTypesCombinations(
-                    typeAlgorithm.getId(),
-                    typeBenchmark.getId(),
-                    typeMetric.getId()
-            );
-
-            if (similarMetricOpt.isPresent()) {
-                var similarMetric = similarMetricOpt.get();
-                metric.setLabelMetric(similarMetric.getLabelMetric());
-                metric.setDescrMetric(similarMetric.getDescrMetric());
-            } else {
                 metric.setLabelMetric(criterion.getLabel() + (" Metric"));
-                metric.setDescrMetric("Metric created for " + motivationRepository.findById(id).getLabel() + " and used by criterion " + criterion.getCri() + ".");
-            }
+                metric.setDescrMetric("Metric created for \"" + motivationRepository.findById(id).getLabel() + "\" and used by \"" + criterion.getCri() + "\".");
         }
 
         metricRepository.persist(metric);

--- a/service/src/main/java/org/grnet/cat/services/registry/RegistryActorService.java
+++ b/service/src/main/java/org/grnet/cat/services/registry/RegistryActorService.java
@@ -10,13 +10,15 @@ import org.grnet.cat.dtos.pagination.PageResource;
 import org.grnet.cat.dtos.registry.codelist.RegistryActorResponse;
 import org.grnet.cat.dtos.registry.criterion.CriterionActorRequest;
 import org.grnet.cat.dtos.registry.criterion.CriterionActorResponse;
+import org.grnet.cat.dtos.registry.metric.MetricRequestDto;
+import org.grnet.cat.dtos.registry.motivation.MultipleCriterionMetricRequest;
 import org.grnet.cat.entities.PageQuery;
-import org.grnet.cat.entities.registry.Motivation;
-import org.grnet.cat.entities.registry.MotivationActorJunction;
-import org.grnet.cat.entities.registry.RegistryActor;
+import org.grnet.cat.entities.registry.*;
 import org.grnet.cat.mappers.registry.CriterionActorMapper;
 import org.grnet.cat.mappers.registry.RegistryActorMapper;
 import org.grnet.cat.repositories.registry.*;
+import org.grnet.cat.repositories.registry.metric.MetricRepository;
+import org.mapstruct.Mapping;
 
 import java.sql.Timestamp;
 import java.time.Instant;
@@ -24,6 +26,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 @ApplicationScoped
 public class RegistryActorService {
@@ -41,6 +44,18 @@ public class RegistryActorService {
 
     @Inject
     MotivationActorRepository motivationActorRepository;
+
+    @Inject
+    CriterionMetricService criterionMetricService;
+
+    @Inject
+    MotivationService motivationService;
+
+    @Inject
+    CriterionMetricRepository criterionMetricRepository;
+
+    @Inject
+    MetricRepository metricRepository;
 
     /**
      * Retrieves a specific RegistryActor.
@@ -201,6 +216,184 @@ public class RegistryActorService {
         });
 
         return resultMessages;
+    }
+
+
+    /**
+     * Add Criteria to Actor.
+     *
+     * @param motivationId          The Motivation
+     * @param actorId               The Actor.
+     * @param criterionActorRequest The CriterionActorRequest to be added.
+     * @param userId                The user who requests to add criteria to  the Actor.
+     * @return The added relation.
+     */
+    @Transactional
+    public List<String> addCriterionWithAutoMetricToActor(String motivationId, String actorId, Set<CriterionActorRequest> criterionActorRequest, String userId) {
+
+        var resultMessages = new ArrayList<String>();
+
+        if (!motivationActorRepository.existsByMotivationAndActorAndVersion(motivationId, actorId, 1)) {
+            throw new NotFoundException("relation between motivation with id: " + motivationId + " and actor with id: " + actorId + " in version : " + 1 + " does not exist");
+        }
+        Optional<MotivationActorJunction> motivationActorJunctionOpt =
+                motivationActorRepository.fetchByMotivationAndActorAndVersion(motivationId, actorId, 1);
+
+        if (motivationActorJunctionOpt.get().getPublished() == Boolean.TRUE) {
+            throw new ForbiddenException("No action is permitted as motivation-actor relation is published");
+        }
+
+        var motivation = motivationRepository.findById(motivationId);
+        var actor = registryActorRepository.findById(actorId);
+
+        criterionActorRequest.stream().iterator().forEachRemaining(req -> {
+            var imperative = imperativeRepository.findById(req.imperativeId);
+            var principleCriterionJunction = principleCriterionRepository.findCriterion(req.criterionId, motivation.getId());
+            if (principleCriterionJunction.isEmpty()) {
+                resultMessages.add("criterion with id :: " + req.criterionId + " is not related to principles");
+            } else {
+
+                var criterion = principleCriterionJunction.get().getCriterion();
+                if (!criterionActorRepository.existsByMotivationAndActorAndCriterion(motivationId, actorId, req.criterionId, 1)) {
+
+                    generateAutoMetricForCriterion(motivationId, criterion.getId(), userId);
+                    actor.addCriterion(motivation, criterion, imperative, motivation.getId(), 1, userId, Timestamp.from(Instant.now()));
+                    resultMessages.add("criterion with id :: " + criterion.getId() + " successfully added to actor");
+                } else {
+                    resultMessages.add("criterion with id :: " + criterion.getId() + " already exists to actor");
+                }
+            }
+        });
+        return resultMessages;
+    }
+
+    /**
+     * Adds  a new Actor to motivation.
+     *
+     * @param motivationId          The Motivation
+     * @param actorId               The Actor.
+     * @param criterionActorRequest The CriterionActorRequest to be added.
+     * @param userId                The user who requests to add criteria to  the Actor.
+     * @return The added relation.
+     */
+    //@CheckPublishedRelation(permittedStatus = false, type = PublishEntityType.ACTOR)
+    // Only proceed if `published` is false
+    @Transactional
+    public List<String> updateCriterionWithAutoMetricToActor(String motivationId, String actorId, Set<CriterionActorRequest> criterionActorRequest, String userId) {
+        var resultMessages = new ArrayList<String>();
+
+        if (!motivationActorRepository.existsByMotivationAndActorAndVersion(motivationId, actorId, 1)) {
+            throw new NotFoundException("relation between motivation with id: " + motivationId + " and actor with id: " + actorId + " in version : " + 1 + " does not exist");
+        }
+        Optional<MotivationActorJunction> motivationActorJunctionOpt =
+                motivationActorRepository.fetchByMotivationAndActorAndVersion(motivationId, actorId, 1);
+
+        if (motivationActorJunctionOpt.get().getPublished() == Boolean.TRUE) {
+            throw new ForbiddenException("No action is permitted as motivation-actor relation is published");
+        }
+
+        var motivation = motivationRepository.findById(motivationId);
+        var actor = registryActorRepository.findById(actorId);
+
+        removeCriteriaAndAutoMetric(motivation, actor, criterionActorRequest, resultMessages);
+
+        criterionActorRequest.stream().iterator().forEachRemaining(req -> {
+            var imperative = imperativeRepository.findById(req.imperativeId);
+            var principleCriterionJunction = principleCriterionRepository.findCriterion(req.criterionId, motivation.getId());
+
+            if (principleCriterionJunction.isEmpty()) {
+                resultMessages.add("criterion with id: " + req.criterionId + " is not related to principles");
+            } else {
+
+                var criterion = principleCriterionJunction.get().getCriterion();
+                var junction = criterionActorRepository.findByMotivationAndActorAndCriterion(motivationId, actorId, req.criterionId, 1);
+
+                if (junction.isPresent()) {
+
+                    var existingJunction = junction.get();
+
+                    if (!existingJunction.getImperative().equals(imperative)) {
+                        existingJunction.setImperative(imperative);
+                        existingJunction.setLastTouch(Timestamp.from(Instant.now()));
+                        existingJunction.setPopulatedBy(userId);
+                        resultMessages.add("criterion with id: " + criterion.getId() + " updated with new imperative for actor.");
+                    } else {
+                        resultMessages.add("criterion with id: " + criterion.getId() + " already exists with the same imperative");
+                    }
+                } else {
+                    generateAutoMetricForCriterion(motivationId, criterion.getId(), userId);
+                    actor.addCriterion(motivation, criterion, imperative, motivation.getId(), 1, userId, Timestamp.from(Instant.now()));
+                    resultMessages.add("criterion with id: " + criterion.getId() + " successfully added to actor");
+                }
+            }
+        });
+
+        return resultMessages;
+    }
+
+    private void generateAutoMetricForCriterion(String motivationId, String criterionId, String userId) {
+
+        boolean alreadyLinked = criterionMetricRepository.existsByMotivationAndCriterionAndVersion(motivationId, criterionId, 1);
+
+        if (alreadyLinked) {
+            return; // Skip metric generation
+        }
+
+        var createMetric = new MetricRequestDto();
+        createMetric.MTR = " ";
+        createMetric.labelMetric = " ";
+        createMetric.descrMetric = " ";
+        createMetric.criterion_id = criterionId;
+        createMetric.typeBenchmarkId = "pid_graph:7085006F";
+        createMetric.typeAlgorithmId = "pid_graph:AE39C968";
+        createMetric.typeMetricId = "pid_graph:8D79984F";
+        createMetric.valueBenchmark = "1";
+
+        var metric = motivationService.createMetricForMotivation(motivationId, createMetric, userId);
+
+        var criMtr = new MultipleCriterionMetricRequest();
+        criMtr.criterionId = criterionId;
+        criMtr.relation = "maintainedBy";
+        criMtr.metricId = metric.id;
+
+        criterionMetricService.createNewCriteriaMetricsRelationship(motivationId, Set.of(criMtr), userId);
+    }
+
+    private void removeCriteriaAndAutoMetric(Motivation motivation, RegistryActor actor, Set<CriterionActorRequest> request, List<String> resultMessages) {
+
+        var criterionIdsToKeep = request.stream()
+                .map(req -> req.criterionId)
+                .collect(Collectors.toSet());
+
+        var allLinked = criterionActorRepository.fetchCriteriaByMotivationAndActor(motivation.getId(), actor.getId());
+
+        for (var junction : allLinked) {
+            var criterion = junction.getCriterion();
+            if (!criterionIdsToKeep.contains(criterion.getId())) {
+
+                // Remove CriterionActorJunction
+                criterionActorRepository.delete(junction);
+                resultMessages.add("Criterion with id: " + criterion.getId() + " removed from actor");
+
+                // Check for metric linked to this criterion in this motivation
+                var cmJunctions = criterionMetricRepository.fetchCriterionMetricByMotivationAndCriterion(motivation.getId(), criterion.getId());
+
+                cmJunctions.ifPresent(cm -> {
+                    var metric = cm.getMetric();
+
+                    var expectedLabel = criterion.getLabel() + " Metric";
+                    var expectedDesc = "Metric created for \"" + motivation.getLabel() + "\" and used by \"" + criterion.getCri() + "\".";
+
+                    if (expectedLabel.equals(metric.getLabelMetric())
+                            && expectedDesc.equals(metric.getDescrMetric())) {
+
+                        criterionMetricRepository.delete(cm);
+                        metricRepository.delete(metric);
+                        resultMessages.add("Auto-generated metric " + metric.getId() + " removed along with its criterion.");
+                    }
+                });
+            }
+        }
     }
 
     private void removeCriteria(Motivation motivation, RegistryActor actor, Set<CriterionActorRequest> request, List<String> resultMessages) {


### PR DESCRIPTION
### Description
This PR introduces enhanced functionality for assigning criteria to actors within a Motivation, with automatic metric management. It includes both creation (POST) and update (PUT) endpoints:
- Automatically creates and links a simple metric when a new criterion is assigned.
- On update, it:
  - Updates the imperative if changed.
  - Removes old criteria not included in the update payload.
  - Cleans up auto-generated metrics when their associated criteria are removed.
----
### Endpoints: 

**POST /motivations/{id}/actors/{actor-id}/criteria/auto-metric**
- Automatically creates a simple metric for the selected criterion.
- Links the metric to the criterion using the maintainedBy relation.
- Assigns the criterion to the actor.

**PUT /motivations/{id}/actors/{actor-id}/criteria/auto-metric**
- Allows updating the imperative for an existing criterion-actor link.
- Adds new criteria, with auto-metric generation (same as POST).
- Removes previously assigned criteria that are not included in the payload.
  - If a removed criterion has an auto-generated metric, that metric and its link are also deleted.


----
### Metric Configuration
Each auto-created metric uses:
- Type Metric: Binary (pid_graph:8D79984F)
- Type Algorithm: Simple Sum (pid_graph:AE39C968)
- Type Benchmark: Binary-Binary (pid_graph:7085006F)
- Benchmark Value: 1
- Label: Derived from criterion, e.g. "\"criterionLabel\" Metric"
- Description: "Metric created for \"motivationLabel\" and used by \"CRI\"."

----
### How to Test

1. Go to the Registry and create a new Criterion.
2. Create a new Motivation
3. Assign a Principle to Criterion from the endpoint: /v1/registry/motivations/{id}/principles-criteria (or the "old" way)
4. Add actor to motivation
5. Use the new endpoint: POST /motivations/{motivationId}/actors/{actorId}/criteria/auto-metric with the criterion ID and imperative ID.
6. Open the Assessment Builder and check that:
 -The criterion appears under the actor.
 -A metric is already created and linked.
