### PR TITLE
CAT-1005 Updating zenodo key on the fly in settings is not retrieved in service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,7 @@ According to [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) , the `Unr
 - [#535](https://github.com/FC4E-CAT/fc4e-cat-api/pull/535) CAT-888 Update view for Tests (friendly label Testmethod)
 - [#536](https://github.com/FC4E-CAT/fc4e-cat-api/pull/536) CAT-981 Change num_params of Binary-Evidence Testmethod from 2 to 1
 - [#537](https://github.com/FC4E-CAT/fc4e-cat-api/pull/537) CAT-982: Minor Fixes for Assessment Build
+- [#542](https://github.com/FC4E-CAT/fc4e-cat-api/pull/542) CAT-1005 Updating zenodo key on the fly in settings is not retrieved in service
 
 
 ## 2.0.0 - 2025-03-31

--- a/service/src/main/java/org/grnet/cat/services/zenodo/ZenodoService.java
+++ b/service/src/main/java/org/grnet/cat/services/zenodo/ZenodoService.java
@@ -80,6 +80,10 @@ public class ZenodoService {
 
 
     public String getAccessToken() {
+        API_KEY = Optional.ofNullable(settingService
+                .getSettingValueOrDefault("zenodo.api.key", () -> API_KEY.orElse(null))
+                .orElseThrow(() -> new IllegalStateException("Zenodo API key is not configured.")));
+
         return "Bearer " + API_KEY.orElseThrow(() ->
                 new IllegalStateException("Zenodo API key is missing.")
         );
@@ -91,10 +95,7 @@ public class ZenodoService {
 
     @PostConstruct
     void init() {
-        API_KEY = Optional.ofNullable(settingService
-                .getSettingValueOrDefault("zenodo.api.key", () -> API_KEY.orElse(null))
-                .orElseThrow(() -> new IllegalStateException("Zenodo API key is not configured.")));
-
+       getAccessToken();
     }
 
     @ShareableEntity(type = ShareableEntityType.ASSESSMENT, id = String.class)
@@ -343,6 +344,7 @@ public class ZenodoService {
         final AtomicReference<String> depositIdRef = new AtomicReference<>(null);
         final AtomicReference<ZenodoAssessmentInfo> zenodoAssessmentInfoRef = new AtomicReference<>(null);
         String accessToken = getAccessToken();
+        System.out.println("*** The access token is : "+accessToken);
         return CompletableFuture
                 .supplyAsync(() -> {
                     // Step 1: Preparation of assessment for Zenodo


### PR DESCRIPTION
fix to update zenodo key on the fly after service is loaded 