### PR TITLE
CAT-1011: Add Criteria Failure Statistics

### DIFF
--- a/api/src/main/java/org/grnet/cat/api/endpoints/AdminEndpoint.java
+++ b/api/src/main/java/org/grnet/cat/api/endpoints/AdminEndpoint.java
@@ -37,6 +37,7 @@ import org.grnet.cat.dtos.assessment.registry.JsonRegistryAssessmentRequest;
 import org.grnet.cat.dtos.assessment.registry.UserJsonRegistryAssessmentResponse;
 import org.grnet.cat.dtos.assessment.zenodo.ZenodoDepositResponse;
 import org.grnet.cat.dtos.pagination.PageResource;
+import org.grnet.cat.dtos.registry.criterion.CriteriaFailureStatDto;
 import org.grnet.cat.dtos.setting.SettingResponseDto;
 import org.grnet.cat.dtos.setting.SettingUpdateDto;
 import org.grnet.cat.dtos.statistics.StatisticsResponse;
@@ -44,7 +45,9 @@ import org.grnet.cat.enums.ValidationStatus;
 import org.grnet.cat.repositories.*;
 import org.grnet.cat.services.*;
 import org.grnet.cat.services.assessment.JsonAssessmentService;
+import org.grnet.cat.services.registry.CriterionService;
 import org.grnet.cat.services.registry.RegistryActorService;
+import org.grnet.cat.services.registry.TestService;
 import org.grnet.cat.services.zenodo.ZenodoService;
 import org.grnet.cat.utils.Utility;
 
