### PR TITLE
CAT-1037: Add CSV Export Support for Reports

### DIFF
--- a/api/src/main/java/org/grnet/cat/api/endpoints/ReportsEndpoint.java
+++ b/api/src/main/java/org/grnet/cat/api/endpoints/ReportsEndpoint.java
@@ -22,6 +22,7 @@ import org.eclipse.microprofile.openapi.annotations.security.SecurityScheme;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
 import org.grnet.cat.api.filters.Registration;
 import org.grnet.cat.constraints.NotFoundEntity;
+import org.grnet.cat.dtos.CsvResponseDto;
 import org.grnet.cat.dtos.InformativeResponse;
 import org.grnet.cat.dtos.report.*;
 import org.grnet.cat.repositories.ReportRepository;
@@ -297,6 +298,120 @@ public class ReportsEndpoint {
 
         var response = reportService.run(id, request, utility.getUserUniqueIdentifier());
         return Response.ok().entity(response).build();
+    }
+
+    @Tag(name = "Reports")
+    @Operation(
+            summary = "Export a report",
+            description = "Converts a generated report (JSON) into CSV for download."
+    )
+    @APIResponse(
+            responseCode = "200",
+            description = "CSV export of the report results",
+            content = @Content(
+                    schema = @Schema(
+                            type = SchemaType.OBJECT,
+                            implementation = CsvResponseDto.class)
+            )
+    )
+    @APIResponse(
+            responseCode = "401",
+            description = "User has not been authenticated.",
+            content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                    schema = @Schema(
+                    type = SchemaType.OBJECT,
+                    implementation = InformativeResponse.class))
+    )
+    @APIResponse(
+            responseCode = "403",
+            description = "Not permitted.",
+            content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                    schema = @Schema(
+                            type = SchemaType.OBJECT,
+                            implementation = InformativeResponse.class))    )
+    @APIResponse(
+            responseCode = "500",
+            description = "Internal Server Error.",
+            content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                    schema = @Schema(implementation = InformativeResponse.class))
+    )
+    @SecurityRequirement(name = "Authentication")
+    @POST
+    @Path("/export/{id}")
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces({MediaType.APPLICATION_JSON, "text/csv"})
+    @Registration
+    public Response exportReport(
+            @Parameter(
+                    description = "The ID of the report definition.",
+                    required = true,
+                    example = "1",
+                    schema = @Schema(type = SchemaType.STRING))
+            @PathParam("id") Long id,
+            @RequestBody(
+                    description = "The generated report response to convert into CSV.",
+                    required = true,
+                    content = @Content(
+                            schema = @Schema(implementation = ReportResponseDto.class),
+                            examples = {
+                                    @ExampleObject(
+                                            name = "Actors × Assessments",
+                                            summary = "Export report ID = 1 (Actors)",
+                                            value = "{\n" +
+                                                    "  \"label\": \"Actors × Assessments\",\n" +
+                                                    "  \"description\": \"Assessment results per actor\",\n" +
+                                                    "  \"rows_dimension\": \"actor\",\n" +
+                                                    "  \"columns_dimension\": \"assessment\",\n" +
+                                                    "  \"value_type\": \"compliance\",\n" +
+                                                    "  \"created_by\": \"admin_voperson_id\",\n" +
+                                                    "  \"created_on\": \"2025-09-29T11:05:59.384882Z\",\n" +
+                                                    "  \"rows\": [\"PID Manager (Role)\", \"PID Owner (Role)\"],\n" +
+                                                    "  \"columns\": [\"assessment-1\", \"assessment-2\", \"assessment-3\"],\n" +
+                                                    "  \"data\": [\n" +
+                                                    "    [\"FAIL\", \"N/A\", \"N/A\"],\n" +
+                                                    "    [\"N/A\", \"PASS\", \"PASS\"]\n" +
+                                                    "  ]\n" +
+                                                    "}"
+                                    ),
+                                    @ExampleObject(
+                                            name = "Organisations × Assessments",
+                                            summary = "Export report ID = 2 (Organisations)",
+                                            value = "{\n" +
+                                                    "  \"label\": \"Organisations × Assessments\",\n" +
+                                                    "  \"description\": \"Assessment results per organisation\",\n" +
+                                                    "  \"rows_dimension\": \"organisation\",\n" +
+                                                    "  \"columns_dimension\": \"assessment\",\n" +
+                                                    "  \"value_type\": \"compliance\",\n" +
+                                                    "  \"created_by\": \"admin_voperson_id\",\n" +
+                                                    "  \"created_on\": \"2025-09-29T11:06:12.111Z\",\n" +
+                                                    "  \"rows\": [\"GRNET S.A\"],\n" +
+                                                    "  \"columns\": [\"assessment-2\", \"assessment-3\"],\n" +
+                                                    "  \"data\": [\n" +
+                                                    "    [\"PASS\", \"FAIL\"]\n" +
+                                                    "  ]\n" +
+                                                    "}"
+                                    )
+                            }
+                    )
+            )
+            @Valid @NotNull(message = "The request body is empty.")
+            ReportResponseDto report) {
+
+        var csvContent = reportService.exportToCsv(report);
+
+        var safeLabel = report.label != null
+                ? report.label.replaceAll("[^a-zA-Z0-9 ]", "")
+                .trim()
+                .replaceAll("\\s+", "_")
+                : "Report_" + id;
+
+        var filename = "CAT_Report_" + safeLabel + ".csv";
+
+        return Response.ok(csvContent)
+                .header("Content-Disposition", "attachment; filename=\"" + filename + "\"")
+                .type("text/csv")
+                .build();
+
     }
 
 }

