### PR TITLE
CAT-1010: Add REJECTED Assessments to Statistics Endpoint

### DIFF
--- a/data-transfer-object/src/main/java/org/grnet/cat/dtos/statistics/StatisticsResponse.java
+++ b/data-transfer-object/src/main/java/org/grnet/cat/dtos/statistics/StatisticsResponse.java
@@ -53,8 +53,9 @@ public class StatisticsResponse {
                     "  \n" +
                     "  \"validation_statistics\": {\n" +
                     "    \"total_validations\": 6,\n" +
-                    "    \"accepted_validations\": 1,\n" +
+                    "    \"accepted_validations\": 8,\n" +
                     "    \"pending_validations\": 4\n" +
+                    "    \"rejected_validations\": 2\n" +
                     "  }\n" +
                     "}"
     )

--- a/data-transfer-object/src/main/java/org/grnet/cat/dtos/statistics/ValidationStatisticsResponse.java
+++ b/data-transfer-object/src/main/java/org/grnet/cat/dtos/statistics/ValidationStatisticsResponse.java
@@ -37,5 +37,15 @@ public class ValidationStatisticsResponse {
 
     @JsonProperty("pending_validations")
     public Long  pendingValidationNum;
+
+    @Schema(
+            type = SchemaType.NUMBER,
+            implementation = Long.class,
+            description = "The number of rejected validations.",
+            example = "10"
+    )
+
+    @JsonProperty("rejected_validations")
+    public Long  rejectedValidationNum;
 }
 

--- a/service/src/main/java/org/grnet/cat/services/KeycloakAdminRoleService.java
+++ b/service/src/main/java/org/grnet/cat/services/KeycloakAdminRoleService.java
@@ -85,10 +85,12 @@ public class KeycloakAdminRoleService implements RoleService {
         var total_validations = StatisticsEnum.Validation.TOTAL.getStatistics(validationRepository);
         var accepted_count = StatisticsEnum.Validation.ACCEPTED.getStatistics(validationRepository);
         var pending_count = StatisticsEnum.Validation.PENDING.getStatistics(validationRepository);
+        var rejected_count = StatisticsEnum.Validation.REJECTED.getStatistics(validationRepository);
         var validationResponse= new ValidationStatisticsResponse();
         validationResponse.totalValidationNum=total_validations;
         validationResponse.acceptedValidationNum=accepted_count;
         validationResponse.pendingValidationNum=pending_count;
+        validationResponse.rejectedValidationNum=rejected_count;
 
         //assessment statistics
         var total_assessments = StatisticsEnum.Assessment.TOTAL.getStatistics(assessmentRepository);

--- a/service/src/main/java/org/grnet/cat/services/StatisticsEnum.java
+++ b/service/src/main/java/org/grnet/cat/services/StatisticsEnum.java
@@ -88,6 +88,13 @@ public class StatisticsEnum{
                 return validationRepository.find("from Validation val where val.status =?1 or val.status=?2 ", ValidationStatus.PENDING, ValidationStatus.REVIEW).stream().count();
 
             }
+        },
+        REJECTED {
+            @Override
+            public Long getStatistics(ValidationRepository validationRepository) {
+                return validationRepository.find("from Validation val where val.status =?1", ValidationStatus.REJECTED).stream().count();
+
+            }
         };
 
         public abstract Long getStatistics(ValidationRepository validationRepository);


### PR DESCRIPTION
#### Description
This PR updates the /statistics endpoint to include information about rejected validations in the response.

#### Example Response
```
{
  "user_statistics": {
    "total_users": 7,
    "validated_users": 2,
    "banned_users": 0,
    "identified_users": 3
  },
  "assessment_statistics": {
    "total_assessments": 0,
    "public_assessments": 0,
    "private_assessments": 0,
    "assessment_per_role": []
  },
  "validation_statistics": {
    "total_validations": 3,
    "accepted_validations": 2,
    "pending_validations": 0,
    "rejected_assessments": 0,         // <-- New field
  },
  "subject_statistics": {
    "total_subjects": 1
  }
}
```

