### PR TITLE
CAT-982: Minor Fixes for Assessment Build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,7 @@ According to [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) , the `Unr
 - [#534]()https://github.com/FC4E-CAT/fc4e-cat-api/pull/534 CAT-976 Change ROR path to /v1/organizations
 - [#535](https://github.com/FC4E-CAT/fc4e-cat-api/pull/535) CAT-888 Update view for Tests (friendly label Testmethod)
 - [#536](https://github.com/FC4E-CAT/fc4e-cat-api/pull/536) CAT-981 Change num_params of Binary-Evidence Testmethod from 2 to 1
+- [#537](https://github.com/FC4E-CAT/fc4e-cat-api/pull/537) CAT-982: Minor Fixes for Assessment Build
 
 
 ## 2.0.0 - 2025-03-31

--- a/data-transfer-object/src/main/java/org/grnet/cat/dtos/registry/criterion/CriterionRequest.java
+++ b/data-transfer-object/src/main/java/org/grnet/cat/dtos/registry/criterion/CriterionRequest.java
@@ -1,5 +1,6 @@
 package org.grnet.cat.dtos.registry.criterion;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.validation.constraints.NotEmpty;
 import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
@@ -7,7 +8,6 @@ import org.eclipse.microprofile.openapi.annotations.media.Schema;
 import org.grnet.cat.constraints.NotFoundEntity;
 import org.grnet.cat.repositories.registry.CriterionRepository;
 import org.grnet.cat.repositories.registry.ImperativeRepository;
-import org.grnet.cat.repositories.registry.MotivationRepository;
 import org.grnet.cat.repositories.registry.TypeCriterionRepository;
 
 @Schema(name = "CriterionRequest", description = "This object represents the data required to create a Criterion.")
@@ -78,6 +78,16 @@ public class CriterionRequest {
     )
     @JsonProperty("url")
     public String url;
+
+    @Schema(
+            type = SchemaType.STRING,
+            implementation = String.class,
+            description = "Motivation id",
+            example = "pid_graph:3E109B2E"
+    )
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    @JsonProperty(value = "motivation_id")
+    public String lodMTV;
 
     @Schema(
             type = SchemaType.STRING,

--- a/data-transfer-object/src/main/java/org/grnet/cat/dtos/registry/template/AssessmentTypeTestNode.java
+++ b/data-transfer-object/src/main/java/org/grnet/cat/dtos/registry/template/AssessmentTypeTestNode.java
@@ -6,9 +6,10 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import lombok.Getter;
 import lombok.Setter;
 
+import java.sql.Timestamp;
 import java.util.List;
 
-@JsonPropertyOrder({ "db_id", "id", "name", "description", "text", "param", "tooltip", "type_db_id", "type", "value", "result", "evidence_url"})
+@JsonPropertyOrder({ "db_id", "id", "name", "description", "text", "param", "tooltip", "type_db_id", "type", "value", "result", "evidence_url", "metric_test_created_on"})
 @Getter
 @Setter
 public class AssessmentTypeTestNode extends TemplateTestNode{
@@ -21,9 +22,38 @@ public class AssessmentTypeTestNode extends TemplateTestNode{
     @JsonInclude(JsonInclude.Include.NON_NULL)
     private String lodTME;
 
+    @JsonProperty("metric_test_created_on")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private Timestamp metricTestCreatedOn;
+
     public AssessmentTypeTestNode(String lodTES, String id, String name, String description, String lodTME, String type, List<String> urls, String text, String params, String toolTip) {
         super(id, name, description, type, urls, text, params, toolTip);
         this.lodTES = lodTES;
         this.lodTME = lodTME;
+    }
+
+    @Override
+    public int compareTo(Node other) {
+        if (other instanceof AssessmentTypeTestNode) {
+            AssessmentTypeTestNode o = (AssessmentTypeTestNode) other;
+            Timestamp a = this.getMetricTestCreatedOn();
+            Timestamp b = o.getMetricTestCreatedOn();
+
+            // Sort by metricTestCreatedOn DESC (newest first)
+            if (a != null && b != null) {
+                int cmp = b.compareTo(a);
+                if (cmp != 0) return cmp;
+            } else if (a != null) {
+                return -1; // this first if other has null date
+            } else if (b != null) {
+                return 1;  // this after if this has null date
+            }
+
+            // Fallback: ID ascending
+            return this.getId().compareTo(o.getId());
+        }
+
+        // Different Node types fallback to ID comparison
+        return super.compareTo(other);
     }
 }

--- a/entity/src/main/java/org/grnet/cat/entities/registry/AssessmentTypeTemplate.java
+++ b/entity/src/main/java/org/grnet/cat/entities/registry/AssessmentTypeTemplate.java
@@ -5,6 +5,7 @@ import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.Setter;
 
+import java.sql.Timestamp;
 import java.util.UUID;
 
 @Getter
@@ -55,6 +56,9 @@ public class AssessmentTypeTemplate {
     private String testQuestion;
     private String testParams;
     private String toolTip;
+
+    @Column(name = "metric_test_created_on")
+    private Timestamp metricTestCreatedOn;
 
     private String mt_mtv;
     private String cm_mtv;

--- a/entity/src/main/java/org/grnet/cat/entities/registry/MetricTestJunction.java
+++ b/entity/src/main/java/org/grnet/cat/entities/registry/MetricTestJunction.java
@@ -41,6 +41,16 @@ public class MetricTestJunction extends Registry{
     @NotNull
     private Relation relation;
 
+    @Column(name = "created_on")
+    private Timestamp metricTestCreatedOn;
+
+    @PrePersist
+    protected void onCreate() {
+        if (metricTestCreatedOn == null) {
+            metricTestCreatedOn = Timestamp.from(Instant.now());
+        }
+    }
+
     public MetricTestJunction(Motivation motivation, Metric metric, Test test, Relation relation, String motivationX, Integer lodMTTDV) {
 
         this.motivation = motivation;

--- a/entity/src/main/resources/db/migration/tables/registry/V1.91__metric_test_add_colum.sql
+++ b/entity/src/main/resources/db/migration/tables/registry/V1.91__metric_test_add_colum.sql
@@ -1,0 +1,13 @@
+-- ------------------------------------------------
+-- Version: v1.91
+--
+-- Description: Adds a `created_on` column to `p_metric_test` table
+-- ------------------------------------------------
+
+ALTER TABLE p_metric_test
+ADD COLUMN created_on TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP;
+
+UPDATE p_metric_test
+SET created_on = lasttouch
+WHERE created_on IS NULL;
+

--- a/entity/src/main/resources/db/migration/tables/registry/V1.92__registry_template_flexible_v3.sql
+++ b/entity/src/main/resources/db/migration/tables/registry/V1.92__registry_template_flexible_v3.sql
@@ -1,0 +1,85 @@
+-- ------------------------------------------------
+-- Version: v1.92
+--
+-- Description: Recreates the `assessment_type_template` view to support. This updated view includes additional fields such as `metric_test_created_on`
+-- ------------------------------------------------
+
+DROP VIEW IF EXISTS assessment_type_template;
+
+CREATE VIEW assessment_type_template AS
+SELECT
+    p.lodpri,
+    p.pri,
+    p.labelprinciple,
+    p.descprinciple,
+
+    c,lodcri,
+    c.cri,
+    c.labelcriterion,
+    c.desccriterion,
+
+    m.lodmtr,
+    m.mtr,
+    m.labelmetric,
+
+    ta.lodtal,
+    ta.labelalgorithmtype,
+    ttm.lodtmt,
+    ttm.labeltypemetric,
+
+    t.tes,
+    t.lodtes,
+    t.labeltest,
+    t.desctest,
+    t.testquestion,
+    t.testparams,
+    t.tooltip,
+
+    m.valuebenchmark,
+    mt.created_on AS metric_test_created_on,
+    tb.lodtbn,
+    tb.labelbenchmarktype,
+
+    pc.motivation_lodmtv AS principle_criterion_motivation_id,
+    ca.actor_lodactor AS lodactor,
+    i.labelimperative,
+
+    tm.lodtme,
+    tm.labeltestmethod,
+
+    mt.motivation_lodmtv AS mt_mtv,
+    cm.motivation_lodmtv AS cm_mtv,
+    ca.motivation_lodmtv AS ca_mtv,
+
+    md5(
+        COALESCE(p.lodpri, '') ||
+        COALESCE(c.lodcri, '') ||
+        COALESCE(m.lodmtr, '') ||
+        COALESCE(t.lodtes, '') ||
+        COALESCE(ca.actor_lodactor, '') ||
+        COALESCE(pc.motivation_lodmtv, '')
+      )::uuid AS lod_id
+
+FROM p_principle_criterion pc
+JOIN p_principle p ON pc.principle_lodpri::text = p.lodpri::text
+JOIN p_criterion c ON pc.criterion_lodcri::text = c.lodcri::text
+JOIN p_criterion_actor ca ON ca.criterion_lodcri::text = c.lodcri::text
+
+LEFT JOIN s_imperative i ON ca.imperative_lodimp::text = i.lodimp::text
+
+LEFT JOIN p_criterion_metric cm
+    ON cm.criterion_lodcri::text = c.lodcri::text
+    AND cm.motivation_lodmtv::text = pc.motivation_lodmtv::text
+
+LEFT JOIN p_metric m ON cm.metric_lodmtr::text = m.lodmtr::text
+LEFT JOIN t_type_benchmark tb ON m.lodtbn::text = tb.lodtbn::text
+LEFT JOIN t_type_algorithm ta ON m.lodtal::text = ta.lodtal::text
+LEFT JOIN t_type_metric ttm ON m.lodtmt::text = ttm.lodtmt::text
+
+LEFT JOIN p_metric_test mt
+    ON mt.metric_lodmtr::text = m.lodmtr::text
+    AND mt.motivation_lodmtv::text = pc.motivation_lodmtv::text
+
+LEFT JOIN p_test t ON mt.test_lodtes::text = t.lodtes::text
+LEFT JOIN t_testmethod tm ON t.lodtme::text = tm.lodtme::text;
+

--- a/service/src/main/java/org/grnet/cat/services/TemplateService.java
+++ b/service/src/main/java/org/grnet/cat/services/TemplateService.java
@@ -214,12 +214,13 @@ public class TemplateService {
 
                         if (row.getLabelTestMethod().contains("Evidence")) {
 
-                            tn = new AssessmentTypeTestNode(k, row.getTES(), row.getLabelTest().trim(), row.getDescTest().trim(), row.getLodTMT(), row.getLabelTestMethod().trim(), new ArrayList<>(), row.getTestQuestion(), TestParamsTransformer.transformTestParams(row.getTestParams()), row.getToolTip());
+                            tn = new AssessmentTypeTestNode(k, row.getTES(), row.getLabelTest().trim(), row.getDescTest().trim(), row.getLodTME(), row.getLabelTestMethod().trim(), new ArrayList<>(), row.getTestQuestion(), TestParamsTransformer.transformTestParams(row.getTestParams()), row.getToolTip());
                         } else {
 
-                            tn = new AssessmentTypeTestNode(k, row.getTES(), row.getLabelTest().trim(), row.getDescTest().trim(), row.getLodTMT(), row.getLabelTestMethod().trim(), null, row.getTestQuestion(), TestParamsTransformer.transformTestParams(row.getTestParams()), row.getToolTip());
+                            tn = new AssessmentTypeTestNode(k, row.getTES(), row.getLabelTest().trim(), row.getDescTest().trim(), row.getLodTME(), row.getLabelTestMethod().trim(), null, row.getTestQuestion(), TestParamsTransformer.transformTestParams(row.getTestParams()), row.getToolTip());
                         }
 
+                        tn.setMetricTestCreatedOn(row.getMetricTestCreatedOn());
                         return tn;
                     });
                     if (!mtrNode.getChildren().contains(testNode)) {

--- a/service/src/main/java/org/grnet/cat/services/registry/CriterionService.java
+++ b/service/src/main/java/org/grnet/cat/services/registry/CriterionService.java
@@ -104,6 +104,10 @@ public class CriterionService {
         criteria.setImperative(Panache.getEntityManager().getReference(Imperative.class, criteriaRequestDto.imperative));
         criteria.setTypeCriterion(Panache.getEntityManager().getReference(TypeCriterion.class, criteriaRequestDto.typeCriterion));
 
+        if (!(criteriaRequestDto.lodMTV == null)) {
+            criteria.setLodMTV(criteriaRequestDto.lodMTV);
+        }
+
         criteriaRepository.persist(criteria);
 
         criteria.setLodCriP(criteria.getId());

--- a/service/src/main/java/org/grnet/cat/services/registry/MotivationService.java
+++ b/service/src/main/java/org/grnet/cat/services/registry/MotivationService.java
@@ -813,6 +813,7 @@ public class MotivationService {
 
         metricTest.setPopulatedBy(userId);
         metricTest.setLastTouch(Timestamp.from(Instant.now()));
+        // createdOn will be set automatically by @PrePersist in the entity
 
         metricTestRepository.persist(metricTest);
 


### PR DESCRIPTION
#### Description
This PR implements several targeted fixes to improve the Assessment Build process.

------
#### Changes
- Order tests by creation date (descending)
  -   Tests are now consistently displayed newest-to-oldest, based on the created_on field in the metric–test relationship.
- Correct lodTME value for tests
  - Fixed an issue where lodTME was incorrectly populated with lodTMT.
  - Now returns the correct lodTME from the associated test method.
- Add motivation_id on criteria request
  - Fixed missing motivation_id on criterion creation requests to ensure the link to the correct motivation is always set.