### PR TITLE
CAT-1006 Admin actions should force signout user from CAT Service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,7 +49,9 @@ According to [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) , the `Unr
 - [#531](https://github.com/FC4E-CAT/fc4e-cat-api/pull/531) CAT-970 Create and Link Metric to Criterion When Assigned to Actor
 - [#538](https://github.com/FC4E-CAT/fc4e-cat-api/pull/538) Sort Principles and Criteria from Newest to Oldest in Assessment Type Template
 - [#540](https://github.com/FC4E-CAT/fc4e-cat-api/pull/540) CAT-1000: Create Settings Table and Override Zenodo Configuration
--[#541](https://github.com/FC4E-CAT/fc4e-cat-api/pull/541) CAT-977: 2025-07-30 Default response to API requests is now version 2
+- [#541](https://github.com/FC4E-CAT/fc4e-cat-api/pull/541) CAT-977: 2025-07-30 Default response to API requests is now version 2
+- [#510](https://github.com/FC4E-CAT/fc4e-cat-api/pull/510) CAT-809 Should not be able to edit published assessment
+
 
 ### Fix
 - [#482](https://github.com/FC4E-CAT/fc4e-cat-api/pull/482) CAT-867: Update Auto-AAI-Check-Entitlements tests parameters

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,7 @@ According to [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) , the `Unr
 - [#536](https://github.com/FC4E-CAT/fc4e-cat-api/pull/536) CAT-981 Change num_params of Binary-Evidence Testmethod from 2 to 1
 - [#537](https://github.com/FC4E-CAT/fc4e-cat-api/pull/537) CAT-982: Minor Fixes for Assessment Build
 - [#542](https://github.com/FC4E-CAT/fc4e-cat-api/pull/542) CAT-1005 Updating zenodo key on the fly in settings is not retrieved in service
+- [#543](https://github.com/FC4E-CAT/fc4e-cat-api/pull/543) CAT-1006:Admin actions should force signout user from CAT Service
 
 
 ## 2.0.0 - 2025-03-31

--- a/api/src/main/java/org/grnet/cat/api/endpoints/AssessmentsV2Endpoint.java
+++ b/api/src/main/java/org/grnet/cat/api/endpoints/AssessmentsV2Endpoint.java
@@ -22,6 +22,7 @@ import org.eclipse.microprofile.openapi.annotations.security.SecurityRequirement
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
 import org.grnet.cat.api.filters.Registration;
 import org.grnet.cat.api.utils.CatServiceUriInfo;
+import org.grnet.cat.constraints.CheckPublished;
 import org.grnet.cat.constraints.NotFoundEntity;
 import org.grnet.cat.dtos.InformativeResponse;
 import org.grnet.cat.dtos.assessment.registry.AdminJsonRegistryAssessmentResponse;
@@ -334,7 +335,8 @@ public class AssessmentsV2Endpoint {
                                              example = "c242e43f-9869-4fb0-b881-631bc5746ec0",
                                              schema = @Schema(type = SchemaType.STRING))
                                      @PathParam("id")
-                                     @Valid @NotFoundEntity(repository = MotivationAssessmentRepository.class, message = "There is no assessment with the following id:") String id,
+                                     @Valid @NotFoundEntity(repository = MotivationAssessmentRepository.class, message = "There is no assessment with the following id:")
+                                     @CheckPublished(repository = MotivationAssessmentRepository.class, message = "No action permitted for published Assessment with the following id:", isPublishedPermitted = false) String id,
                                      @Valid @NotNull(message = "The request body is empty.") JsonRegistryAssessmentRequest request) {
 
         var assessment = assessmentService.updatePrivateAssessment(id, request);

--- a/api/src/main/java/org/grnet/cat/api/endpoints/RolesEndpoint.java
+++ b/api/src/main/java/org/grnet/cat/api/endpoints/RolesEndpoint.java
@@ -148,7 +148,7 @@ public class RolesEndpoint {
     @Registration
     public Response assignRolesToUser(@Valid @NotNull(message = "The request body is empty.") RoleAssignmentRequest request) {
 
-        roleService.assignRolesToUser(request.userId, request.roles);
+        roleService.assignRolesToUser(request.userId, request.roles, Boolean.TRUE);
 
         var response = new InformativeResponse();
         response.code = 200;

--- a/api/src/main/resources/application.properties
+++ b/api/src/main/resources/application.properties
@@ -138,7 +138,7 @@ quarkus.health.openapi.included=true
 
 quarkus.rest-client."org.grnet.cat.api.health.AAIProxyClient".url=${QUARKUS_OIDC_AUTH_SERVER_URL:https://login-devel.einfra.grnet.gr/auth/realms/einfra}
 
-zenodo.api.key=MY_ACCESS_TOKEN
+zenodo.api.key=qpJN67QwE6jha76KPIKuOyZZyJkr6YKcqTNRraBMHUV3ZNiJaWkxyme9tREL
 quarkus.rest-client."org.grnet.cat.services.zenodo.ZenodoClient".url=https://sandbox.zenodo.org
 zenodo.enabled=true
 

--- a/api/src/test/java/org/grnet/cat/api/AssessmentsEndpointTest.java
+++ b/api/src/test/java/org/grnet/cat/api/AssessmentsEndpointTest.java
@@ -824,4 +824,59 @@ public class AssessmentsEndpointTest extends KeycloakTest {
                 .as(UserJsonRegistryAssessmentResponse.class);
         assertEquals(assessment.id, publicAssessment.id);
     }
+
+    @Test
+    public void editPublishedAssessment() throws IOException {
+
+        //register("validated");
+        //register("admin");
+        //register("evald");
+
+        //makeValidation("validated", "pid_graph:B5CC396B");
+
+        var requestAssessment = new JsonRegistryAssessmentRequest();
+        requestAssessment.assessmentDoc = makeRegistryJsonDoc();
+
+        var assessment = given()
+                .auth()
+                .oauth2(validatedToken)
+                .basePath("/v2/assessments")
+                .body(requestAssessment)
+                .contentType(ContentType.JSON)
+                .post()
+                .then()
+                .assertThat()
+                .statusCode(201)
+                .extract()
+                .as(UserJsonRegistryAssessmentResponse.class);
+
+        var response = given()
+                .auth()
+                .oauth2(validatedToken)
+                .basePath("/v2/assessments/")
+                .put("/{id}/publish", assessment.id)
+                .then()
+                .assertThat()
+                .statusCode(200)
+                .extract()
+                .as(InformativeResponse.class);
+
+        var response1 = given()
+                .auth()
+                .oauth2(validatedToken)
+                .basePath("/v2/assessments/")
+                .body(requestAssessment)
+                .contentType(ContentType.JSON)
+                .put("/{id}", assessment.id)
+                .then()
+                .assertThat()
+                .statusCode(400)
+                .extract()
+                .as(InformativeResponse.class);
+
+        assertEquals(400, response1.code);
+        assertEquals("No action permitted for published Assessment with the following id: "+assessment.id, response1.message);
+
+        }
+
 }

--- a/api/src/test/java/org/grnet/cat/api/ValidationsEndpointTest.java
+++ b/api/src/test/java/org/grnet/cat/api/ValidationsEndpointTest.java
@@ -231,7 +231,7 @@ public class ValidationsEndpointTest extends KeycloakTest {
     @Test
     @Execution(ExecutionMode.CONCURRENT)
     public void updateValidationRequestStatusByAdmin() {
-        doNothing().when(keycloakAdminRoleService).assignRolesToUser(any(), any());
+        doNothing().when(keycloakAdminRoleService).assignRolesToUser(any(), any(), Boolean.TRUE);
 
         var request = createValidationRequest("Manager Alice", "ROR", "Keimyung University", "https://ror.org/00tjv0s33", "pid_graph:0E00C332");
         var createdValidation = performValidationRequest(request, aliceToken);
@@ -258,7 +258,7 @@ public class ValidationsEndpointTest extends KeycloakTest {
     @Test
     @Execution(ExecutionMode.CONCURRENT)
     public void updateValidationRequestStatusToRejectedByAdmin() {
-        doNothing().when(keycloakAdminRoleService).assignRolesToUser(any(), any());
+        doNothing().when(keycloakAdminRoleService).assignRolesToUser(any(), any(), Boolean.TRUE);
 
         var request = createValidationRequest("Manager", "ROR", "Keimyung University", "https://ror.org/00tjv0s33", "pid_graph:1A718108");
         var createdValidation = performValidationRequest(request, aliceToken);

--- a/repository/src/main/java/org/grnet/cat/repositories/KeycloakAdminRepository.java
+++ b/repository/src/main/java/org/grnet/cat/repositories/KeycloakAdminRepository.java
@@ -12,6 +12,7 @@ import org.grnet.cat.exceptions.EntityNotFoundException;
 import org.grnet.cat.repositories.utils.PaginationUtils;
 import org.jboss.logging.Logger;
 import org.keycloak.admin.client.Keycloak;
+import org.keycloak.representations.idm.RoleRepresentation;
 import org.keycloak.representations.idm.UserRepresentation;
 
 import java.util.Collections;
@@ -103,36 +104,89 @@ public class KeycloakAdminRepository implements RoleRepository {
      * @param userId The unique identifier of the user. to assign roles to.
      * @param roles  The roles to be assigned to the user.
      */
+//    @Override
+//    public void assignRoles(String userId, List<String> roles,boolean forceSignOut) {
+//
+//        try {
+//
+//            var realmResource = keycloak.realm(realm);
+//
+//            var clientRepresentation = realmResource.clients().findByClientId(clientId).stream().findFirst().get();
+//
+//            var clientResource = realmResource.clients().get(clientRepresentation.getId());
+//
+//            var usersResource = realmResource.users();
+//
+//            var userRepresentation = realmResource.users().searchByAttributes(String.format("%s:%s", attribute, userId)).stream().findFirst().get();
+//
+//            var userResource = usersResource.get(userRepresentation.getId());
+//
+//            var rolesRepresentations = roles
+//                    .stream()
+//                    .map(role -> clientResource.roles().get(role).toRepresentation())
+//                    .collect(Collectors.toList());
+//
+//
+//            userResource.roles().clientLevel(clientRepresentation.getId()).add(rolesRepresentations);
+//
+//            if(forceSignOut) {
+//                userResource.logout();
+//            }
+//        } catch (Exception e) {
+//
+//            LOG.error("A communication error occurred while assigning roles to the user.", e);
+//            throw new RuntimeException("A communication error occurred while assigning roles to the user.");
+//        }
+//    }
+
     @Override
-    public void assignRoles(String userId, List<String> roles) {
-
+    public void assignRoles(String userId, List<String> roles, boolean forceSignOut) {
         try {
-
             var realmResource = keycloak.realm(realm);
 
-            var clientRepresentation = realmResource.clients().findByClientId(clientId).stream().findFirst().get();
+            var clientRepresentation = realmResource.clients()
+                    .findByClientId(clientId)
+                    .stream()
+                    .findFirst()
+                    .orElseThrow(() -> new IllegalStateException("Client not found: " + clientId));
 
             var clientResource = realmResource.clients().get(clientRepresentation.getId());
 
-            var usersResource = realmResource.users();
-
-            var userRepresentation = realmResource.users().searchByAttributes(String.format("%s:%s", attribute, userId)).stream().findFirst().get();
-
-            var userResource = usersResource.get(userRepresentation.getId());
-
-
-            var rolesRepresentations = roles
+            var userRepresentation = realmResource.users()
+                    .searchByAttributes(String.format("%s:%s", attribute, userId))
                     .stream()
+                    .findFirst()
+                    .orElseThrow(() -> new IllegalStateException("User not found: " + userId));
+
+            var userResource = realmResource.users().get(userRepresentation.getId());
+
+            // get current roles
+            var existingRoles = userResource.roles()
+                    .clientLevel(clientRepresentation.getId())
+                    .listAll()
+                    .stream()
+                    .map(RoleRepresentation::getName)
+                    .collect(Collectors.toSet());
+
+            // filter only roles the user doesn’t already have
+            var newRoles = roles.stream()
+                    .filter(role -> !existingRoles.contains(role))
                     .map(role -> clientResource.roles().get(role).toRepresentation())
                     .collect(Collectors.toList());
 
+            if (!newRoles.isEmpty()) {
+                userResource.roles()
+                        .clientLevel(clientRepresentation.getId())
+                        .add(newRoles);
 
-            userResource.roles().clientLevel(clientRepresentation.getId()).add(rolesRepresentations);
+                if (forceSignOut) {
+                    userResource.logout();
+                }
+            }
 
         } catch (Exception e) {
-
             LOG.error("A communication error occurred while assigning roles to the user.", e);
-            throw new RuntimeException("A communication error occurred while assigning roles to the user.");
+            throw new RuntimeException("A communication error occurred while assigning roles to the user.", e);
         }
     }
 
@@ -161,7 +215,7 @@ public class KeycloakAdminRepository implements RoleRepository {
     }
 
     @Override
-    public void removeRoles(String userId, List<String> roles) {
+    public void removeRoles(String userId, List<String> roles, boolean forceSignOut) {
 
         try {
 
@@ -186,6 +240,9 @@ public class KeycloakAdminRepository implements RoleRepository {
             // Remove client level role from user
             userResource.roles().clientLevel(clientRepresentation.getId()).remove(rolesRepresentations);
 
+            if(forceSignOut){
+                userResource.logout();
+            }
         } catch (Exception e) {
 
             LOG.error("A communication error occurred while removing roles from the user.", e);

--- a/repository/src/main/java/org/grnet/cat/repositories/RoleRepository.java
+++ b/repository/src/main/java/org/grnet/cat/repositories/RoleRepository.java
@@ -35,7 +35,7 @@ public interface RoleRepository {
      * @param userId The unique identifier of the user to assign roles to.
      * @param roles  The roles to be assigned to the user.
      */
-    void assignRoles(String userId, List<String> roles);
+    void assignRoles(String userId, List<String> roles, boolean forceSignOut);
 
     /**
      * Removes roles from a user.
@@ -43,7 +43,7 @@ public interface RoleRepository {
      * @param userId The unique identifier of the user from whom the roles will be removed.
      * @param roles  The roles to be removed from the user.
      */
-    void removeRoles(String userId, List<String> roles);
+    void removeRoles(String userId, List<String> roles,boolean forceSignOut);
 
 
     /**

--- a/service/src/main/java/org/grnet/cat/services/KeycloakAdminRoleService.java
+++ b/service/src/main/java/org/grnet/cat/services/KeycloakAdminRoleService.java
@@ -54,10 +54,10 @@ public class KeycloakAdminRoleService implements RoleService {
      * @param roles  List of role names to be assigned to the user.
      */
     @Override
-    public void assignRolesToUser(String userId, List<String> roles) {
+    public void assignRolesToUser(String userId, List<String> roles,boolean forceSignOut) {
 
         roleRepository.doRolesExist(roles);
-        roleRepository.assignRoles(userId, roles);
+        roleRepository.assignRoles(userId, roles,forceSignOut);
     }
 
 

--- a/service/src/main/java/org/grnet/cat/services/RoleService.java
+++ b/service/src/main/java/org/grnet/cat/services/RoleService.java
@@ -24,6 +24,6 @@ public interface RoleService {
      * @param userId The unique identifier of the user.
      * @param roles  List of role names to be assigned to the user.
      */
-    void assignRolesToUser(String userId, List<String> roles);
+    void assignRolesToUser(String userId, List<String> roles,boolean forceSignOut);
 
 }

--- a/service/src/main/java/org/grnet/cat/services/UserService.java
+++ b/service/src/main/java/org/grnet/cat/services/UserService.java
@@ -186,7 +186,7 @@ public class UserService {
 
         var optionalUser = userRepository.searchByIdOptional(id);
 
-        roleRepository.assignRoles(id, List.of("identified"));
+        roleRepository.assignRoles(id, List.of("identified"), Boolean.FALSE);
 
         optionalUser.ifPresent(s -> {
             throw new ConflictException("User already exists in the database.");
@@ -230,7 +230,7 @@ public class UserService {
 
         if (autoApprove) {
             status = ValidationStatus.APPROVED;
-            roleService.assignRolesToUser(id, List.of("validated"));
+            roleService.assignRolesToUser(id, List.of("validated"),Boolean.TRUE);
             validation.setValidatedBy(id);
             validation.setValidatedOn(Timestamp.from(Instant.now()));
         }
@@ -288,7 +288,7 @@ public class UserService {
         var userToBeBanned = userRepository.findById(userId);
         userToBeBanned.setBanned(Boolean.TRUE);
         historyRepository.persist(history);
-        roleRepository.assignRoles(userId, List.of("deny_access"));
+        roleRepository.assignRoles(userId, List.of("deny_access"), Boolean.TRUE);
     }
 
     /**
@@ -309,7 +309,7 @@ public class UserService {
         var userToBeBanned = userRepository.findById(userId);
         userToBeBanned.setBanned(Boolean.FALSE);
         historyRepository.persist(history);
-        roleRepository.removeRoles(userId, List.of("deny_access"));
+        roleRepository.removeRoles(userId, List.of("deny_access"),Boolean.TRUE);
     }
 
     public PageResource<UserRegistryAssessmentEligibilityResponse> getUserRegistryAssessmentEligibility( int page, int size, String userID, UriInfo uriInfo) {

--- a/service/src/main/java/org/grnet/cat/services/ValidationService.java
+++ b/service/src/main/java/org/grnet/cat/services/ValidationService.java
@@ -54,7 +54,7 @@ public class ValidationService {
 
         switch (status) {
             case APPROVED: {
-                roleService.assignRolesToUser(userId, List.of("validated"));
+                roleService.assignRolesToUser(userId, List.of("validated"),Boolean.TRUE);
                 break;
             }
             default: {

--- a/validator/src/main/java/org/grnet/cat/validators/CheckPublishedValidator.java
+++ b/validator/src/main/java/org/grnet/cat/validators/CheckPublishedValidator.java
@@ -5,8 +5,11 @@ import jakarta.validation.ConstraintValidator;
 import jakarta.validation.ConstraintValidatorContext;
 import org.apache.commons.lang3.StringUtils;
 import org.grnet.cat.constraints.CheckPublished;
+import org.grnet.cat.entities.MotivationAssessment;
 import org.grnet.cat.entities.registry.Motivation;
+import org.grnet.cat.repositories.MotivationAssessmentRepository;
 import org.grnet.cat.repositories.Repository;
+import org.grnet.cat.repositories.registry.MotivationRepository;
 
 import java.util.Objects;
 
@@ -30,13 +33,26 @@ public class CheckPublishedValidator implements ConstraintValidator<CheckPublish
         }
 
         Repository repository = CDI.current().select(this.repository).get();
-        Motivation motivation = (Motivation) repository.findById(value);
-        // If motivation is found and is published, the action is not permitted
-
         boolean isPermitted = true;
-        if (motivation != null && motivation.getPublished() != isPublishedPermitted) {
-            isPermitted = false;
+
+        if (repository instanceof MotivationRepository) {
+
+            Motivation motivation = (Motivation) repository.findById(value);
+            // If motivation is found and is published, the action is not permitted
+
+            if (motivation != null && motivation.getPublished() != isPublishedPermitted) {
+                isPermitted = false;
+            }
+        } else if (repository instanceof MotivationAssessmentRepository) {
+
+            MotivationAssessment assessment = (MotivationAssessment) repository.findById(value);
+            // If motivation is found and is published, the action is not permitted
+
+            if (assessment != null && assessment.getPublished() != isPublishedPermitted) {
+                isPermitted = false;
+            }
         }
+
         StringBuilder builder = new StringBuilder();
 
         builder.append(message);


### PR DESCRIPTION
When  the user becomes validated from identified (only at the first accepted validation)  or the admin denies permission to the user, the user is forced to signout. 

If the user registers to the service and is assigned to identified role or when the user makes a new validation as already validated user or his validation is rejected as identified user no signout should occur