### PR TITLE
CAT-1017: Add Report Functionality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,7 @@ According to [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) , the `Unr
 - [#545](https://github.com/FC4E-CAT/fc4e-cat-api/pull/545) CAT-1002 Settings / Enable disable AAI autocomplete values
 - [#546](https://github.com/FC4E-CAT/fc4e-cat-api/pull/546) CAT-1007: Avoid unecessary role checks while approving validation
 - [#547](https://github.com/FC4E-CAT/fc4e-cat-api/pull/547) CAT-1008: Encrypt/Decrypt Sensitive Setting Values and Add Info Column 
+- [#551](https://github.com/FC4E-CAT/fc4e-cat-api/pull/551) CAT-1017 Add Run Report Functionality
 
 ### Fix
 - [#502](https://github.com/FC4E-CAT/fc4e-cat-api/pull/502) CAT-1026 Fix: Ensure test fields are correctly updated in Test update method

--- a/api/config/quarkus-realm.json
+++ b/api/config/quarkus-realm.json
@@ -365,9 +365,17 @@
           "containerId": "0ac5df91-e044-4051-bd03-106a3a5fb9cc",
           "attributes": {}
         },
-         {
+        {
           "id": "df147a91-4db7-5bbc-266c-f70cf99b2630",
           "name": "deny_access",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "0ac5df91-e044-4051-bd03-106a3a5fb9cc",
+          "attributes": {}
+        },
+        {
+          "id": "df147a91-4db7-5bbc-266c-f70cf99b9876",
+          "name": "reporter",
           "composite": false,
           "clientRole": true,
           "containerId": "0ac5df91-e044-4051-bd03-106a3a5fb9cc",
@@ -932,6 +940,29 @@
             "icon_uri": ""
           },
           {
+            "name": "Reporter Resource",
+            "ownerManagedAccess": false,
+            "displayName": "Reporter Resource",
+            "attributes": {},
+            "_id": "b9cc5be8-fgd3-43de-bb6f-12d6d8169653",
+            "uris": [
+              "/v1/reports/*"
+            ],
+            "scopes": [
+              {
+                "name": "cat.create"
+              },
+              {
+                "name": "cat.update"
+              },
+              {
+                "name": "cat.read"
+              }
+            ],
+            "icon_uri": ""
+          },
+
+          {
             "name": "Assessment Resource",
             "ownerManagedAccess": false,
             "displayName": "Assessment Resource",
@@ -991,6 +1022,22 @@
               {
                 "name": "cat.update"
               },
+              {
+                "name": "cat.read"
+              }
+            ],
+            "icon_uri": ""
+          },
+          {
+            "name": "Reporter View Motivation Assessment Resource",
+            "ownerManagedAccess": false,
+            "displayName": "Reporter View Motivation Assessment Resource",
+            "attributes": {},
+            "_id": "f3a0a76a-8f64-4f1d-9c37-9a77e71c5a6e",
+            "uris": [
+              "/v2/assessments/"
+            ],
+            "scopes": [
               {
                 "name": "cat.read"
               }
@@ -1263,6 +1310,18 @@
               "roles": "[{\"id\":\"backend-service/admin\",\"required\":false}]"
             }
           },
+
+          {
+            "id": "jcaf30b2-68b2-2v71-9f3d-9162c6cdf5cb",
+            "name": "Only Reporters",
+            "description": "Only reporters can access",
+            "type": "role",
+            "logic": "POSITIVE",
+            "decisionStrategy": "UNANIMOUS",
+            "config": {
+              "roles": "[{\"id\":\"backend-service/reporter\",\"required\":false}]"
+            }
+          },
           {
             "id": "839406ad-46c6-40ad-9423-305acaaeb8b7",
             "name": "Read Template By Type and Actor",
@@ -1302,6 +1361,19 @@
               "applyPolicies": "[\"Any Validated Policy\",\"Only Administrators\"]"
             }
           },
+
+          {
+            "id": "29329298-d55b-4066-b231-6a7c56ss8sg5",
+            "name": "Reporter Resource Permission",
+            "description": "",
+            "type": "resource",
+            "logic": "POSITIVE",
+            "decisionStrategy": "AFFIRMATIVE",
+            "config": {
+              "resources": "[\"Reporter Resource\", \"Reporter View Motivation Assessment Resource\"]",
+              "applyPolicies": "[\"Only Reporters\"]"
+            }
+          },
           {
             "id": "60188298-d55b-4066-b231-6a7c56ff7cc5",
             "name": "Administration Resource Permission",
@@ -1310,7 +1382,7 @@
             "logic": "POSITIVE",
             "decisionStrategy": "AFFIRMATIVE",
             "config": {
-              "resources": "[\"Zenodo Resource\",\"Motivation Assessment Resource\",\"Assessment Resource\",\"Role Resource\",\"Subject Resource\",\"Administration Resource\",\"Template Resource\"]",
+              "resources": "[\"Reporter Resource\", \"Reporter View Motivation Assessment Resource\",\"Zenodo Resource\",\"Motivation Assessment Resource\",\"Assessment Resource\",\"Role Resource\",\"Subject Resource\",\"Administration Resource\",\"Template Resource\"]",
               "applyPolicies": "[\"Only Administrators\"]"
             }
           },
@@ -3238,6 +3310,25 @@
         "backend-service": [
           "identified",
           "validated"
+        ]
+      }
+    },
+    {
+      "username": "reporter",
+      "enabled": true,
+      "attributes": {
+        "voperson_id": ["reporter_voperson_id"]
+      },
+      "credentials": [
+        {
+          "type": "password",
+          "value": "reporter"
+        }
+      ],
+      "clientRoles": {
+        "backend-service": [
+          "identified",
+          "reporter"
         ]
       }
     },

--- a/api/src/main/java/org/grnet/cat/api/endpoints/ReportsEndpoint.java
+++ b/api/src/main/java/org/grnet/cat/api/endpoints/ReportsEndpoint.java
@@ -1,0 +1,302 @@
+package org.grnet.cat.api.endpoints;
+
+import io.quarkus.security.Authenticated;
+import jakarta.inject.Inject;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+import jakarta.ws.rs.*;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import org.eclipse.microprofile.openapi.annotations.Operation;
+import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
+import org.eclipse.microprofile.openapi.annotations.enums.SecuritySchemeIn;
+import org.eclipse.microprofile.openapi.annotations.enums.SecuritySchemeType;
+import org.eclipse.microprofile.openapi.annotations.media.Content;
+import org.eclipse.microprofile.openapi.annotations.media.ExampleObject;
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
+import org.eclipse.microprofile.openapi.annotations.parameters.Parameter;
+import org.eclipse.microprofile.openapi.annotations.parameters.RequestBody;
+import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
+import org.eclipse.microprofile.openapi.annotations.security.SecurityRequirement;
+import org.eclipse.microprofile.openapi.annotations.security.SecurityScheme;
+import org.eclipse.microprofile.openapi.annotations.tags.Tag;
+import org.grnet.cat.api.filters.Registration;
+import org.grnet.cat.constraints.NotFoundEntity;
+import org.grnet.cat.dtos.InformativeResponse;
+import org.grnet.cat.dtos.report.*;
+import org.grnet.cat.repositories.ReportRepository;
+import org.grnet.cat.services.report.ReportService;
+import org.grnet.cat.utils.Utility;
+
+@Path("/v1/reports")
+@Authenticated
+@SecurityScheme(securitySchemeName = "Authentication",
+        description = "JWT token",
+        type = SecuritySchemeType.HTTP,
+        scheme = "bearer",
+        bearerFormat = "JWT",
+        in = SecuritySchemeIn.HEADER)
+public class ReportsEndpoint {
+
+    @Inject
+    ReportService reportService;
+
+    @Inject
+    Utility utility;
+
+    @Tag(name = "Reports")
+    @Operation(
+            summary = "List report definitions",
+            description = "Returns all predefined report definitions available for execution."
+    )
+    @APIResponse(
+            responseCode = "200",
+            description = "List of available report definitions",
+            content = @Content(schema = @Schema(
+                    type = SchemaType.ARRAY,
+                    implementation = ReportDefinitionDto.class))
+    )
+    @APIResponse(
+            responseCode = "401",
+            description = "User has not been authenticated.",
+            content = @Content(schema = @Schema(
+                    type = SchemaType.OBJECT,
+                    implementation = InformativeResponse.class))
+    )
+    @APIResponse(
+            responseCode = "403",
+            description = "Not permitted.",
+            content = @Content(schema = @Schema(
+                    type = SchemaType.OBJECT,
+                    implementation = InformativeResponse.class))
+    )
+    @APIResponse(
+            responseCode = "500",
+            description = "Internal Server Error.",
+            content = @Content(schema = @Schema(
+                    type = SchemaType.OBJECT,
+                    implementation = InformativeResponse.class))
+    )
+    @SecurityRequirement(name = "Authentication")
+    @GET
+    @Path("/definitions")
+    @Produces(MediaType.APPLICATION_JSON)
+    @Registration
+    public Response getDefinitions() {
+
+        var response = reportService.getAllDefinitions();
+
+        return Response.ok().entity(response).build();
+    }
+
+    @Tag(name = "Reports")
+    @Operation(
+            summary = "Get a report definition",
+            description = "Returns a predefined report by Id."
+    )
+    @APIResponse(
+            responseCode = "200",
+            description = "Get a report definition",
+            content = @Content(schema = @Schema(
+                    type = SchemaType.ARRAY,
+                    implementation = ReportDefinitionDto.class))
+    )
+    @APIResponse(
+            responseCode = "401",
+            description = "User has not been authenticated.",
+            content = @Content(schema = @Schema(
+                    type = SchemaType.OBJECT,
+                    implementation = InformativeResponse.class))
+    )
+    @APIResponse(
+            responseCode = "403",
+            description = "Not permitted.",
+            content = @Content(schema = @Schema(
+                    type = SchemaType.OBJECT,
+                    implementation = InformativeResponse.class))
+    )
+    @APIResponse(
+            responseCode = "500",
+            description = "Internal Server Error.",
+            content = @Content(schema = @Schema(
+                    type = SchemaType.OBJECT,
+                    implementation = InformativeResponse.class))
+    )
+    @SecurityRequirement(name = "Authentication")
+    @GET
+    @Path("/definitions/{id}")
+    @Produces(MediaType.APPLICATION_JSON)
+    @Registration
+    public Response getDefinition(
+            @Parameter(
+                    description = "The ID of the report definition.",
+                    required = true,
+                    example = "1",
+                    schema = @Schema(type = SchemaType.STRING))
+            @PathParam("id") @NotFoundEntity(repository = ReportRepository.class, message = "There is no Report with the following id:") Long id) {
+
+        var response = reportService.getDefinitionById(id);
+
+        return Response.ok().entity(response).build();
+    }
+
+    @Tag(name = "Reports")
+    @Operation(
+            summary = "Get available report filters",
+            description = "Returns the list of motivations and publication status values that can be used as filters when running reports."
+    )
+    @APIResponse(
+            responseCode = "200",
+            description = "Filters returned successfully",
+            content = @Content(schema = @Schema(
+                    type = SchemaType.OBJECT,
+                    implementation = ReportFiltersListDto.class))
+    )
+    @APIResponse(
+            responseCode = "401",
+            description = "User has not been authenticated.",
+            content = @Content(schema = @Schema(
+                    type = SchemaType.OBJECT,
+                    implementation = InformativeResponse.class))
+    )
+    @APIResponse(
+            responseCode = "403",
+            description = "Not permitted.",
+            content = @Content(schema = @Schema(
+                    type = SchemaType.OBJECT,
+                    implementation = InformativeResponse.class))
+    )
+    @APIResponse(
+            responseCode = "500",
+            description = "Internal Server Error.",
+            content = @Content(schema = @Schema(
+                    type = SchemaType.OBJECT,
+                    implementation = InformativeResponse.class))
+    )
+    @SecurityRequirement(name = "Authentication")
+    @GET
+    @Path("/filters/by-report-definition/{report-id}")
+    @Produces(MediaType.APPLICATION_JSON)
+    @Registration
+    public Response getFilters(@Parameter(
+            description = "The ID of the report definition.",
+            required = true,
+            example = "1",
+            schema = @Schema(type = SchemaType.STRING))
+                               @PathParam("report-id") @NotFoundEntity(repository = ReportRepository.class, message = "There is no Report with the following id:") Long reportId) {
+
+        var response = reportService.getAllFilters(reportId);
+
+        return Response.ok().entity(response).build();
+    }
+
+
+    /**
+     * Runs an ad-hoc report definition and returns the generated table.
+     *
+     * @param request Report definition (rows, columns, values, filters).
+     * @return Report results including rows, columns, and data.
+     */
+
+    @Tag(name = "Reports")
+    @Operation(
+            summary = "Generate an ad-hoc report",
+            description = "This endpoint executes a report definition provided in the path and returns the generated results as a table."
+    )
+    @APIResponse(
+            responseCode = "200",
+            description = "Report results with rows, columns, and data matrix",
+            content = @Content(schema = @Schema(
+                    type = SchemaType.OBJECT,
+                    implementation = ReportResponseDto.class))
+    )
+    @APIResponse(
+            responseCode = "401",
+            description = "User has not been authenticated.",
+            content = @Content(schema = @Schema(
+                    type = SchemaType.OBJECT,
+                    implementation = InformativeResponse.class))
+    )
+    @APIResponse(
+            responseCode = "403",
+            description = "Not permitted.",
+            content = @Content(schema = @Schema(
+                    type = SchemaType.OBJECT,
+                    implementation = InformativeResponse.class))
+    )
+    @APIResponse(
+            responseCode = "500",
+            description = "Internal Server Error.",
+            content = @Content(schema = @Schema(
+                    type = SchemaType.OBJECT,
+                    implementation = InformativeResponse.class))
+    )
+    @SecurityRequirement(name = "Authentication")
+    @POST
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    @Registration
+
+    @Path("/generate/{id}")
+    public Response generate(
+            @Parameter(
+            description = "The ID of the report definition.",
+            required = true,
+            example = "1",
+            schema = @Schema(type = SchemaType.STRING))
+            @PathParam("id")
+            @NotFoundEntity(repository = ReportRepository.class, message = "There is no Report with the following id:") Long id,
+            @RequestBody(
+                    description = "Filters to apply when generating the report.",
+                    required = true,
+                    content = @Content(
+                            schema = @Schema(implementation = ReportFilterDto.class),
+                            examples = {
+                                    @ExampleObject(
+                                            name = "Actors × Assessments",
+                                            summary = "Example for report ID = 1",
+                                            value = "{\n" +
+                                                    "  \"filters\": {\n" +
+                                                    "    \"actor\": [\n" +
+                                                    "      \"pid_graph:0E00C332\"\n" +
+                                                    "    ],\n" +
+                                                    "    \"motivation\": [\n" +
+                                                    "      \"pid_graph:3E109BBA\"\n" +
+                                                    "    ],\n" +
+                                                    "    \"publication_status\": [\n" +
+                                                    "      \"1\",\n" +
+                                                    "      \"2\"\n" +
+                                                    "    ]\n" +
+                                                    "  }\n" +
+                                                    "}"
+                                    ),
+                                    @ExampleObject(
+                                            name = "Organisations × Assessments",
+                                            summary = "Example for report ID = 2",
+                                            value = "{\n" +
+                                                    "  \"filters\": {\n" +
+                                                    "    \"organisation\": [\n" +
+                                                    "      \"05tcasm11\"\n" +
+                                                    "    ],\n" +
+                                                    "    \"motivation\": [\n" +
+                                                    "      \"pid_graph:3E109BBA\"\n" +
+                                                    "    ],\n" +
+                                                    "    \"publication_status\": [\n" +
+                                                    "      \"1\",\n" +
+                                                    "      \"2\"\n" +
+                                                    "    ]\n" +
+                                                    "  }\n" +
+                                                    "}"
+                                    )
+                            }
+                    )
+            )
+            @Valid
+            @NotNull(message = "The request body is empty.")
+            ReportFilterDto request) {
+
+        var response = reportService.run(id, request, utility.getUserUniqueIdentifier());
+        return Response.ok().entity(response).build();
+    }
+
+}

--- a/api/src/main/resources/application.properties
+++ b/api/src/main/resources/application.properties
@@ -138,9 +138,7 @@ quarkus.health.openapi.included=true
 
 quarkus.rest-client."org.grnet.cat.api.health.AAIProxyClient".url=${QUARKUS_OIDC_AUTH_SERVER_URL:https://login-devel.einfra.grnet.gr/auth/realms/einfra}
 
-# zenodo.api.key=MY_ACCESS_TOKEN
 quarkus.rest-client."org.grnet.cat.services.zenodo.ZenodoClient".url=https://sandbox.zenodo.org
-# zenodo.enabled=true
 
 quarkus.rest-client.naco-service.url=https://cvs.data.kit.edu
 quarkus.rest-client.naco-service.scope=jakarta.inject.Singleton

--- a/data-transfer-object/src/main/java/org/grnet/cat/dtos/report/FilterDefinitionDto.java
+++ b/data-transfer-object/src/main/java/org/grnet/cat/dtos/report/FilterDefinitionDto.java
@@ -1,0 +1,56 @@
+package org.grnet.cat.dtos.report;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
+
+// Nested DTO for FilterDefinition
+public  class FilterDefinitionDto {
+    @Schema(
+            type = SchemaType.STRING,
+            description = "Name of the filter",
+            example = "status"
+    )
+    @JsonProperty("name")
+    public String name;
+
+    @Schema(
+            type = SchemaType.STRING,
+            description = "Type of the filter. E.g., String, Enum, Date",
+            example = "String"
+    )
+    @JsonProperty("type")
+    public String type;
+
+    @Schema(
+            type = SchemaType.BOOLEAN,
+            description = "Indicates if the filter is required",
+            example = "true"
+    )
+    @JsonProperty("required")
+    public Boolean required;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public void setType(String type) {
+        this.type = type;
+    }
+
+    public Boolean getRequired() {
+        return required;
+    }
+
+    public void setRequired(Boolean required) {
+        this.required = required;
+    }
+}

--- a/data-transfer-object/src/main/java/org/grnet/cat/dtos/report/FilterWithValuesResponseDto.java
+++ b/data-transfer-object/src/main/java/org/grnet/cat/dtos/report/FilterWithValuesResponseDto.java
@@ -1,0 +1,68 @@
+package org.grnet.cat.dtos.report;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
+
+import java.util.List;
+
+public class FilterWithValuesResponseDto {
+
+    @Schema(
+            description = "The filter definition (name, type, required)"
+    )
+    @JsonProperty("definition")
+    private FilterDefinitionDto definition;
+
+    @Schema(
+            type = SchemaType.ARRAY,
+            description = "Permitted values for this filter",
+            example = "[\"1\", \"2\"]"
+    )
+    @JsonProperty("values")
+    private List<PermittedValueDto> values;
+
+
+    // Getters and setters
+    public FilterDefinitionDto getDefinition() {
+        return definition;
+    }
+
+    public void setDefinition(FilterDefinitionDto definition) {
+        this.definition = definition;
+    }
+
+    public List<PermittedValueDto> getValues() {
+        return values;
+    }
+
+    public void setValues(List<PermittedValueDto> values) {
+        this.values = values;
+    }
+
+    public static class PermittedValueDto {
+        private String id;
+        private String label;
+
+        public PermittedValueDto(String id, String name) {
+            this.id = id;
+            this.label = name;
+        }
+
+        public String getId() {
+            return id;
+        }
+
+        public void setId(String id) {
+            this.id = id;
+        }
+
+        public String getLabel() {
+            return label;
+        }
+
+        public void setLabel(String name) {
+            this.label = name;
+        }
+    }
+}

--- a/data-transfer-object/src/main/java/org/grnet/cat/dtos/report/MotivationPartialDto.java
+++ b/data-transfer-object/src/main/java/org/grnet/cat/dtos/report/MotivationPartialDto.java
@@ -1,0 +1,19 @@
+package org.grnet.cat.dtos.report;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
+
+public class MotivationPartialDto {
+
+    /**
+     * Option DTO for motivations.
+     */
+    @Schema(
+            type = SchemaType.STRING,
+            implementation = String.class,
+            description = "Motivation id",
+            example = "pid_graph:3E109BBA")
+    @JsonProperty("id")
+    public String id;
+}

--- a/data-transfer-object/src/main/java/org/grnet/cat/dtos/report/ReportDefinitionDto.java
+++ b/data-transfer-object/src/main/java/org/grnet/cat/dtos/report/ReportDefinitionDto.java
@@ -1,0 +1,127 @@
+package org.grnet.cat.dtos.report;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
+
+import java.util.List;
+@Getter
+public class ReportDefinitionDto {
+
+    @Schema(
+            type = SchemaType.STRING,
+            description = "The ID of the report",
+            example = "1"
+    )
+    @JsonProperty("id")
+    public Long id;
+
+    @Schema(
+            type = SchemaType.STRING,
+            description = "Label of the report",
+            example = "Actors x Assessments"
+    )
+    @JsonProperty("label")
+    public String label;
+
+    @Schema(
+            type = SchemaType.STRING,
+            description = "Description of the report",
+            example = "Assessment results per actor"
+    )
+    @JsonProperty("description")
+    public String description;
+
+    @Schema(
+            type = SchemaType.STRING,
+            implementation = String.class,
+            description = "Dimension used for table rows. Allowed values: actor, organisation",
+            example = "actor"
+    )
+    @JsonProperty("row_dimension")
+    public String rowDimension;
+
+    @Schema(
+            type = SchemaType.STRING,
+            implementation = String.class,
+            description = "Dimension used for table columns. Allowed values: assessment, subject",
+            example = "assessment"
+    )
+    @JsonProperty("column_dimension")
+    public String columnDimension;
+
+    @Schema(
+            type = SchemaType.STRING,
+            implementation = String.class,
+            description = "Type of value (e.g., compliance, status, score). Allowed values: compliance",
+            example = "compliance"
+    )
+    @JsonProperty("value_type")
+    public String valueType;
+
+    @Schema(
+            type = SchemaType.ARRAY,
+            description = "Filters applied to the report",
+            implementation = FilterDefinitionDto.class
+    )
+    @JsonProperty("filters")
+    public List<FilterDefinitionDto> filters;
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getLabel() {
+        return label;
+    }
+
+    public void setLabel(String label) {
+        this.label = label;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public String getRowDimension() {
+        return rowDimension;
+    }
+
+    public void setRowDimension(String rowDimension) {
+        this.rowDimension = rowDimension;
+    }
+
+    public String getColumnDimension() {
+        return columnDimension;
+    }
+
+    public void setColumnDimension(String columnDimension) {
+        this.columnDimension = columnDimension;
+    }
+
+    public String getValueType() {
+        return valueType;
+    }
+
+    public void setValueType(String valueType) {
+        this.valueType = valueType;
+    }
+
+    public List<FilterDefinitionDto> getFilters() {
+        return filters;
+    }
+
+    public void setFilters(List<FilterDefinitionDto> filters) {
+        this.filters = filters;
+    }
+
+}

--- a/data-transfer-object/src/main/java/org/grnet/cat/dtos/report/ReportFilterDto.java
+++ b/data-transfer-object/src/main/java/org/grnet/cat/dtos/report/ReportFilterDto.java
@@ -1,0 +1,33 @@
+package org.grnet.cat.dtos.report;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
+import org.grnet.cat.constraints.ValidFilters;
+import org.grnet.cat.repositories.registry.MotivationRepository;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class ReportFilterDto {
+
+    @Schema(
+            type = SchemaType.OBJECT,
+            description = "Dynamic map of filters (name → values).",
+            example = "{ \"motivations\": [\"pid_graph:3E109BBA\"], \"publication_status\": [\"published\"] }"
+    )
+    @JsonProperty("filters")
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    @ValidFilters(repository = MotivationRepository.class)
+    private Map<String, List<String>> filters = new HashMap<>();
+
+    public Map<String, List<String>> getFilters() {
+        return filters;
+    }
+
+    public void setFilters(Map<String, List<String>> filters) {
+        this.filters = filters;
+    }
+}

--- a/data-transfer-object/src/main/java/org/grnet/cat/dtos/report/ReportFiltersListDto.java
+++ b/data-transfer-object/src/main/java/org/grnet/cat/dtos/report/ReportFiltersListDto.java
@@ -1,0 +1,26 @@
+package org.grnet.cat.dtos.report;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
+
+import java.util.List;
+
+public class ReportFiltersListDto {
+
+    private List<FilterWithValuesResponseDto> filters;
+
+    public ReportFiltersListDto() {}
+
+    public ReportFiltersListDto(List<FilterWithValuesResponseDto> filters) {
+        this.filters = filters;
+    }
+
+    public List<FilterWithValuesResponseDto> getFilters() {
+        return filters;
+    }
+
+    public void setFilters(List<FilterWithValuesResponseDto> filters) {
+        this.filters = filters;
+    }
+}

--- a/data-transfer-object/src/main/java/org/grnet/cat/dtos/report/ReportRequestDto.java
+++ b/data-transfer-object/src/main/java/org/grnet/cat/dtos/report/ReportRequestDto.java
@@ -1,0 +1,19 @@
+package org.grnet.cat.dtos.report;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.Valid;
+import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
+import org.grnet.cat.constraints.ValidUrl;
+
+public class ReportRequestDto {
+
+    @Schema(
+            type = SchemaType.OBJECT,
+            implementation = ReportFilterDto.class,
+            description = "Selected filters for the report"
+    )
+    @JsonProperty("filters")
+    @Valid
+    public ReportFilterDto filters;
+}

--- a/data-transfer-object/src/main/java/org/grnet/cat/dtos/report/ReportResponseDto.java
+++ b/data-transfer-object/src/main/java/org/grnet/cat/dtos/report/ReportResponseDto.java
@@ -1,0 +1,195 @@
+package org.grnet.cat.dtos.report;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
+
+import java.util.List;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@Getter
+public class ReportResponseDto {
+
+    @Schema(
+            type = SchemaType.STRING,
+            description = "Name of the report",
+            example = "Actor x Assessments"
+    )
+    @JsonProperty("label")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public String label;
+
+    @Schema(
+            type = SchemaType.STRING,
+            description = "Optional description of the report",
+            example = "Assessment results per actor"
+    )
+    @JsonProperty("description")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public String description;
+
+    @Schema(
+            type = SchemaType.STRING,
+            description = "Dimension used for table rows",
+            example = "actor"
+    )
+    @JsonProperty("rows_dimension")
+    public String rowsDimension;
+
+    @Schema(
+            type = SchemaType.STRING,
+            description = "Dimension used for table columns",
+            example = "assessment"
+    )
+    @JsonProperty("columns_dimension")
+    public String columnsDimension;
+
+    @Schema(
+            type = SchemaType.STRING,
+            description = "Type of value (e.g., compliance, status)",
+            example = "compliance"
+    )
+    @JsonProperty("value_type")
+    public String valueType;
+
+    @Schema(
+            type = SchemaType.OBJECT,
+            example = "{\"motivationId\":\"pid_graph:3E109BBA\",\"published\":true}"
+    )
+    @JsonProperty("filters")
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    public ReportFilterDto filters;
+
+    @Schema(
+            type = SchemaType.STRING,
+            description = "User who created the report",
+            example = "reporter"
+    )
+    @JsonProperty("created_by")
+    public String createdBy;
+
+    @Schema(
+            type = SchemaType.STRING,
+            implementation = String.class,
+            description = "Timestamp when the report was created",
+            example = "2025-09-15T20:30:00Z"
+    )
+    @JsonProperty("created_on")
+    public String createdOn;
+
+    @Schema(
+            type = SchemaType.ARRAY,
+            implementation = String.class,
+            description = "List of row labels (e.g.actors, organizations)",
+            example = "[\"PID Manager (Role)\", \"PID Owner (Role)\", \"PID Service Provider (Role)\"]"
+    )
+    @JsonProperty("rows")
+    public List<String> rows;
+
+    @Schema(
+            type = SchemaType.ARRAY,
+            implementation = String.class,
+            description = "List of column labels (e.g. assessments)",
+            example = "[\"Assessment-1\", \"Assessment-2\"]"
+    )
+    @JsonProperty("columns")
+    public List<String> columns;
+
+    @Schema(
+            type = SchemaType.ARRAY,
+            description = "Matrix of data values, aligned with rows and columns",
+            example = "[[\"PASS\",\"FAIL\"],[\"PASS\",\"N/A\"],[\"FAIL\",\"PASS\"]]"
+    )
+    @JsonProperty("data")
+    public List<List<String>> data;
+
+    public String getLabel() {
+        return label;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public String getRowsDimension() {
+        return rowsDimension;
+    }
+
+    public String getColumnsDimension() {
+        return columnsDimension;
+    }
+
+    public String getValueType() {
+        return valueType;
+    }
+
+    public ReportFilterDto getFilters() {
+        return filters;
+    }
+
+    public String getCreatedBy() {
+        return createdBy;
+    }
+
+    public String getCreatedOn() {
+        return createdOn;
+    }
+
+    public List<String> getRows() {
+        return rows;
+    }
+
+    public List<String> getColumns() {
+        return columns;
+    }
+
+    public List<List<String>> getData() {
+        return data;
+    }
+
+    public void setLabel(String label) {
+        this.label = label;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public void setRowsDimension(String rowsDimension) {
+        this.rowsDimension = rowsDimension;
+    }
+
+    public void setColumnsDimension(String columnsDimension) {
+        this.columnsDimension = columnsDimension;
+    }
+
+    public void setValueType(String valueType) {
+        this.valueType = valueType;
+    }
+
+    public void setFilters(ReportFilterDto filters) {
+        this.filters = filters;
+    }
+
+    public void setCreatedBy(String createdBy) {
+        this.createdBy = createdBy;
+    }
+
+    public void setCreatedOn(String createdOn) {
+        this.createdOn = createdOn;
+    }
+
+    public void setRows(List<String> rows) {
+        this.rows = rows;
+    }
+
+    public void setColumns(List<String> columns) {
+        this.columns = columns;
+    }
+
+    public void setData(List<List<String>> data) {
+        this.data = data;
+    }
+}

--- a/entity/src/main/java/org/grnet/cat/converter/FilterDefinition.java
+++ b/entity/src/main/java/org/grnet/cat/converter/FilterDefinition.java
@@ -1,0 +1,26 @@
+package org.grnet.cat.converter;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class FilterDefinition {
+
+    private String name;
+    private String type;
+    private Boolean required;
+
+    public FilterDefinition() {} // no-args constructor
+
+    // getters and setters
+    public String getName() { return name; }
+    public void setName(String name) { this.name = name; }
+
+    public String getType() { return type; }
+    public void setType(String type) { this.type = type; }
+
+    public Boolean getRequired() { return required; }
+    public void setRequired(Boolean required) { this.required = required; }
+
+}

--- a/entity/src/main/java/org/grnet/cat/converter/JsonConverter.java
+++ b/entity/src/main/java/org/grnet/cat/converter/JsonConverter.java
@@ -1,0 +1,35 @@
+package org.grnet.cat.converter;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+import org.grnet.cat.entities.ReportDefinition;
+
+import java.io.IOException;
+import java.util.List;
+
+@Converter
+public class JsonConverter implements AttributeConverter<List<FilterDefinition>, String> {
+
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    @Override
+    public String convertToDatabaseColumn(List<FilterDefinition> attribute) {
+        try {
+            return mapper.writeValueAsString(attribute);
+        } catch (JsonProcessingException e) {
+            throw new IllegalArgumentException(e);
+        }
+    }
+
+    @Override
+    public List<FilterDefinition> convertToEntityAttribute(String dbData) {
+        try {
+            return mapper.readValue(dbData, new TypeReference<List<FilterDefinition>>() {});
+        } catch (IOException e) {
+            throw new IllegalArgumentException(e);
+        }
+    }
+}

--- a/entity/src/main/java/org/grnet/cat/entities/ReportDefinition.java
+++ b/entity/src/main/java/org/grnet/cat/entities/ReportDefinition.java
@@ -1,0 +1,103 @@
+package org.grnet.cat.entities;
+
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.Setter;
+import org.grnet.cat.converter.FilterDefinition;
+import org.grnet.cat.converter.JsonConverter;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
+
+import java.util.List;
+
+@Entity
+@Table(name = "t_Report_Definition")
+@Getter
+@Setter
+public class ReportDefinition {
+
+    @Id
+    private Long id;
+
+    @Column(name = "label")
+    @NotNull
+    private String label;
+
+    @Column(name = "description")
+    @NotNull
+    private String description;
+
+    @Column(name = "row_dimension")
+    @NotNull
+    private String rowDimension;
+
+    @Column(name = "column_dimension")
+    @NotNull
+    private String columnDimension;
+
+    @Column(name = "value_type")
+    @NotNull
+    private String valueType;
+
+    @Column(columnDefinition = "jsonb")
+    //@Convert(converter = JsonConverter.class)
+    @JdbcTypeCode(SqlTypes.JSON)
+    private List<FilterDefinition> filters;
+
+    public Long getId() {
+        return id;
+    }
+
+    public String getLabel() {
+        return label;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public String getRowDimension() {
+        return rowDimension;
+    }
+
+    public String getColumnDimension() {
+        return columnDimension;
+    }
+
+    public String getValueType() {
+        return valueType;
+    }
+
+    public List<FilterDefinition> getFilters() {
+        return filters;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public void setLabel(String label) {
+        this.label = label;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public void setRowDimension(String rowDimension) {
+        this.rowDimension = rowDimension;
+    }
+
+    public void setColumnDimension(String columnDimension) {
+        this.columnDimension = columnDimension;
+    }
+
+    public void setValueType(String valueType) {
+        this.valueType = valueType;
+    }
+
+    public void setFilters(List<FilterDefinition> filters) {
+        this.filters = filters;
+    }
+}

--- a/entity/src/main/java/org/grnet/cat/entities/Validation.java
+++ b/entity/src/main/java/org/grnet/cat/entities/Validation.java
@@ -82,4 +82,12 @@ public class Validation {
 
     @Column(name = "rejection_reason")
     private String rejectionReason;
+
+    public String getOrganisationId() {
+        return organisationId;
+    }
+
+    public String getOrganisationName() {
+        return organisationName;
+    }
 }

--- a/entity/src/main/java/org/grnet/cat/entities/registry/Motivation.java
+++ b/entity/src/main/java/org/grnet/cat/entities/registry/Motivation.java
@@ -85,6 +85,13 @@ public class Motivation extends Registry {
         actorMotivation.getMotivation().actors.add(actorMotivation);
     }
 
+    public String getMtv() {
+        return mtv;
+    }
+
+    public void setMtv(String mtv) {
+        this.mtv = mtv;
+    }
     public String getId() {
         return id;
     }

--- a/entity/src/main/java/org/grnet/cat/entities/registry/MotivationActorJunction.java
+++ b/entity/src/main/java/org/grnet/cat/entities/registry/MotivationActorJunction.java
@@ -102,4 +102,8 @@ public class MotivationActorJunction extends Registry{
     public MotivationActorId getId() {
         return id;
     }
+
+    public RegistryActor getActor() {
+        return actor;
+    }
 }

--- a/entity/src/main/java/org/grnet/cat/entities/registry/RegistryActor.java
+++ b/entity/src/main/java/org/grnet/cat/entities/registry/RegistryActor.java
@@ -100,4 +100,8 @@ public class RegistryActor extends Registry {
     public void setLodMTV(String lodMTV) {
         this.lodMTV = lodMTV;
     }
+
+    public String getAct() {
+        return act;
+    }
 }

--- a/entity/src/main/resources/db/migration/tables/report/V1.99__report_definition.sql
+++ b/entity/src/main/resources/db/migration/tables/report/V1.99__report_definition.sql
@@ -1,0 +1,32 @@
+-- ------------------------------------------------
+-- Version: V1.99
+-- Description: Create table for fixed report definitions
+-- ------------------------------------------------
+
+CREATE TABLE t_Report_Definition (
+    id SERIAL PRIMARY KEY,
+    label VARCHAR(255) NOT NULL,
+    description TEXT,
+    row_dimension VARCHAR(50) NOT NULL,
+    column_dimension VARCHAR(50) NOT NULL,
+    value_type VARCHAR(50) NOT NULL,
+    filters JSONB
+);
+INSERT INTO t_Report_Definition (label, description, row_dimension, column_dimension, value_type, filters)
+VALUES
+(
+    'Actors × Assessments',
+    'Assessment results per actor',
+    'actor', 'assessment', 'compliance',
+    $$[{"name":"actor","type":"String","required":false},
+       {"name":"motivation","type":"String","required":false},
+       {"name":"publication_status","type":"String","required":false}]$$::jsonb
+),
+(
+    'Organisations × Assessments',
+    'Assessment results per organisation',
+    'organisation', 'assessment', 'compliance',
+    $$[{"name":"organisation","type":"String","required":false},
+       {"name":"motivation","type":"String","required":false},
+       {"name":"publication_status","type":"String","required":false}]$$::jsonb
+);

--- a/enum/src/main/java/org/grnet/cat/enums/PublicationStatus.java
+++ b/enum/src/main/java/org/grnet/cat/enums/PublicationStatus.java
@@ -1,0 +1,37 @@
+package org.grnet.cat.enums;
+
+public enum PublicationStatus {
+    PUBLISHED("1", "published", true),
+    UNPUBLISHED("2", "unpublished", false);
+
+    private final String id;
+    private final String label;
+    private final boolean flag;
+
+    PublicationStatus(String id, String label, boolean flag) {
+        this.id = id;
+        this.label = label;
+        this.flag = flag;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public String getLabel() {
+        return label;
+    }
+
+    public boolean asBoolean() {
+        return flag;
+    }
+
+    public static PublicationStatus fromId(String id) {
+        for (PublicationStatus ps : values()) {
+            if (ps.id.equals(id)) {
+                return ps;
+            }
+        }
+        throw new IllegalArgumentException("Invalid publication_status: " + id);
+    }
+}

--- a/mapper/src/main/java/org/grnet/cat/mappers/ReportMapper.java
+++ b/mapper/src/main/java/org/grnet/cat/mappers/ReportMapper.java
@@ -1,0 +1,24 @@
+package org.grnet.cat.mappers;
+
+import org.grnet.cat.converter.FilterDefinition;
+import org.grnet.cat.dtos.report.FilterDefinitionDto;
+import org.grnet.cat.dtos.report.ReportDefinitionDto;
+import org.grnet.cat.entities.ReportDefinition;
+import org.mapstruct.IterableMapping;
+import org.mapstruct.Mapper;
+import org.mapstruct.Named;
+import org.mapstruct.factory.Mappers;
+
+import java.util.List;
+@Mapper
+public interface ReportMapper {
+    ReportMapper INSTANCE = Mappers.getMapper(ReportMapper.class);
+
+    @Named("map")
+    ReportDefinitionDto entityToDto(ReportDefinition entity);
+
+    @IterableMapping(qualifiedByName = "map")
+    List<ReportDefinitionDto> entitiesToDtos(List<ReportDefinition> entities);
+
+    FilterDefinitionDto filterToDto(FilterDefinition filter);
+}

--- a/repository/src/main/java/org/grnet/cat/repositories/ReportRepository.java
+++ b/repository/src/main/java/org/grnet/cat/repositories/ReportRepository.java
@@ -1,0 +1,137 @@
+package org.grnet.cat.repositories;
+
+import io.quarkus.hibernate.orm.panache.Panache;
+import jakarta.enterprise.context.ApplicationScoped;
+import org.grnet.cat.entities.ReportDefinition;
+import org.grnet.cat.enums.PublicationStatus;
+
+import java.util.List;
+import java.util.Optional;
+
+
+@ApplicationScoped
+public class ReportRepository implements Repository<ReportDefinition, Long> {
+
+    /**
+     * Returns all stored report definitions.
+     */
+    public List<ReportDefinition> listAllDefinitions() {
+        return listAll();
+    }
+
+    /**
+     * Finds a report definition by its ID.
+     *
+     * @param id the definition ID
+     * @return an Optional containing the definition if found
+     */
+    public Optional<ReportDefinition> findDefinitionById(Long id) {
+        return find("id", id).firstResultOptional();
+    }
+
+    public List<Object[]> fetchReportData(List<String> motivations,
+                                          List<String> publicationStatus,
+                                          List<String> actors,
+                                          List<String> organisations,
+                                          Long reportDefinitionId) {
+        var em = Panache.getEntityManager();
+        var def = findById(reportDefinitionId);
+
+        var where = new StringBuilder("WHERE 1=1 ");
+
+        // Handle publicationStatus (IDs: 1 = published, 2 = unpublished)
+        if (!publicationStatus.isEmpty()) {
+            where.append("AND (");
+            for (int i = 0; i < publicationStatus.size(); i++) {
+                String paramName = "status" + i;
+                if (i > 0) where.append(" OR ");
+                where.append(" a.published = :").append(paramName);
+            }
+            where.append(") ");
+        }
+
+        // Handle motivations
+        if (!motivations.isEmpty()) {
+            where.append("AND (");
+            for (int i = 0; i < motivations.size(); i++) {
+                String paramName = "motivation" + i;
+                if (i > 0) where.append(" OR ");
+                where.append(" a.motivation_id = :").append(paramName);
+            }
+            where.append(") ");
+        }
+
+        String selectRow;
+        String selectCol;
+
+        if (reportDefinitionId == 1) {
+            // Actors × Assessments
+            selectRow = "a.assessment_doc->'actor'->>'name'";
+            selectCol = "a.assessment_doc->>'name'";
+
+            if (!actors.isEmpty()) {
+                where.append("AND (");
+                for (int i = 0; i < actors.size(); i++) {
+                    String paramName = "actor" + i;
+                    if (i > 0) where.append(" OR ");
+                    where.append(" a.assessment_doc->'actor'->>'id' = :").append(paramName);
+                }
+                where.append(") ");
+            }
+
+        } else if (reportDefinitionId == 2) {
+            // Organisations × Assessments
+            selectRow = "a.assessment_doc->'organisation'->>'name'";
+            selectCol = "a.assessment_doc->>'name'";
+
+            if (!organisations.isEmpty()) {
+                where.append("AND (");
+                for (int i = 0; i < organisations.size(); i++) {
+                    String paramName = "org" + i;
+                    if (i > 0) where.append(" OR ");
+                    where.append(" a.assessment_doc->'organisation'->>'id' = :").append(paramName);
+                }
+                where.append(") ");
+            }
+
+        } else {
+            throw new IllegalArgumentException("Unsupported definition: " + def);
+        }
+
+        var sql = "SELECT " + selectRow + " AS rowLabel, "
+                + selectCol + " AS colLabel, "
+                + "a.assessment_doc AS assessmentDoc "
+                + "FROM MotivationAssessment a "
+                + where
+                + "ORDER BY 1, 2";
+
+        var q = em.createNativeQuery(sql);
+
+        // Bind publicationStatus using enum
+        for (int i = 0; i < publicationStatus.size(); i++) {
+            var ps = PublicationStatus.fromId(publicationStatus.get(i));
+            q.setParameter("status" + i, ps.asBoolean());
+        }
+
+        // Bind motivations
+        for (int i = 0; i < motivations.size(); i++) {
+            q.setParameter("motivation" + i, motivations.get(i));
+        }
+
+        // Bind actors
+        if (reportDefinitionId == 1) {
+            for (int i = 0; i < actors.size(); i++) {
+                q.setParameter("actor" + i, actors.get(i));
+            }
+        }
+
+        // Bind organisations
+        if (reportDefinitionId == 2) {
+            for (int i = 0; i < organisations.size(); i++) {
+                q.setParameter("org" + i, organisations.get(i));
+            }
+        }
+
+        return (List<Object[]>) q.getResultList();
+    }
+}

--- a/service/src/main/java/org/grnet/cat/services/report/ReportService.java
+++ b/service/src/main/java/org/grnet/cat/services/report/ReportService.java
@@ -1,0 +1,287 @@
+package org.grnet.cat.services.report;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.transaction.Transactional;
+import jakarta.ws.rs.BadRequestException;
+import jakarta.ws.rs.NotFoundException;
+import org.grnet.cat.converter.FilterDefinition;
+import org.grnet.cat.dtos.report.*;
+import org.grnet.cat.entities.ReportDefinition;
+import org.grnet.cat.entities.Validation;
+import org.grnet.cat.entities.registry.Motivation;
+import org.grnet.cat.entities.registry.RegistryActor;
+import org.grnet.cat.enums.PublicationStatus;
+import org.grnet.cat.mappers.ReportMapper;
+import org.grnet.cat.repositories.ReportRepository;
+import org.grnet.cat.repositories.ValidationRepository;
+import org.grnet.cat.repositories.registry.MotivationActorRepository;
+import org.grnet.cat.repositories.registry.MotivationRepository;
+import org.grnet.cat.services.utils.FilterType;
+
+import java.time.Instant;
+import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Function;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+
+@ApplicationScoped
+public class ReportService {
+
+    @Inject
+    ReportRepository reportRepository;
+    @Inject
+    ObjectMapper objectMapper;
+
+    @Inject
+    MotivationRepository motivationRepository;
+    @Inject
+    MotivationActorRepository motivationActorRepository;
+    @Inject
+    ValidationRepository validationRepository;
+
+
+    /**
+     * Returns all available report definitions from the database.
+     */
+    @Transactional
+    public List<ReportDefinitionDto> getAllDefinitions() {
+
+        var def = reportRepository.listAllDefinitions();
+
+        return ReportMapper.INSTANCE.entitiesToDtos(def);
+    }
+
+    /**
+     * Returns all available report definitions from the database.
+     */
+    @Transactional
+    public ReportDefinitionDto getDefinitionById(Long id) {
+
+        var def = reportRepository.findById(id);
+
+        return ReportMapper.INSTANCE.entityToDto(def);
+    }
+
+    /**
+     * Returns available filter options.
+     */
+    public List<FilterWithValuesResponseDto> getAllFilters(Long reportId) {
+        var reportDefinitionOpt = reportRepository.findDefinitionById(reportId);
+        var filters = reportDefinitionOpt.get().getFilters();
+
+        var repos = new FilterType.Repositories(motivationRepository, motivationActorRepository, validationRepository);
+
+        return filters.stream()
+                .map(def -> {
+                    var dto = new FilterWithValuesResponseDto();
+                    dto.setDefinition(ReportMapper.INSTANCE.filterToDto(def));
+
+                    FilterType.fromName(def.getName())
+                            .ifPresent(ft -> dto.setValues(ft.getValues(repos)));
+
+                    return dto;
+                })
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * Executes a report definition by ID with the given filters and user context.
+     *
+     * @param request DTO containing the reportDefinitionId and optional filters
+     * @param userId  ID of the user running the report
+     * @return a populated ReportResponseDto
+     */
+    @Transactional
+    public ReportResponseDto run(Long id, ReportFilterDto request, String userId) {
+
+        // 1. Load the report definition
+        var reportDefinition = reportRepository.findDefinitionById(id)
+                .orElseThrow(() -> new NotFoundException("Report definition not found for id " + id));
+
+        var def = ReportMapper.INSTANCE.entityToDto(reportDefinition);
+
+        // 2. Validate filters against definition
+        if (request != null && request.getFilters() != null) {
+            Map<String, List<String>> provided = request.getFilters();
+            List<FilterDefinition> expectedFilters = reportDefinition.getFilters();
+
+            for (FilterDefinition expected : expectedFilters) {
+                List<String> values = provided.get(expected.getName());
+
+                // required check
+                if (Boolean.TRUE.equals(expected.getRequired()) &&
+                        (values == null || values.isEmpty())) {
+                    throw new BadRequestException("Missing required filter: " + expected.getName());
+                }
+
+                // type check
+                if (values != null && !validateListType(values, expected.getType())) {
+                    throw new BadRequestException(
+                            "Filter '" + expected.getName() + "' must be of type " + expected.getType()
+                    );
+                }
+            }
+        }
+
+        // 3. Extract specific filters (if needed by repository)
+        List<String> motivations = request.getFilters().getOrDefault("motivations", List.of());
+        List<String> publicationStatus = request.getFilters().getOrDefault("publication_status", List.of());
+        List<String> actors = request.getFilters().getOrDefault("actor", List.of());
+        List<String> organisations = request.getFilters().getOrDefault("organisation", List.of());
+
+
+        // 4. Fetch raw data
+        var raw = reportRepository.fetchReportData(motivations, publicationStatus, actors, organisations, id);
+
+        // 5. Build matrix
+        var matrix = new LinkedHashMap<String, Map<String, String>>();
+        var colSet = new LinkedHashSet<String>();
+        buildMatrix(raw, matrix, colSet);
+
+        // 6. Return response
+        return buildResponse(def, request, userId, matrix, colSet);
+    }
+
+    private boolean validateListType(List<String> values, String expectedType) {
+        switch (expectedType.toLowerCase()) {
+            case "string":
+                return true; // always valid
+            case "number":
+                return values.stream().allMatch(v -> v.matches("-?\\d+(\\.\\d+)?"));
+            case "boolean":
+                return values.stream().allMatch(v -> v.equalsIgnoreCase("true") || v.equalsIgnoreCase("false"));
+            default:
+                return false;
+        }
+    }
+
+    private void buildMatrix(List<Object[]> raw,
+                             Map<String, Map<String, String>> matrix,
+                             Set<String> colSet) {
+        for (Object[] row : raw) {
+            var rowLabel = safeLabel((String) row[0]);
+            var colLabel = safeLabel((String) row[1]);
+            var assessmentDoc = (String) row[2];
+
+            var value = extractCompliance(assessmentDoc);
+
+            matrix.computeIfAbsent(rowLabel, k -> new LinkedHashMap<>())
+                    .put(colLabel, value);
+
+            colSet.add(colLabel);
+        }
+    }
+
+    /**
+     * Validate filter types from request against expected definitions.
+     */
+    private boolean validateType(Object value, String expectedType) {
+        switch (expectedType.toLowerCase()) {
+            case "string":
+                return value instanceof String ||
+                        (value instanceof List && ((List<?>) value).stream().allMatch(v -> v instanceof String));
+            case "number":
+                return value instanceof Number ||
+                        (value instanceof List && ((List<?>) value).stream().allMatch(v -> v instanceof Number));
+            case "boolean":
+                return value instanceof Boolean ||
+                        (value instanceof List && ((List<?>) value).stream().allMatch(v -> v instanceof Boolean));
+            default:
+                return true; // unknown type → let it pass
+        }
+    }
+
+    /**
+     * Builds the response DTO from a definition, userId, and table data.
+     */
+    private ReportResponseDto buildResponse(ReportDefinitionDto def,
+                                            ReportFilterDto request,
+                                            String userId,
+                                            LinkedHashMap<String, Map<String, String>> matrix,
+                                            LinkedHashSet<String> colSet) {
+
+        var table = matrixToDto(matrix, colSet);
+
+        var response = new ReportResponseDto();
+        response.label = def.label;
+        response.description = def.description;
+        response.rowsDimension = def.rowDimension;
+        response.columnsDimension = def.columnDimension;
+        response.rows = table.rows;
+        response.columns = table.columns;
+        response.data = table.data;
+        response.valueType = def.valueType;
+        response.createdBy = userId;
+        response.createdOn = Instant.now().toString();
+
+        // Attach filters back into response
+        if (request != null && request.getFilters() != null && !request.getFilters().isEmpty()) {
+            var filterDto = new ReportFilterDto();
+            filterDto.setFilters(new HashMap<>(request.getFilters())); // copy to avoid mutation
+            response.filters = filterDto;
+        }
+
+        return response;
+    }
+
+
+    /**
+     * Builds the response DTO from definition, userId, and table data.
+     */
+    ReportResponseDto matrixToDto(Map<String, Map<String, String>> matrix, Set<String> assessments) {
+        var result = new ReportResponseDto();
+        result.rows = new ArrayList<>(matrix.keySet());
+        result.columns = new ArrayList<>(assessments);
+
+        List<List<String>> tableData = new ArrayList<>();
+        for (String org : result.rows) {
+            List<String> rowData = new ArrayList<>();
+            for (String assess : result.columns) {
+                String val = "N/A";
+                if (matrix.containsKey(org) && matrix.get(org).containsKey(assess)) {
+                    val = matrix.get(org).get(assess);
+                }
+                rowData.add(val);
+            }
+            tableData.add(rowData);
+        }
+        result.data = tableData;
+        return result;
+    }
+
+    /**
+     * Extracts compliance result from the assessment JSON.
+     * Returns PASS/FAIL/IN PROGRESS/N/A depending on the data.
+     */
+    private String extractCompliance(String assessmentDoc) {
+        try {
+            JsonNode root = objectMapper.readTree(assessmentDoc);
+            JsonNode node = root.path("result").path("compliance");
+
+            if (!node.isMissingNode() && !node.isNull()) {
+                if (node.isBoolean()) {
+                    return node.asBoolean() ? "PASS" : "FAIL";
+                } else if (node.isInt()) {
+                    return node.asInt() == 1 ? "PASS" : "FAIL";
+                } else if (node.isTextual()) {
+                    String s = node.asText().trim();
+                    return s.isEmpty() ? "IN PROGRESS" : s;
+                }
+            }
+            return "IN PROGRESS";
+        } catch (Exception e) {
+            return "N/A";
+        }
+    }
+
+    /**
+     * Ensures labels are non-null and trimmed.
+     */
+    private String safeLabel(String s) {
+        return (s == null || s.trim().isEmpty()) ? "(unknown)" : s.trim();
+    }
+}

--- a/service/src/main/java/org/grnet/cat/services/utils/FilterType.java
+++ b/service/src/main/java/org/grnet/cat/services/utils/FilterType.java
@@ -1,0 +1,96 @@
+package org.grnet.cat.services.utils;
+
+import org.grnet.cat.dtos.report.FilterWithValuesResponseDto;
+import org.grnet.cat.entities.Validation;
+import org.grnet.cat.entities.registry.RegistryActor;
+import org.grnet.cat.enums.PublicationStatus;
+import org.grnet.cat.repositories.ValidationRepository;
+import org.grnet.cat.repositories.registry.MotivationActorRepository;
+import org.grnet.cat.repositories.registry.MotivationRepository;
+
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+public enum FilterType {
+
+
+    MOTIVATION("motivation") {
+        @Override
+        public List<FilterWithValuesResponseDto.PermittedValueDto> getValues(Repositories repos) {
+            return repos.motivationRepository.findAll().stream()
+                    .map(m -> new FilterWithValuesResponseDto.PermittedValueDto(m.getId(), m.getLabel()))
+                    .collect(Collectors.toList());
+        }
+    },
+    PUBLICATION_STATUS("publication_status") {
+        @Override
+        public List<FilterWithValuesResponseDto.PermittedValueDto> getValues(Repositories repos) {
+            return Arrays.stream(PublicationStatus.values())
+                    .map(ps -> new FilterWithValuesResponseDto.PermittedValueDto(ps.getId(), ps.getLabel()))
+                    .collect(Collectors.toList());
+        }
+    },
+    ACTOR("actor") {
+        @Override
+        public List<FilterWithValuesResponseDto.PermittedValueDto> getValues(Repositories repos) {
+            return repos.motivationActorRepository.findAll().stream()
+                    .map(m -> m.getActor())
+                    .collect(Collectors.toMap(
+                            RegistryActor::getId,
+                            RegistryActor::getLabelActor,
+                            (first, duplicate) -> first
+                    ))
+                    .entrySet().stream()
+                    .map(e -> new FilterWithValuesResponseDto.PermittedValueDto(e.getKey(), e.getValue()))
+                    .sorted(Comparator.comparing(FilterWithValuesResponseDto.PermittedValueDto::getLabel))
+                    .collect(Collectors.toList());
+        }
+    },
+    ORGANISATION("organisation") {
+        @Override
+        public List<FilterWithValuesResponseDto.PermittedValueDto> getValues(Repositories repos) {
+            return repos.validationRepository.findAll().stream()
+                    .collect(Collectors.toMap(
+                            Validation::getOrganisationId,
+                            Validation::getOrganisationName,
+                            (first, duplicate) -> first
+                    ))
+                    .entrySet().stream()
+                    .map(e -> new FilterWithValuesResponseDto.PermittedValueDto(e.getKey(), e.getValue()))
+                    .sorted(Comparator.comparing(FilterWithValuesResponseDto.PermittedValueDto::getLabel))
+                    .collect(Collectors.toList());
+        }
+    };
+
+    private final String name;
+
+    FilterType(String name) {
+        this.name = name;
+    }
+
+    public abstract List<FilterWithValuesResponseDto.PermittedValueDto> getValues(Repositories repos);
+
+    public static Optional<FilterType> fromName(String name) {
+        return Arrays.stream(values())
+                .filter(ft -> ft.name.equalsIgnoreCase(name))
+                .findFirst();
+    }
+
+    // Simple container to pass repos/services
+    public static class Repositories {
+        public final MotivationRepository motivationRepository;
+        public final MotivationActorRepository motivationActorRepository;
+        public final ValidationRepository validationRepository;
+
+        public Repositories(MotivationRepository motivationRepository,
+                            MotivationActorRepository motivationActorRepository,
+                            ValidationRepository validationRepository) {
+            this.motivationRepository = motivationRepository;
+            this.motivationActorRepository = motivationActorRepository;
+            this.validationRepository = validationRepository;
+        }
+    }
+}

--- a/service/src/main/java/org/grnet/cat/services/zenodo/ZenodoService.java
+++ b/service/src/main/java/org/grnet/cat/services/zenodo/ZenodoService.java
@@ -11,13 +11,11 @@ import jakarta.ws.rs.BadRequestException;
 import jakarta.ws.rs.NotFoundException;
 import jakarta.ws.rs.ProcessingException;
 import jakarta.ws.rs.WebApplicationException;
-import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.eclipse.microprofile.rest.client.inject.RestClient;
 import org.grnet.cat.constraints.ValidZenodoAction;
 import org.grnet.cat.dtos.assessment.ZenodoAssessmentInfoResponse;
 import org.grnet.cat.dtos.assessment.zenodo.ZenodoDepositResponse;
 import org.grnet.cat.dtos.assessment.registry.UserJsonRegistryAssessmentResponse;
-import org.grnet.cat.dtos.setting.SettingResponseDto;
 import org.grnet.cat.entities.*;
 import org.grnet.cat.enums.MailType;
 import org.grnet.cat.enums.ShareableEntityType;
@@ -80,8 +78,6 @@ public class ZenodoService {
         String token = settingService.getSettingConfig("1", "zenodo.api.key")
                 // Look for this key anywhere in the JSON
                 .orElseThrow(() -> new IllegalStateException("Zenodo API key is not configured."));
-
-        System.out.println("!!!!!!!!!!! Found key: zenodo.api.key => " + token);
 
         return "Bearer " + token;
     }

--- a/validator/src/main/java/org/grnet/cat/constraints/CheckMotivations.java
+++ b/validator/src/main/java/org/grnet/cat/constraints/CheckMotivations.java
@@ -1,0 +1,24 @@
+package org.grnet.cat.constraints;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+import org.grnet.cat.repositories.Repository;
+import org.grnet.cat.validators.CheckMotivationValidator;
+
+import java.lang.annotation.*;
+
+@Constraint(validatedBy = CheckMotivationValidator.class)
+@Target({ElementType.FIELD,  ElementType.PARAMETER, ElementType.TYPE_USE})
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+public @interface CheckMotivations {
+
+
+    String message() default "Action  permitted";
+    Class<?>[] groups() default {};
+    Class<? extends Payload>[] payload() default {};
+    Class<? extends Repository<?,?>> repository();
+    //   boolean isPublishedPermitted()  default false; // Default to checking if published
+    String populatedBy() default "";
+
+}

--- a/validator/src/main/java/org/grnet/cat/constraints/CheckPublicationStatus.java
+++ b/validator/src/main/java/org/grnet/cat/constraints/CheckPublicationStatus.java
@@ -1,0 +1,21 @@
+package org.grnet.cat.constraints;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+import org.grnet.cat.validators.CheckPublicationStatusValidator;
+
+import java.lang.annotation.*;
+
+
+@Constraint(validatedBy = CheckPublicationStatusValidator.class)
+@Target({ElementType.FIELD, ElementType.PARAMETER})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface CheckPublicationStatus {
+
+
+    String message() default "Invalid publication status value. Allowed values are: published, unpublished.";
+
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
+}

--- a/validator/src/main/java/org/grnet/cat/constraints/ValidFilters.java
+++ b/validator/src/main/java/org/grnet/cat/constraints/ValidFilters.java
@@ -1,0 +1,25 @@
+package org.grnet.cat.constraints;
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+import org.grnet.cat.repositories.Repository;
+import org.grnet.cat.validators.CheckMotivationValidator;
+import org.grnet.cat.validators.FiltersValidator;
+
+import java.lang.annotation.*;
+
+
+@Constraint(validatedBy = FiltersValidator.class)
+@Target({ElementType.FIELD,  ElementType.PARAMETER, ElementType.TYPE_USE})
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+public @interface ValidFilters {
+
+
+    String message() default "Action  permitted";
+    Class<?>[] groups() default {};
+    Class<? extends Payload>[] payload() default {};
+    Class<? extends Repository<?,?>> repository();
+    //   boolean isPublishedPermitted()  default false; // Default to checking if published
+    String populatedBy() default "";
+
+}

--- a/validator/src/main/java/org/grnet/cat/validators/CheckMotivationValidator.java
+++ b/validator/src/main/java/org/grnet/cat/validators/CheckMotivationValidator.java
@@ -1,0 +1,51 @@
+package org.grnet.cat.validators;
+
+import jakarta.enterprise.inject.spi.CDI;
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+import org.grnet.cat.constraints.CheckMotivations;
+import org.grnet.cat.repositories.Repository;
+
+import java.util.ArrayList;
+import java.util.List;
+
+
+public class CheckMotivationValidator implements ConstraintValidator<CheckMotivations, List<String>> {
+
+    private Class<? extends Repository<?, ?>> repository;
+
+    @Override
+    public void initialize(CheckMotivations constraintAnnotation) {
+        this.repository = constraintAnnotation.repository();
+    }
+
+    @Override
+    public boolean isValid(List<String> value, ConstraintValidatorContext context) {
+        System.out.println("it is here ");
+        if (value == null || value.isEmpty()) {
+            return true; // no motivations → nothing to check
+        }
+
+        Repository repositoryBean = CDI.current().select(this.repository).get();
+        List<String> notExistingIds = new ArrayList<>();
+
+        for (String id : value) {
+            if (repositoryBean.findById(id) == null) {
+                notExistingIds.add(id);
+            }
+        }
+
+        if (!notExistingIds.isEmpty()) {
+            String message = "Motivation(s) not found with ID(s): " + String.join(", ", notExistingIds);
+
+            // disable default and add custom message
+            context.disableDefaultConstraintViolation();
+            context.buildConstraintViolationWithTemplate(message)
+                    .addConstraintViolation();
+
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/validator/src/main/java/org/grnet/cat/validators/CheckPublicationStatusValidator.java
+++ b/validator/src/main/java/org/grnet/cat/validators/CheckPublicationStatusValidator.java
@@ -1,0 +1,32 @@
+package org.grnet.cat.validators;
+
+
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+import org.grnet.cat.constraints.CheckPublicationStatus;
+
+import java.util.List;
+import java.util.Set;
+
+public class CheckPublicationStatusValidator implements ConstraintValidator<CheckPublicationStatus, List<String>> {
+
+    private static final Set<String> ALLOWED_VALUES = Set.of("published", "unpublished");
+
+    @Override
+    public boolean isValid(List<String> value, ConstraintValidatorContext context) {
+        if (value == null || value.isEmpty()) {
+            return true; // empty is allowed
+        }
+
+        for (String status : value) {
+            if (!ALLOWED_VALUES.contains(status.toLowerCase())) {
+                context.disableDefaultConstraintViolation();
+                context.buildConstraintViolationWithTemplate(
+                        "Invalid publication status: " + status + ". Allowed values are: published, unpublished."
+                ).addConstraintViolation();
+                return false;
+            }
+        }
+        return true;
+    }
+}

--- a/validator/src/main/java/org/grnet/cat/validators/FiltersValidator.java
+++ b/validator/src/main/java/org/grnet/cat/validators/FiltersValidator.java
@@ -1,0 +1,62 @@
+package org.grnet.cat.validators;
+
+import jakarta.enterprise.inject.spi.CDI;
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+import org.grnet.cat.constraints.ValidFilters;
+import org.grnet.cat.enums.PublicationStatus;
+import org.grnet.cat.repositories.Repository;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+
+public class FiltersValidator implements ConstraintValidator<ValidFilters, Map<String, List<String>>> {
+
+    private Class<? extends Repository<?, ?>> repository;
+
+    @Override
+    public void initialize(ValidFilters constraintAnnotation) {
+        this.repository = constraintAnnotation.repository();
+    }
+
+    @Override
+    public boolean isValid(Map<String, List<String>> filters, ConstraintValidatorContext context) {
+        if (filters == null) return true;
+
+        Repository repositoryBean = CDI.current().select(this.repository).get();
+        List<String> notExistingIds = new ArrayList<>();
+
+
+        boolean valid = true;
+
+        if (filters.containsKey("motivations")) {
+            for (String id : filters.get("motivations")) {
+                if (repositoryBean.findById(id) == null) {
+                    context.disableDefaultConstraintViolation();
+                    context.buildConstraintViolationWithTemplate("Invalid motivation ID: " + id)
+                            .addConstraintViolation();
+                    valid = false;
+                }
+            }
+        }
+
+        // Validate publication_status (via enum)
+        if (filters.containsKey("publication_status")) {
+            for (String status : filters.get("publication_status")) {
+                try {
+                    PublicationStatus.fromId(status); // throws if invalid
+                } catch (IllegalArgumentException e) {
+                    context.disableDefaultConstraintViolation();
+                    context.buildConstraintViolationWithTemplate("Invalid publication_status: " + status)
+                            .addConstraintViolation();
+                    valid = false;
+                }
+            }
+        }
+
+
+        return valid;
+    }
+}


### PR DESCRIPTION
# Report Functionality

## Description
This PR introduces the **Report Definitions and Run Report** functionality in the CAT platform.  

Users can now:
- Retrieve **predefined report definitions** from the DB (t_report_definition)  
- Retrieve **available filters metadata** (get motivations id and available/hardcoded publication status)  
- Execute reports by referencing a **definition ID** and applying filters  

---

## New Endpoints

- `GET /v1/reports/definitions` → List all report definitions  
- `GET /v1/reports/definitions/{id}` → Get a specific report definition  
- `GET /v1/reports/filters` → Get available report filters metadata  
- `POST /v1/reports` → Run a report based on a definition and filters  

---

## Request Example
```
{
  "reportDefinitionId": "1",
  "filters": {
    "motivations": {
      "id": "pid_graph:3E109BBA",
      "label": "EOSC PID Policy"
    },
    "publication_status": "all"
  }
}
```

---
## Response Example
```
{
  "name": "Actors × Assessments",
  "description": "Assessment results per actor",
  "rows_dimension": "actor",
  "columns_dimension": "assessment",
  "value_type": "compliance",
  "filters": {
    "motivation": {
      "id": "pid_graph:3E109BBA",
      "label": "EOSC PID Policy"
    },
    "publication_status": "all"
  },
  "created_by": "admin_voperson_id",
  "created_on": "2025-09-18T16:01:47.605577Z",
  "rows": [
    "PID Authority (Role)",
    "PID Owner (Role)",
    "PID Scheme (Component)"
  ],
  "columns": [
    "Assessment-1",
    "Assessment-2"
  ],
  "data": [
    ["PASS", "FAIL"],
    ["PASS", "N/A"],
    ["FAIL", "PASS"]
  ]
}
```

---
## Supported Dimensions (for now)
* **Row dimensions**: actor, organisation
* **Column dimensions**: assessment
* **Value types:** compliance