@@ -112,6 +115,9 @@ public class AdminEndpoint {
      */
     @Inject
     SettingService settingService;
+
+    @Inject
+    CriterionService criterionService;
 
     @Tag(name = "Admin")
     @Operation(
@@ -680,6 +686,61 @@ public class AdminEndpoint {
 
     @Tag(name = "Admin")
     @Operation(
+            summary = "Get most failed criteria",
+            description = "Returns a ranked list of the most frequently failed criteria across all assessments, based on their metric results."
+    )
+    @APIResponse(
+            responseCode = "200",
+            description = "List of failed criteria retrieved successfully.",
+            content = @Content(schema = @Schema(
+                    type = SchemaType.OBJECT,
+                    implementation = PageableCriteriaFailureStatDto.class)))
+    @APIResponse(
+            responseCode = "400",
+            description = "Invalid request parameters.",
+            content = @Content(schema = @Schema(
+                    type = SchemaType.OBJECT,
+                    implementation = InformativeResponse.class)))
+    @APIResponse(
+            responseCode = "401",
+            description = "User not authenticated.",
+            content = @Content(schema = @Schema(
+                    type = SchemaType.OBJECT,
+                    implementation = InformativeResponse.class)))
+    @APIResponse(
+            responseCode = "403",
+            description = "Not permitted.",
+            content = @Content(schema = @Schema(
+                    type = SchemaType.OBJECT,
+                    implementation = InformativeResponse.class)))
+    @APIResponse(
+            responseCode = "500",
+            description = "Internal server error.",
+            content = @Content(schema = @Schema(
+                    type = SchemaType.OBJECT,
+                    implementation = InformativeResponse.class)))
+    @SecurityRequirement(name = "Authentication")
+    @GET
+    @Path("/statistics/criteria/most-failed")
+    @Produces(MediaType.APPLICATION_JSON)
+    @Registration
+    public Response getMostFailedTests(
+            @Parameter(name = "page", in = QUERY,
+                    description = "Indicates the page number. Page number must be >= 1.")
+            @DefaultValue("1") @Min(value = 1, message = "Page number must be >= 1.") @QueryParam("page") int page,
+            @Parameter(name = "size", in = QUERY,
+                    description = "The page size.")
+            @DefaultValue("10") @Min(value = 1, message = "Page size must be between 1 and 20.")
+            @Max(value = 100, message = "Page size must be between 1 and 20.")
+            @QueryParam("size") int size,
+            UriInfo uriInfo) {
+        var list = criterionService.getMostFailedCriteria(page, size, uriInfo);
+        return Response.ok(list).build();
+    }
+
+
+    @Tag(name = "Admin")
+    @Operation(
             summary = "Update an existing assessment.",
             description = "Allows an admin to update the details of an existing assessment.")
     @APIResponse(
@@ -1212,6 +1273,23 @@ public class AdminEndpoint {
             @PathParam("id") String id, SettingUpdateDto request) {
         var updated = settingService.updateSetting(id, request, utility.getUserUniqueIdentifier() );
         return Response.ok(updated).build();
+    }
+
+
+
+    public static class PageableCriteriaFailureStatDto extends PageResource<CriteriaFailureStatDto> {
+
+        private List<CriteriaFailureStatDto> content;
+
+        @Override
+        public List<CriteriaFailureStatDto> getContent() {
+            return content;
+        }
+
+        @Override
+        public void setContent(List<CriteriaFailureStatDto> content) {
+            this.content = content;
+        }
     }
 
 }

--- a/data-transfer-object/src/main/java/org/grnet/cat/dtos/registry/criterion/CriteriaFailureStatDto.java
+++ b/data-transfer-object/src/main/java/org/grnet/cat/dtos/registry/criterion/CriteriaFailureStatDto.java
@@ -1,0 +1,68 @@
+package org.grnet.cat.dtos.registry.criterion;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
+import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
+
+@Schema(
+        name = "CriteriaFailureStatDto",
+        description = "Information about a criterion that frequently fails in assessments."
+)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class CriteriaFailureStatDto {
+
+    @Schema(
+            type = SchemaType.STRING,
+            implementation = String.class,
+            description = "The unique identifier of the criterion",
+            example = "pid_graph:116489G8"
+    )
+    @JsonProperty("id")
+    public String id;
+
+    @Schema(
+            type = SchemaType.STRING,
+            implementation = String.class,
+            description = "The criterion name or short code",
+            example = "C24"
+    )
+    @JsonProperty("cri")
+    public String cri;
+
+    @Schema(
+            type = SchemaType.STRING,
+            implementation = String.class,
+            description = "The label or title of the test",
+            example = "Services MUST be available to all researchers in the EU."
+    )
+    @JsonProperty("label")
+    public String label;
+
+    @Schema(
+            type = SchemaType.INTEGER,
+            implementation = Integer.class,
+            description = "Number of times this criterion failed across all assessments",
+            example = "14"
+    )
+    @JsonProperty("fail_count")
+    public int failCount;
+
+    @Schema(
+            type = SchemaType.INTEGER,
+            implementation = Integer.class,
+            description = "Percentage of this criterion failed across all assessments",
+            example = "15.21"
+    )
+    @JsonProperty("failure_percentage")
+    public double failurePercentage;
+
+    @Schema(
+            type = SchemaType.INTEGER,
+            implementation = Integer.class,
+            description = "Number of assessments that used this criterion.",
+            example = "92"
+    )
+    @JsonProperty("used_in_assessments")
+    public int countAssessments;
+}

--- a/service/src/main/java/org/grnet/cat/services/registry/CriterionService.java
+++ b/service/src/main/java/org/grnet/cat/services/registry/CriterionService.java
@@ -1,23 +1,24 @@
 package org.grnet.cat.services.registry;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.quarkus.hibernate.orm.panache.Panache;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import jakarta.transaction.Transactional;
+import jakarta.ws.rs.BadRequestException;
 import jakarta.ws.rs.ForbiddenException;
 import jakarta.ws.rs.NotFoundException;
 import jakarta.ws.rs.core.UriInfo;
 import org.apache.commons.lang3.StringUtils;
-import org.grnet.cat.dtos.registry.criterion.CriterionRequest;
-import org.grnet.cat.dtos.registry.criterion.CriterionResponse;
-import org.grnet.cat.dtos.registry.criterion.CriterionUpdate;
+import org.grnet.cat.dtos.registry.criterion.*;
 import org.grnet.cat.dtos.pagination.PageResource;
-import org.grnet.cat.dtos.registry.criterion.DetailedCriterionDto;
-import org.grnet.cat.dtos.registry.criterion.PrincipleCriterionResponse;
 import org.grnet.cat.dtos.registry.template.MetricNode;
 import org.grnet.cat.dtos.registry.template.Node;
 import org.grnet.cat.dtos.registry.template.TestNode;
+import org.grnet.cat.entities.Page;
+import org.grnet.cat.entities.PageQueryImpl;
 import org.grnet.cat.mappers.registry.PrincipleMapper;
+import org.grnet.cat.repositories.MotivationAssessmentRepository;
 import org.grnet.cat.utils.TestParamsTransformer;
 import org.grnet.cat.entities.registry.*;
 import org.grnet.cat.exceptions.UniqueConstraintViolationException;
@@ -49,6 +50,12 @@ public class CriterionService {
     PrincipleCriterionRepository principleCriterionRepository;
     @Inject
     CriterionActorRepository criterionActorRepository;
+
+    @Inject
+    MotivationAssessmentRepository motivationAssessmentRepository;
+
+    @Inject
+    ObjectMapper objectMapper;
 
     private static final Logger LOG = Logger.getLogger(CriterionService.class);
 
@@ -317,6 +324,93 @@ public class CriterionService {
         criterionResponse.setMetrics(new ArrayList<>(metricNodeMap.values()));
 
         return criterionResponse;
+    }
+
+
+    @Transactional
+    public PageResource<CriteriaFailureStatDto> getMostFailedCriteria(int page, int size, UriInfo uriInfo) {
+        var assessments = motivationAssessmentRepository.listAll();
+
+        Map<String, Integer> criterionUsageCountMap = new HashMap<>();
+        Map<String, CriteriaFailureStatDto> failCountMap = new HashMap<>();
+
+        assessments.forEach(assessment -> {
+            if (StringUtils.isBlank(assessment.getAssessmentDoc())) return;
+
+            try {
+                var doc = objectMapper.readTree(assessment.getAssessmentDoc());
+                var principles = doc.get("principles");
+                if (principles == null || !principles.isArray()) return;
+
+                principles.forEach(principle -> {
+                    var criteria = principle.get("criteria");
+                    if (criteria == null || !criteria.isArray()) return;
+
+                    criteria.forEach(criterion -> {
+                        var id = criterion.path("id").asText();
+                        var name = criterion.path("name").asText();
+                        var label = criterion.path("description").asText();
+
+                        criterionUsageCountMap.merge(id, 1, Integer::sum);
+
+                        var metric = criterion.get("metric");
+                        if (metric == null) return;
+
+                        int result = metric.path("result").asInt(1); // default to 1 (pass)
+
+                        if (result == 0) {
+                            failCountMap.compute(id, (key, dto) -> {
+                                if (dto == null) {
+                                    var failed = new CriteriaFailureStatDto();
+                                    failed.id = id;
+                                    failed.cri = name;
+                                    failed.label = label;
+                                    failed.failCount = 1;
+                                    return failed;
+                                } else {
+                                    dto.failCount++;
+                                    return dto;
+                                }
+                            });
+                        }
+                    });
+                });
+
+            } catch (Exception e) {
+                throw new BadRequestException("Failed to parse assessment JSON for assessment " + assessment.getId());
+            }
+        });
+
+        // Calculate failure percentage per criterion
+        failCountMap.values().forEach(dto -> {
+            int totalUsage = criterionUsageCountMap.getOrDefault(dto.id, 0);
+            dto.countAssessments = totalUsage;
+
+            if (totalUsage > 0) {
+                dto.failurePercentage = Math.round((dto.failCount * 100.0 / totalUsage) * 100.0) / 100.0;
+            } else {
+                dto.failurePercentage = 0.0;
+            }
+        });
+
+        // Sort and paginate
+        var sorted = failCountMap.values().stream()
+                .sorted(Comparator.comparingInt(dto -> -dto.failCount))
+                .collect(Collectors.toList());
+
+        int total = sorted.size();
+        int from = Math.min((page - 1) * size, total);
+        int to = Math.min(from + size, total);
+        List<CriteriaFailureStatDto> pageContent = sorted.subList(from, to);
+
+        PageQueryImpl<CriteriaFailureStatDto> pageQuery = new PageQueryImpl<>();
+        pageQuery.list = pageContent;
+        pageQuery.index = page;
+        pageQuery.size = size;
+        pageQuery.count = total;
+        pageQuery.page = Page.of(page, size);
+
+        return new PageResource<>(pageQuery, pageContent, uriInfo);
     }
 
 }

--- a/service/src/main/java/org/grnet/cat/services/registry/TestService.java
+++ b/service/src/main/java/org/grnet/cat/services/registry/TestService.java
@@ -1,5 +1,6 @@
 package org.grnet.cat.services.registry;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.quarkus.hibernate.orm.panache.Panache;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
@@ -15,19 +16,21 @@ import org.grnet.cat.entities.registry.TestMethod;
 import org.grnet.cat.exceptions.UniqueConstraintViolationException;
 import org.grnet.cat.mappers.registry.MotivationMapper;
 import org.grnet.cat.mappers.registry.TestMapper;
+import org.grnet.cat.repositories.MotivationAssessmentRepository;
 import org.grnet.cat.repositories.registry.MetricTestRepository;
 import org.grnet.cat.repositories.registry.TestMethodRepository;
 import org.grnet.cat.repositories.registry.TestRepository;
 
 import org.jboss.logging.Logger;
 
-import java.util.List;
-import java.util.Objects;
+import java.util.*;
 import java.util.stream.Collectors;
 
 @ApplicationScoped
 public class TestService {
 
+    @Inject
+    ObjectMapper objectMapper;
     @Inject
     TestRepository testRepository;
     @Inject
@@ -35,6 +38,9 @@ public class TestService {
 
     @Inject
     TestMethodRepository testMethodRepository;
+
+    @Inject
+    MotivationAssessmentRepository motivationAssessmentRepository;
 
     private static final Logger LOG = Logger.getLogger(TestService.class);
 
@@ -102,7 +108,6 @@ public class TestService {
      * @param id      The unique ID of the Test to update.
      * @param userId  The user performing the update.
      * @param request The Test update data.
-     * @return The updated Test DTO.
      */
     @Transactional
     public void updateTest(String id, String userId, TestUpdateDto request) {


### PR DESCRIPTION
### Description

This PR introduces a new admin API endpoint that returns a paginated list of the most failed criteria across all assessments in the CAT platform.

A criterion is considered failed if the result of its metric is 0 in the assessment JSON (assessmentDoc). 

----
### Endpoint
GET /v1/admin/statistics/criteria/most-failed

### Response Format:

```json
{
  "size_of_page": 10,
  "number_of_page": 2,
  "total_elements": 27,
  "total_pages": 3,
  "content": [
    {
      "id": "C20",
      "cri": "Openly Available",
      "label": "Services MUST be available to all researchers in the EU.",
      "fail_count": 5,
      "failure_percentage": 83.33,
      "used_in_assessments": 6
    },
    {
      "id": "C28",
      "cri": "Certification",
      "label": "PID Authorities and Services MUST agree to be certified with a mutually agreed frequency in respect of policy compliance.",
      "fail_count": 5,
      "failure_percentage": 83.33,
      "used_in_assessments": 6
    },
    {
      "id": "C22",
      "cri": "No End User Cost",
      "label": "The basic services of PID registration and resolution SHALL have no cost to end users.",
      "fail_count": 3,
      "failure_percentage": 100,
      "used_in_assessments": 3
    },
    {
      "id": "C29",
      "cri": "Agreed Responsibilities",
      "label": "PID Services SHOULD agree with PID Managers the responsibilities for Kernel Information maintenance, preferably via contract.",
      "fail_count": 3,
      "failure_percentage": 100,
      "used_in_assessments": 3
    },
    {
      "id": "C4",
      "cri": "Maintenance",
      "label": "The PID owner SHOULD maintain PID attributes.",
      "fail_count": 3,
      "failure_percentage": 100,
      "used_in_assessments": 3
    }
  ],
  "links": [
    {
      "href": "http://localhost:8080/v1/admin/statistics/criteria/most-failed?page=1&size=10",
      "rel": "first"
    },
    {
      "href": "http://localhost:8080/v1/admin/statistics/criteria/most-failed?page=3&size=10",
      "rel": "last"
    },
    {
      "href": "http://localhost:8080/v1/admin/statistics/criteria/most-failed?page=2&size=10",
      "rel": "self"
    },
    {
      "href": "http://localhost:8080/v1/admin/statistics/criteria/most-failed?page=1&size=10",
      "rel": "prev"
    },
    {
      "href": "http://localhost:8080/v1/admin/statistics/criteria/most-failed?page=3&size=10",
      "rel": "next"
    }
  ]
}