--- a/data-transfer-object/src/main/java/org/grnet/cat/dtos/CsvResponseDto.java
+++ b/data-transfer-object/src/main/java/org/grnet/cat/dtos/CsvResponseDto.java
@@ -1,0 +1,19 @@
+package org.grnet.cat.dtos;
+
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
+
+/**
+ * Wrapper DTO for CSV export responses.
+ */
+@Schema(name = "CsvResponse",
+        description = "Represents a CSV export as plain text content.")
+public class CsvResponseDto {
+
+    @Schema(
+            description = "The generated CSV content as plain text.",
+            example = "Actors × Assessments,assessment-1,assessment-2,assessment-3\n"
+                    + "PID Manager (Role),FAIL,N/A,N/A\n"
+                    + "PID Owner (Role),N/A,PASS,PASS"
+    )
+    public String content;
+}

--- a/service/src/main/java/org/grnet/cat/services/report/ReportService.java
+++ b/service/src/main/java/org/grnet/cat/services/report/ReportService.java
@@ -9,11 +9,6 @@ import jakarta.ws.rs.BadRequestException;
 import jakarta.ws.rs.NotFoundException;
 import org.grnet.cat.converter.FilterDefinition;
 import org.grnet.cat.dtos.report.*;
-import org.grnet.cat.entities.ReportDefinition;
-import org.grnet.cat.entities.Validation;
-import org.grnet.cat.entities.registry.Motivation;
-import org.grnet.cat.entities.registry.RegistryActor;
-import org.grnet.cat.enums.PublicationStatus;
 import org.grnet.cat.mappers.ReportMapper;
 import org.grnet.cat.repositories.ReportRepository;
 import org.grnet.cat.repositories.ValidationRepository;
@@ -23,9 +18,6 @@ import org.grnet.cat.services.utils.FilterType;
 
 import java.time.Instant;
 import java.util.*;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.function.Function;
-import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 @ApplicationScoped
@@ -228,6 +220,40 @@ public class ReportService {
         return response;
     }
 
+    /**
+     * Converts a ReportResponseDto to CSV.
+     * First row is the header: <label>,<col1>,<col2>,...
+     */
+    public String exportToCsv(ReportResponseDto report) {
+        StringBuilder sb = new StringBuilder();
+
+        // Header: first cell = report label (no separate title row)
+        sb.append(escapeCsv(report.label != null ? report.label : ""));
+        for (String col : report.columns) {
+            sb.append(",").append(escapeCsv(col));
+        }
+        sb.append("\n");
+
+        // Data rows
+        for (int i = 0; i < report.rows.size(); i++) {
+            sb.append(escapeCsv(report.rows.get(i))); // row label in first column
+            for (String val : report.data.get(i)) {
+                sb.append(",").append(escapeCsv(val));
+            }
+            sb.append("\n");
+        }
+
+        return sb.toString();
+    }
+
+    private String escapeCsv(String value) {
+        if (value == null) return "";
+        String escaped = value.replace("\"", "\"\"");
+        if (escaped.contains(",") || escaped.contains("\"") || escaped.contains("\n")) {
+            return "\"" + escaped + "\"";
+        }
+        return escaped;
+    }
 
     /**
      * Builds the response DTO from definition, userId, and table data.


### PR DESCRIPTION
## Description  
This PR introduces the ability to **export generated reports into CSV format**.

- Added a new endpoint:   ```POST /v1/reports/generate/{id}/export ```

- Accepts a `ReportResponseDto` (the previously generated report in JSON).  
- Converts the report data (rows, columns, compliance values) into CSV format.  
- Returns the CSV as a downloadable file with a user-friendly filename:  
  ```
  CAT_Report_<Report_Label>.csv
  ```
---

## Example Download  
For a report with:  
- Rows: `["PID Manager (Role)", "PID Owner (Role)"]`  
- Columns: `["assessment-1", "assessment-2"]`  
- Data: `[["PASS", "FAIL"], ["N/A", "PASS"]]`  

The generated CSV will be:  

**Actors × Assessments**
| &nbsp;              | assessment-1 | assessment-2 |
|:--------------------|:------------:|:------------:|
| PID Manager (Role)  | PASS         | FAIL          |
| PID Owner (Role)    | N/A          | PASS         |



