### PR TITLE
CAT-1002: Settings / Enable disable AAI autocomplete values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,7 +49,8 @@ According to [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) , the `Unr
 - [#531](https://github.com/FC4E-CAT/fc4e-cat-api/pull/531) CAT-970 Create and Link Metric to Criterion When Assigned to Actor
 - [#538](https://github.com/FC4E-CAT/fc4e-cat-api/pull/538) Sort Principles and Criteria from Newest to Oldest in Assessment Type Template
 - [#540](https://github.com/FC4E-CAT/fc4e-cat-api/pull/540) CAT-1000: Create Settings Table and Override Zenodo Configuration
--[#541](https://github.com/FC4E-CAT/fc4e-cat-api/pull/541) CAT-977: 2025-07-30 Default response to API requests is now version 2
+- [#541](https://github.com/FC4E-CAT/fc4e-cat-api/pull/541) CAT-977: 2025-07-30 Default response to API requests is now version 2
+- [#545](https://github.com/FC4E-CAT/fc4e-cat-api/pull/545) CAT-1002 Settings / Enable disable AAI autocomplete values
 
 ### Fix
 - [#482](https://github.com/FC4E-CAT/fc4e-cat-api/pull/482) CAT-867: Update Auto-AAI-Check-Entitlements tests parameters

--- a/api/src/main/java/org/grnet/cat/api/endpoints/AdminEndpoint.java
+++ b/api/src/main/java/org/grnet/cat/api/endpoints/AdminEndpoint.java
@@ -1157,8 +1157,8 @@ public class AdminEndpoint {
     @Consumes(MediaType.APPLICATION_JSON)
     @Produces(MediaType.APPLICATION_JSON)
     public Response updateSetting(
-            @PathParam("id") String key, SettingUpdateDto request) {
-        var updated = settingService.updateSetting(key, request, utility.getUserUniqueIdentifier() );
+            @PathParam("id") String id, SettingUpdateDto request) {
+        var updated = settingService.updateSetting(id, request, utility.getUserUniqueIdentifier() );
         return Response.ok(updated).build();
     }
 

--- a/api/src/main/resources/application.properties
+++ b/api/src/main/resources/application.properties
@@ -152,5 +152,3 @@ naco.service.key = naco_service_key
 # app.logo.url=https://example.org/assets/logo.svg
 # app.title=Compliance Assessment Toolkit
 # app.partners.hide=true
-
-api.cat.user.info.update.from.token = false

--- a/entity/src/main/resources/db/migration/tables/setting/V1.97__add_setting.sql
+++ b/entity/src/main/resources/db/migration/tables/setting/V1.97__add_setting.sql
@@ -1,0 +1,7 @@
+-- ------------------------------------------------
+-- Version: V1.97
+-- Description: Add user info update from token setting
+-- ------------------------------------------------
+
+INSERT INTO t_Setting (setting_key, setting_value, setting_label, setting_enable, updated_by)
+VALUES ( 'api.cat.user.info.update.from.token', NULL, 'Registration', false, NULL);

--- a/service/src/main/java/org/grnet/cat/services/SettingService.java
+++ b/service/src/main/java/org/grnet/cat/services/SettingService.java
@@ -7,6 +7,7 @@ import jakarta.ws.rs.NotFoundException;
 import org.apache.commons.lang3.StringUtils;
 import org.grnet.cat.dtos.setting.SettingResponseDto;
 import org.grnet.cat.dtos.setting.SettingUpdateDto;
+import org.grnet.cat.entities.Setting;
 import org.grnet.cat.mappers.SettingMapper;
 import org.grnet.cat.repositories.SettingRepository;
 
@@ -34,10 +35,10 @@ public class SettingService {
 
 
     @Transactional
-    public SettingResponseDto updateSetting(String key, SettingUpdateDto request, String userId) {
+    public SettingResponseDto updateSetting(String id, SettingUpdateDto request, String userId) {
 
-        var setting = settingRepository.findByIdOptional(key)
-                .orElseThrow(() -> new NotFoundException("Setting with key " + key + " not found."));
+        var setting = settingRepository.findByIdOptional(id)
+                .orElseThrow(() -> new NotFoundException("Setting with key " + id + " not found."));
 
         SettingMapper.INSTANCE.updateSettingFromDto(request, setting);
 
@@ -63,5 +64,12 @@ public class SettingService {
         }
 
         return Optional.ofNullable(defaultSupplier.get());
+    }
+
+    public boolean isEnabled(String key) {
+        return settingRepository.find("key", key)
+                .firstResultOptional()
+                .map(Setting::isEnabled)
+                .orElse(false);
     }
 }

--- a/service/src/main/java/org/grnet/cat/services/UserService.java
+++ b/service/src/main/java/org/grnet/cat/services/UserService.java
@@ -4,9 +4,7 @@ import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import jakarta.inject.Named;
 import jakarta.transaction.Transactional;
-import jakarta.ws.rs.BadRequestException;
 import jakarta.ws.rs.core.UriInfo;
-import org.apache.commons.lang3.StringUtils;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.grnet.cat.dtos.*;
 import org.grnet.cat.dtos.pagination.PageResource;
@@ -29,7 +27,6 @@ import java.sql.Timestamp;
 import java.time.Instant;
 import java.util.Arrays;
 import java.util.List;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 
@@ -85,11 +82,11 @@ public class UserService {
     @ConfigProperty(name = "api.cat.validations.approve.auto")
     boolean autoApprove;
 
-    @ConfigProperty(name = "api.cat.user.info.update.from.token")
-    boolean userInfoUpdateFromToken;
-
     @Inject
     Utility utility;
+
+    @Inject
+    SettingService settingService;
 
     private static final Logger LOG = Logger.getLogger(UserService.class);
 
@@ -197,7 +194,7 @@ public class UserService {
         identified.setRegisteredOn(Timestamp.from(Instant.now()));
         identified.setBanned(Boolean.FALSE);
 
-        if(userInfoUpdateFromToken){
+        if (settingService.isEnabled("api.cat.user.info.update.from.token")) {
 
             var map = roleRepository.getUserInformation(id);
 


### PR DESCRIPTION
### Description
This PR removes the static configuration of api.cat.user.info.update.from.token from application.properties and introduces full support via the dynamic t_Setting table.

User metadata (email, name, surname) is now only auto-filled during registration if:
* the setting api.cat.user.info.update.from.token is enabled
* value is set to "true" 
----
### How to test
#### Create two users in Keycloak:
* test1
* test2

> Make sure to set their metadata (name, surname, email) in the Keycloak admin console.

#### Register the first user (test1) via the /register endpoint.
➜  Expected: user is registered without auto-filled metadata.

#### Enable the autofill setting via admin endpoint:
```
PUT /v1/admin/settings/2
{
  "value": "true",
  "enabled": true
}
```
#### Register the second user (test2) via the /register endpoint.
➜ Expected: user is registered with email, name, and surname automatically filled from Keycloak token.