### PR TITLE
 CAT-1006:Admin actions should force signout user from CAT Service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,7 @@ According to [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) , the `Unr
 - [#536](https://github.com/FC4E-CAT/fc4e-cat-api/pull/536) CAT-981 Change num_params of Binary-Evidence Testmethod from 2 to 1
 - [#537](https://github.com/FC4E-CAT/fc4e-cat-api/pull/537) CAT-982: Minor Fixes for Assessment Build
 - [#542](https://github.com/FC4E-CAT/fc4e-cat-api/pull/542) CAT-1005 Updating zenodo key on the fly in settings is not retrieved in service
+- [#544](https://github.com/FC4E-CAT/fc4e-cat-api/pull/544) CAT-1006:Admin actions should force signout user from CAT Service
 
 
 ## 2.0.0 - 2025-03-31

--- a/api/src/main/java/org/grnet/cat/api/endpoints/RolesEndpoint.java
+++ b/api/src/main/java/org/grnet/cat/api/endpoints/RolesEndpoint.java
@@ -90,11 +90,11 @@ public class RolesEndpoint {
     @Produces(MediaType.APPLICATION_JSON)
     @Registration
     public Response rolesByPage(@Parameter(name = "page", in = QUERY,
-            description = "Indicates the page number. Page number must be >= 1.") @DefaultValue("1") @Min(value = 1, message = "Page number must be >= 1.") @QueryParam("page") int page,
-                                 @Parameter(name = "size", in = QUERY,
-                                         description = "The page size.") @DefaultValue("10") @Min(value = 1, message = "Page size must be between 1 and 100.")
-                                 @Max(value = 100, message = "Page size must be between 1 and 100.") @QueryParam("size") int size,
-                                 @Context UriInfo uriInfo) {
+                                        description = "Indicates the page number. Page number must be >= 1.") @DefaultValue("1") @Min(value = 1, message = "Page number must be >= 1.") @QueryParam("page") int page,
+                                @Parameter(name = "size", in = QUERY,
+                                        description = "The page size.") @DefaultValue("10") @Min(value = 1, message = "Page size must be between 1 and 100.")
+                                @Max(value = 100, message = "Page size must be between 1 and 100.") @QueryParam("size") int size,
+                                @Context UriInfo uriInfo) {
 
         var roles = roleService.getRolesByPage(page-1, size, uriInfo);
 
@@ -148,7 +148,7 @@ public class RolesEndpoint {
     @Registration
     public Response assignRolesToUser(@Valid @NotNull(message = "The request body is empty.") RoleAssignmentRequest request) {
 
-        roleService.assignRolesToUser(request.userId, request.roles);
+        roleService.assignRolesToUser(request.userId, request.roles, Boolean.TRUE);
 
         var response = new InformativeResponse();
         response.code = 200;

--- a/api/src/test/java/org/grnet/cat/api/ValidationsEndpointTest.java
+++ b/api/src/test/java/org/grnet/cat/api/ValidationsEndpointTest.java
@@ -23,6 +23,7 @@ import org.junit.jupiter.api.parallel.ExecutionMode;
 import static io.restassured.RestAssured.given;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doNothing;
 
 @QuarkusTest
@@ -231,7 +232,7 @@ public class ValidationsEndpointTest extends KeycloakTest {
     @Test
     @Execution(ExecutionMode.CONCURRENT)
     public void updateValidationRequestStatusByAdmin() {
-        doNothing().when(keycloakAdminRoleService).assignRolesToUser(any(), any());
+        doNothing().when(keycloakAdminRoleService).assignRolesToUser(any(), any(), eq(Boolean.TRUE));
 
         var request = createValidationRequest("Manager Alice", "ROR", "Keimyung University", "https://ror.org/00tjv0s33", "pid_graph:0E00C332");
         var createdValidation = performValidationRequest(request, aliceToken);
@@ -258,7 +259,7 @@ public class ValidationsEndpointTest extends KeycloakTest {
     @Test
     @Execution(ExecutionMode.CONCURRENT)
     public void updateValidationRequestStatusToRejectedByAdmin() {
-        doNothing().when(keycloakAdminRoleService).assignRolesToUser(any(), any());
+        doNothing().when(keycloakAdminRoleService).assignRolesToUser(any(), any(), eq(Boolean.TRUE));
 
         var request = createValidationRequest("Manager", "ROR", "Keimyung University", "https://ror.org/00tjv0s33", "pid_graph:1A718108");
         var createdValidation = performValidationRequest(request, aliceToken);

--- a/repository/src/main/java/org/grnet/cat/repositories/KeycloakAdminRepository.java
+++ b/repository/src/main/java/org/grnet/cat/repositories/KeycloakAdminRepository.java
@@ -12,6 +12,7 @@ import org.grnet.cat.exceptions.EntityNotFoundException;
 import org.grnet.cat.repositories.utils.PaginationUtils;
 import org.jboss.logging.Logger;
 import org.keycloak.admin.client.Keycloak;
+import org.keycloak.representations.idm.RoleRepresentation;
 import org.keycloak.representations.idm.UserRepresentation;
 
 import java.util.Collections;
@@ -104,35 +105,53 @@ public class KeycloakAdminRepository implements RoleRepository {
      * @param roles  The roles to be assigned to the user.
      */
     @Override
-    public void assignRoles(String userId, List<String> roles) {
-
+    public void assignRoles(String userId, List<String> roles, boolean forceSignOut) {
         try {
-
             var realmResource = keycloak.realm(realm);
 
-            var clientRepresentation = realmResource.clients().findByClientId(clientId).stream().findFirst().get();
+            var clientRepresentation = realmResource.clients()
+                    .findByClientId(clientId)
+                    .stream()
+                    .findFirst()
+                    .orElseThrow(() -> new IllegalStateException("Client not found: " + clientId));
 
             var clientResource = realmResource.clients().get(clientRepresentation.getId());
 
-            var usersResource = realmResource.users();
-
-            var userRepresentation = realmResource.users().searchByAttributes(String.format("%s:%s", attribute, userId)).stream().findFirst().get();
-
-            var userResource = usersResource.get(userRepresentation.getId());
-
-
-            var rolesRepresentations = roles
+            var userRepresentation = realmResource.users()
+                    .searchByAttributes(String.format("%s:%s", attribute, userId))
                     .stream()
+                    .findFirst()
+                    .orElseThrow(() -> new IllegalStateException("User not found: " + userId));
+
+            var userResource = realmResource.users().get(userRepresentation.getId());
+
+            // get current roles
+            var existingRoles = userResource.roles()
+                    .clientLevel(clientRepresentation.getId())
+                    .listAll()
+                    .stream()
+                    .map(RoleRepresentation::getName)
+                    .collect(Collectors.toSet());
+
+            // filter only roles the user doesn’t already have
+            var newRoles = roles.stream()
+                    .filter(role -> !existingRoles.contains(role))
                     .map(role -> clientResource.roles().get(role).toRepresentation())
                     .collect(Collectors.toList());
 
+            if (!newRoles.isEmpty()) {
+                userResource.roles()
+                        .clientLevel(clientRepresentation.getId())
+                        .add(newRoles);
 
-            userResource.roles().clientLevel(clientRepresentation.getId()).add(rolesRepresentations);
+                if (forceSignOut) {
+                    userResource.logout();
+                }
+            }
 
         } catch (Exception e) {
-
             LOG.error("A communication error occurred while assigning roles to the user.", e);
-            throw new RuntimeException("A communication error occurred while assigning roles to the user.");
+            throw new RuntimeException("A communication error occurred while assigning roles to the user.", e);
         }
     }
 
@@ -161,7 +180,7 @@ public class KeycloakAdminRepository implements RoleRepository {
     }
 
     @Override
-    public void removeRoles(String userId, List<String> roles) {
+    public void removeRoles(String userId, List<String> roles, boolean forceSignOut) {
 
         try {
 
@@ -186,6 +205,9 @@ public class KeycloakAdminRepository implements RoleRepository {
             // Remove client level role from user
             userResource.roles().clientLevel(clientRepresentation.getId()).remove(rolesRepresentations);
 
+            if(forceSignOut){
+                userResource.logout();
+            }
         } catch (Exception e) {
 
             LOG.error("A communication error occurred while removing roles from the user.", e);

--- a/repository/src/main/java/org/grnet/cat/repositories/RoleRepository.java
+++ b/repository/src/main/java/org/grnet/cat/repositories/RoleRepository.java
@@ -35,7 +35,7 @@ public interface RoleRepository {
      * @param userId The unique identifier of the user to assign roles to.
      * @param roles  The roles to be assigned to the user.
      */
-    void assignRoles(String userId, List<String> roles);
+    void assignRoles(String userId, List<String> roles, boolean forceSignOut);
 
     /**
      * Removes roles from a user.
@@ -43,7 +43,7 @@ public interface RoleRepository {
      * @param userId The unique identifier of the user from whom the roles will be removed.
      * @param roles  The roles to be removed from the user.
      */
-    void removeRoles(String userId, List<String> roles);
+    void removeRoles(String userId, List<String> roles,boolean forceSignOut);
 
 
     /**

--- a/service/src/main/java/org/grnet/cat/services/KeycloakAdminRoleService.java
+++ b/service/src/main/java/org/grnet/cat/services/KeycloakAdminRoleService.java
@@ -54,10 +54,10 @@ public class KeycloakAdminRoleService implements RoleService {
      * @param roles  List of role names to be assigned to the user.
      */
     @Override
-    public void assignRolesToUser(String userId, List<String> roles) {
+    public void assignRolesToUser(String userId, List<String> roles,boolean forceSignOut) {
 
         roleRepository.doRolesExist(roles);
-        roleRepository.assignRoles(userId, roles);
+        roleRepository.assignRoles(userId, roles,forceSignOut);
     }
 
 
@@ -90,7 +90,7 @@ public class KeycloakAdminRoleService implements RoleService {
         validationResponse.acceptedValidationNum=accepted_count;
         validationResponse.pendingValidationNum=pending_count;
 
-      //assessment statistics
+        //assessment statistics
         var total_assessments = StatisticsEnum.Assessment.TOTAL.getStatistics(assessmentRepository);
         var public_count = StatisticsEnum.Assessment.PUBLIC.getStatistics(assessmentRepository);
         var private_count = StatisticsEnum.Assessment.PRIVATE.getStatistics(assessmentRepository);

--- a/service/src/main/java/org/grnet/cat/services/RoleService.java
+++ b/service/src/main/java/org/grnet/cat/services/RoleService.java
@@ -24,6 +24,6 @@ public interface RoleService {
      * @param userId The unique identifier of the user.
      * @param roles  List of role names to be assigned to the user.
      */
-    void assignRolesToUser(String userId, List<String> roles);
+    void assignRolesToUser(String userId, List<String> roles,boolean forceSignOut);
 
 }

--- a/service/src/main/java/org/grnet/cat/services/UserService.java
+++ b/service/src/main/java/org/grnet/cat/services/UserService.java
@@ -166,7 +166,7 @@ public class UserService {
      */
     public UserProfileDto updateUserProfileMetadata(String id, String name, String surname, String email, String orcidId) {
 
-       Optional<User> optionalUser=userRepository.fetchUserByEmail(email);
+        Optional<User> optionalUser=userRepository.fetchUserByEmail(email);
         if (optionalUser.isPresent() && !optionalUser.get().getId().equals(id)){
             throw new ConflictException("There is a User with email : " + email);
         }
@@ -186,7 +186,7 @@ public class UserService {
 
         var optionalUser = userRepository.searchByIdOptional(id);
 
-        roleRepository.assignRoles(id, List.of("identified"));
+        roleRepository.assignRoles(id, List.of("identified"), Boolean.FALSE);
 
         optionalUser.ifPresent(s -> {
             throw new ConflictException("User already exists in the database.");
@@ -230,7 +230,7 @@ public class UserService {
 
         if (autoApprove) {
             status = ValidationStatus.APPROVED;
-            roleService.assignRolesToUser(id, List.of("validated"));
+            roleService.assignRolesToUser(id, List.of("validated"),Boolean.TRUE);
             validation.setValidatedBy(id);
             validation.setValidatedOn(Timestamp.from(Instant.now()));
         }
@@ -288,7 +288,7 @@ public class UserService {
         var userToBeBanned = userRepository.findById(userId);
         userToBeBanned.setBanned(Boolean.TRUE);
         historyRepository.persist(history);
-        roleRepository.assignRoles(userId, List.of("deny_access"));
+        roleRepository.assignRoles(userId, List.of("deny_access"), Boolean.TRUE);
     }
 
     /**
@@ -309,7 +309,7 @@ public class UserService {
         var userToBeBanned = userRepository.findById(userId);
         userToBeBanned.setBanned(Boolean.FALSE);
         historyRepository.persist(history);
-        roleRepository.removeRoles(userId, List.of("deny_access"));
+        roleRepository.removeRoles(userId, List.of("deny_access"),Boolean.TRUE);
     }
 
     public PageResource<UserRegistryAssessmentEligibilityResponse> getUserRegistryAssessmentEligibility( int page, int size, String userID, UriInfo uriInfo) {

--- a/service/src/main/java/org/grnet/cat/services/ValidationService.java
+++ b/service/src/main/java/org/grnet/cat/services/ValidationService.java
@@ -54,7 +54,7 @@ public class ValidationService {
 
         switch (status) {
             case APPROVED: {
-                roleService.assignRolesToUser(userId, List.of("validated"));
+                roleService.assignRolesToUser(userId, List.of("validated"),Boolean.TRUE);
                 break;
             }
             default: {


### PR DESCRIPTION
if the user becomes validated from identified (only at the first accepted validation)  or the admin denies permission to the user , user should be signout automatically

If the user registers to the service and is assigned to identified role or when the user makes a new validation as already validated user or his validation is rejected as identified user no signout should occur

