### PR TITLE
CAT-1018 Prevent auto signout of admin when validated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,7 +74,7 @@ According to [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) , the `Unr
 - [#537](https://github.com/FC4E-CAT/fc4e-cat-api/pull/537) CAT-982: Minor Fixes for Assessment Build
 - [#542](https://github.com/FC4E-CAT/fc4e-cat-api/pull/542) CAT-1005 Updating zenodo key on the fly in settings is not retrieved in service
 - [#544](https://github.com/FC4E-CAT/fc4e-cat-api/pull/544) CAT-1006:Admin actions should force signout user from CAT Service
-
+- [#552](https://github.com/FC4E-CAT/fc4e-cat-api/pull/552) CAT-1018 Prevent auto signout of admin when validated 
 
 ## 2.0.0 - 2025-03-31
 ---

--- a/service/src/main/java/org/grnet/cat/services/ValidationService.java
+++ b/service/src/main/java/org/grnet/cat/services/ValidationService.java
@@ -18,6 +18,7 @@ import org.grnet.cat.enums.Source;
 import org.grnet.cat.enums.ValidationStatus;
 import org.grnet.cat.exceptions.ConflictException;
 import org.grnet.cat.mappers.ValidationMapper;
+import org.grnet.cat.repositories.RoleRepository;
 import org.grnet.cat.repositories.ValidationRepository;
 import org.grnet.cat.repositories.registry.RegistryActorRepository;
 import org.grnet.cat.validators.ValidationRequestValidator;
@@ -44,9 +45,9 @@ public class ValidationService {
     @Inject
     @Named("keycloak-service")
     RoleService roleService;
-
     @Inject
-    RegistryActorRepository registryActorRepository;
+    RoleRepository roleRepository;
+
 
     private static final Logger LOG = Logger.getLogger(ValidationService.class);
 
@@ -54,8 +55,14 @@ public class ValidationService {
 
         switch (status) {
             case APPROVED: {
-                if (validationRepository.countApprovedValidationsByUserId(userId)<2) { //if it is the first validation approved assign validated role. else there is no need to check for adding roles, validated will alredy exist
-                    roleService.assignRolesToUser(userId, List.of("validated"), Boolean.TRUE);
+                if (validationRepository.countApprovedValidationsByUserId(userId) < 2) { //if it is the first validation approved assign validated role. else there is no need to check for adding roles, validated will alredy exist
+                    boolean hasAdminRole = roleRepository.fetchUserRoles(userId).stream()
+                            .anyMatch(role -> "admin".equalsIgnoreCase(role.getName()));
+                    boolean signoutUser = Boolean.TRUE;
+                    if (hasAdminRole) {
+                        signoutUser = Boolean.FALSE;
+                    }
+                    roleService.assignRolesToUser(userId, List.of("validated"), signoutUser);
                 }
                 break;
             }


### PR DESCRIPTION
When first validation request is pproved check if user is already admin and if so assign validated role without forcing signout
else force signout