### PR TITLE
CAT-665: Deletion in CAT

### DIFF
--- a/api/src/main/java/org/grnet/cat/api/endpoints/registry/MotivationEndpoint.java
+++ b/api/src/main/java/org/grnet/cat/api/endpoints/registry/MotivationEndpoint.java
@@ -396,6 +396,71 @@ public class MotivationEndpoint {
 
         return Response.created(serverInfo.getAbsolutePathBuilder().path(String.valueOf(motivation.id)).build()).entity(motivation).build();
     }
+    @DELETE
+    @Path("/{id}")
+    @Produces(MediaType.APPLICATION_JSON)
+    @Tag(name = "Motivation")
+    @Operation(
+            summary = "Delete a Motivation and clean up unused entities.",
+            description = "Deletes a Motivation and any associated entities not used elsewhere."
+    )
+    @APIResponse(
+            responseCode = "200",
+            description = "Motivation deleted successfully.",
+            content = @Content(schema = @Schema(
+                    type = SchemaType.OBJECT,
+                    implementation = InformativeResponse.class)))
+    @APIResponse(
+            responseCode = "400",
+            description = "Invalid request payload.",
+            content = @Content(schema = @Schema(
+                    type = SchemaType.OBJECT,
+                    implementation = InformativeResponse.class)))
+    @APIResponse(
+            responseCode = "401",
+            description = "User has not been authenticated.",
+            content = @Content(schema = @Schema(
+                    type = SchemaType.OBJECT,
+                    implementation = InformativeResponse.class)))
+    @APIResponse(
+            responseCode = "403",
+            description = "Not permitted.",
+            content = @Content(schema = @Schema(
+                    type = SchemaType.OBJECT,
+                    implementation = InformativeResponse.class)))
+    @APIResponse(
+            responseCode = "409",
+            description = "Motivation already exists.",
+            content = @Content(schema = @Schema(
+                    type = SchemaType.OBJECT,
+                    implementation = InformativeResponse.class)))
+    @APIResponse(
+            responseCode = "500",
+            description = "Internal Server Error.",
+            content = @Content(schema = @Schema(
+                    type = SchemaType.OBJECT,
+                    implementation = InformativeResponse.class)))
+    @SecurityRequirement(name = "Authentication")
+    @Registration
+    public Response deleteMotivation(
+            @Parameter(description = "The ID of the Motivation to delete.",
+                    required = true,
+                    example = "pid_graph:64E8FACF",
+                    schema = @Schema(type = SchemaType.STRING))
+            @PathParam("id")
+            @Valid
+            @NotFoundEntity(repository = MotivationRepository.class, message = "There is no Motivation with the following id:")
+            @CheckPublished(repository = MotivationRepository.class, message = "No action permitted for published Motivation with the following id:", isPublishedPermitted = false)
+            String id) {
+
+        var result = motivationService.deleteMotivation(id);
+
+        var informativeResponse = new InformativeResponse();
+        informativeResponse.code = 200;
+        informativeResponse.message = result;
+
+        return Response.ok().entity(informativeResponse).build();
+    }
 
     @Tag(name = "Motivation")
     @Operation(

--- a/entity/src/main/resources/db/migration/tables/registry/V1.95__delete_motivation_and_cleanup_stored_procedure.sql
+++ b/entity/src/main/resources/db/migration/tables/registry/V1.95__delete_motivation_and_cleanup_stored_procedure.sql
@@ -1,0 +1,74 @@
+-- ------------------------------------------------
+-- Version: v1.95
+--
+-- Description: Stored Procedure to delete a Motivation and related assignments,
+--              and cleanup orphaned principles, criteria, metrics, and tests.
+-- ------------------------------------------------
+
+CREATE OR REPLACE PROCEDURE DeleteMotivationAndCleanup(
+    targetMotivationId VARCHAR
+)
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    -- Delete all metric-test relations for this motivation
+    DELETE FROM p_Metric_Test
+    WHERE motivation_lodMTV = targetMotivationId;
+
+    -- Delete all criterion-metric relations for this motivation
+    DELETE FROM p_Criterion_Metric
+    WHERE motivation_lodMTV = targetMotivationId;
+
+    -- Delete all criterion-actor relations for this motivation
+    DELETE FROM p_Criterion_Actor
+    WHERE motivation_lodMTV = targetMotivationId;
+
+    -- Delete all principle-criterion relations for this motivation
+    DELETE FROM p_Principle_Criterion
+    WHERE motivation_lodMTV = targetMotivationId;
+
+    -- Delete all actor assignments for this motivation
+    DELETE FROM t_Motivation_Actor
+    WHERE motivation_lodMTV = targetMotivationId;
+
+    -- Delete the motivation itself
+    DELETE FROM t_Motivation
+    WHERE lodMTV = targetMotivationId;
+
+    -- Cleanup orphaned tests
+    DELETE FROM p_Test
+    WHERE lodTES NOT IN (
+        SELECT test_lodTES FROM p_Metric_Test
+    );
+
+    -- Cleanup orphaned metrics
+    DELETE FROM p_Metric
+    WHERE lodMTR NOT IN (
+        SELECT metric_lodMTR FROM p_Criterion_Metric
+        UNION
+        SELECT metric_lodMTR FROM p_Metric_Test
+    );
+
+    -- Cleanup orphaned criteria
+    DELETE FROM p_Criterion
+    WHERE lodCRI NOT IN (
+        SELECT criterion_lodCRI FROM p_Criterion_Actor
+        UNION
+        SELECT criterion_lodCRI FROM p_Criterion_Metric
+        UNION
+        SELECT criterion_lodCRI FROM p_Principle_Criterion
+    );
+
+    -- Cleanup orphaned principles
+    DELETE FROM p_Principle
+    WHERE lodPRI NOT IN (
+        SELECT principle_lodPRI FROM p_Principle_Criterion
+        UNION
+        SELECT principle_lodPRI FROM p_Motivation_Principle
+    );
+
+EXCEPTION
+    WHEN OTHERS THEN
+        RAISE EXCEPTION 'Error while deleting motivation: %', SQLERRM;
+END;
+$$;

--- a/repository/src/main/java/org/grnet/cat/repositories/MotivationAssessmentRepository.java
+++ b/repository/src/main/java/org/grnet/cat/repositories/MotivationAssessmentRepository.java
@@ -548,4 +548,10 @@ public class MotivationAssessmentRepository implements Repository<MotivationAsse
         return pageable;
     }
 
+    public boolean existsByMotivationId(String motivationId) {
+        return find("motivation.id = ?1", motivationId)
+                .firstResultOptional()
+                .isPresent();
+    }
+
 }

--- a/service/src/main/java/org/grnet/cat/services/registry/MotivationService.java
+++ b/service/src/main/java/org/grnet/cat/services/registry/MotivationService.java
@@ -3,6 +3,7 @@ package org.grnet.cat.services.registry;
 import io.quarkus.hibernate.orm.panache.Panache;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
+import jakarta.persistence.EntityManager;
 import jakarta.persistence.EntityNotFoundException;
 import jakarta.transaction.Transactional;
 import jakarta.ws.rs.ForbiddenException;
@@ -22,6 +23,7 @@ import org.grnet.cat.dtos.registry.principle.PrincipleResponseDto;
 import org.grnet.cat.dtos.registry.principle.PrincipleUpdateDto;
 import org.grnet.cat.dtos.registry.template.MetricNode;
 import org.grnet.cat.dtos.registry.template.MetricTestNode;
+import org.grnet.cat.entities.MotivationAssessment;
 import org.grnet.cat.entities.registry.*;
 import org.grnet.cat.entities.registry.metric.Metric;
 import org.grnet.cat.entities.registry.metric.TypeAlgorithm;
@@ -32,6 +34,7 @@ import org.grnet.cat.mappers.registry.MotivationMapper;
 import org.grnet.cat.mappers.registry.PrincipleCriterionMapper;
 import org.grnet.cat.mappers.registry.PrincipleMapper;
 import org.grnet.cat.mappers.registry.metric.MetricMapper;
+import org.grnet.cat.repositories.MotivationAssessmentRepository;
 import org.grnet.cat.repositories.registry.*;
 import org.grnet.cat.repositories.registry.metric.MetricRepository;
 import org.grnet.cat.utils.TestParamsTransformer;
@@ -56,6 +59,9 @@ public class MotivationService {
 
     @Inject
     MotivationRepository motivationRepository;
+
+    @Inject
+    MotivationAssessmentRepository motivationAssessmentRepository;
 
     @Inject
     MotivationTypeRepository motivationTypeRepository;
@@ -353,8 +359,16 @@ public class MotivationService {
     }
 
 
+    @Transactional
+    public String deleteMotivation(String motivationId) {
 
+        if (motivationAssessmentRepository.existsByMotivationId(motivationId)) {
+            throw new ForbiddenException("No action permitted, motivation is used in an existing assessment.");
+        }
 
+        relationsService.deleteMotivationAndCleanup(motivationId);
+        return "Motivation " + motivationId + " and all unused elements were deleted successfully.";
+    }
 
 
     /**

--- a/service/src/main/java/org/grnet/cat/services/registry/RelationsService.java
+++ b/service/src/main/java/org/grnet/cat/services/registry/RelationsService.java
@@ -91,6 +91,20 @@ public class RelationsService {
         }
     }
 
+    @Transactional
+    public void deleteMotivationAndCleanup(String motivationId) {
+        try {
+            entityManager
+                    .createNativeQuery("CALL DeleteMotivationAndCleanup(:motivationId)")
+                    .setParameter("motivationId", motivationId)
+                    .executeUpdate();
+        } catch (PersistenceException e) {
+            if (e.getCause() instanceof SQLException) {
+                throw new InternalServerErrorException(e.getCause().getMessage(), 500);
+            }
+        }
+    }
+
     @Setter
     @Getter
     public static class RelationsResponse {


### PR DESCRIPTION
### Despription:
This PR implements the ability to delete a Motivation and all unused related elements via a new API endpoint, backed by a stored procedure. Deletion is blocked if the Motivation is used in any assessment or already published.

----
### API Endpoint
Method: DELETE /v1/motivations/{id}

----
### Stored Procedure: DeleteMotivationAndCleanup(motivationId)
Deletes all associated junctions:
* MotivationActor
* ActorCriterion
* PrincipleCriterion
* CriterionMetric
* MetricTest

Deletes orphaned entities (only if not used elsewhere):
* Principles
* Criteria
* Metrics
* Tests

Deletes the Motivation entity itself.

> **Note:** Actors are never deleted, even if unused.