### PR TITLE
CAT-1049: Add Zenodo Publication Info to Assesment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,14 @@ According to [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) , the `Unr
 
 ## Unreleased
 ---
+
+### Added
+
+- [#558](https://github.com/FC4E-CAT/fc4e-cat-api/pull/558) CAT-1049: Add Zenodo Publication Info to Assesment
+
+### Fixed
+
+
 ## 3.0.0 - 2025-09-23
 ---
 

--- a/data-transfer-object/src/main/java/org/grnet/cat/dtos/assessment/AdminPartialJsonAssessmentResponse.java
+++ b/data-transfer-object/src/main/java/org/grnet/cat/dtos/assessment/AdminPartialJsonAssessmentResponse.java
@@ -107,4 +107,37 @@ public class AdminPartialJsonAssessmentResponse extends AssessmentResponse {
     @JsonInclude(JsonInclude.Include.NON_NULL)
     public List<AdminPartialJsonAssessmentResponse> adminVersions;
 
+
+    @Schema(
+            type = SchemaType.BOOLEAN,
+            implementation = Boolean.class,
+            description = "Indicates whether the assessment has been published on Zenodo.",
+            example = "published"
+    )
+    @Setter
+    @JsonProperty("zenodo_published")
+    public Boolean zenodoPublished;
+
+    @Schema(
+            type = SchemaType.STRING,
+            implementation = String.class,
+            description = "The Zenodo deposit ID associated with this assessment, if published.",
+            example = "1234567"
+    )
+    @Setter
+    @JsonProperty("zenodo_deposit_id")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public String zenodoDepositId;
+
+    @Schema(
+            type = SchemaType.STRING,
+            implementation = String.class,
+            description = "The Zenodo file url associated with this assessment, if published.",
+            example = "https://sandbox.zenodo.org/api/records/185555/draft/files/69ef9a51-09c1-48f8-920f-580d58552e84/"
+    )
+    @Setter
+    @JsonProperty("zenodo_file_url")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public String zenodoFileUrl;
+
 }

--- a/data-transfer-object/src/main/java/org/grnet/cat/dtos/assessment/registry/AdminJsonRegistryAssessmentResponse.java
+++ b/data-transfer-object/src/main/java/org/grnet/cat/dtos/assessment/registry/AdminJsonRegistryAssessmentResponse.java
@@ -5,9 +5,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Setter;
 import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
-import org.grnet.cat.dtos.assessment.AdminPartialJsonAssessmentResponse;
 import org.grnet.cat.dtos.assessment.AssessmentResponse;
-import org.grnet.cat.dtos.assessment.UserPartialJsonAssessmentResponse;
 
 import java.util.List;
 
@@ -39,4 +37,38 @@ public class AdminJsonRegistryAssessmentResponse extends AssessmentResponse {
     @JsonProperty("versions")
     @JsonInclude(JsonInclude.Include.NON_NULL)
     public List<AdminJsonRegistryAssessmentResponse> adminVersions;
+
+    @Schema(
+            type = SchemaType.BOOLEAN,
+            implementation = Boolean.class,
+            description = "Indicates whether the assessment has been published on Zenodo.",
+            example = "published"
+    )
+    @Setter
+    @JsonProperty("zenodo_published")
+    public Boolean zenodoPublished;
+
+    @Schema(
+            type = SchemaType.STRING,
+            implementation = String.class,
+            description = "The Zenodo deposit ID associated with this assessment, if published.",
+            example = "1234567"
+    )
+    @Setter
+    @JsonProperty("zenodo_deposit_id")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public String zenodoDepositId;
+
+    @Schema(
+            type = SchemaType.STRING,
+            implementation = String.class,
+            description = "The Zenodo file url associated with this assessment, if published.",
+            example = "https://sandbox.zenodo.org/api/records/185555/draft/files/69ef9a51-09c1-48f8-920f-580d58552e84/"
+    )
+    @Setter
+    @JsonProperty("zenodo_file_url")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public String zenodoFileUrl;
+
+
 }

--- a/entity/src/main/java/org/grnet/cat/entities/ZenodoAssessmentInfo.java
+++ b/entity/src/main/java/org/grnet/cat/entities/ZenodoAssessmentInfo.java
@@ -1,6 +1,5 @@
 package org.grnet.cat.entities;
 
-import com.vladmihalcea.hibernate.type.json.JsonType;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
@@ -41,6 +40,8 @@ public class ZenodoAssessmentInfo {
     @Column(name = "zenodo_state")
     private ZenodoState zenodoState;
 
+    @Column(name = "file_url")
+    public String fileUrl;
 
     public Boolean getPublished() {
         return isPublished;

--- a/entity/src/main/resources/db/migration/tables/assessment/V1.101__add_colum_zenodo_assessment_info.sql
+++ b/entity/src/main/resources/db/migration/tables/assessment/V1.101__add_colum_zenodo_assessment_info.sql
@@ -1,0 +1,8 @@
+-- ------------------------------------------------
+-- Version: v1.101
+--
+-- Description: Adds a `file_url` column to `ZenodoAssessmentInfo` table
+-- ------------------------------------------------
+
+ALTER TABLE ZenodoAssessmentInfo
+ADD COLUMN file_url VARCHAR(255) NULL;

--- a/service/src/main/java/org/grnet/cat/services/assessment/JsonAssessmentService.java
+++ b/service/src/main/java/org/grnet/cat/services/assessment/JsonAssessmentService.java
@@ -36,6 +36,7 @@ import org.grnet.cat.mappers.UserMapper;
 import org.grnet.cat.repositories.MotivationAssessmentRepository;
 import org.grnet.cat.repositories.UserRepository;
 import org.grnet.cat.repositories.ValidationRepository;
+import org.grnet.cat.repositories.ZenodoAssessmentInfoRepository;
 import org.grnet.cat.services.KeycloakAdminService;
 import org.grnet.cat.services.MailerService;
 import org.grnet.cat.services.SubjectService;
@@ -79,6 +80,9 @@ public class JsonAssessmentService {
 
     @Inject
     MotivationAssessmentRepository motivationAssessmentRepository;
+
+    @Inject
+    ZenodoAssessmentInfoRepository zenodoAssessmentInfoRepository;
 
     @Transactional
     @SneakyThrows
@@ -377,7 +381,20 @@ public class JsonAssessmentService {
             throw new RuntimeException("Failed to sort tests in assessmentDoc", e);
         }
 
-        return AssessmentMapper.INSTANCE.userRegistryAssessmentToJsonAssessment(assessment);
+        var response =  AssessmentMapper.INSTANCE.userRegistryAssessmentToJsonAssessment(assessment);
+
+        var zenodoInfoOpt = zenodoAssessmentInfoRepository.getAssessmentByAsessmentId(assessmentId);
+
+        if (zenodoInfoOpt.isPresent()) {
+            var zenodoInfo = zenodoInfoOpt.get();
+            response.setZenodoPublished(zenodoInfo.getIsPublished());
+            response.setZenodoDepositId(zenodoInfo.getId().getDepositId());
+            response.setZenodoFileUrl(zenodoInfo.getFileUrl());
+        } else {
+            response.published = false;
+        }
+
+        return response;
     }
 
     /**
@@ -486,7 +503,17 @@ public class JsonAssessmentService {
                             .collect(Collectors.toList());
 
                     dto.setUserVersions(prevVersions);
-                    return AssessmentMapper.INSTANCE.userRegistryAssessmentToPartialJsonAssessment(dto);
+                    var partialDto = AssessmentMapper.INSTANCE.userRegistryAssessmentToPartialJsonAssessment(dto);
+
+                    var zenodoInfoOpt = zenodoAssessmentInfoRepository.getAssessmentByAsessmentId(dto.id);
+                    if (zenodoInfoOpt.isPresent()) {
+                        var zenodoInfo = zenodoInfoOpt.get();
+                        partialDto.setZenodoPublished(zenodoInfo.getIsPublished());
+                        partialDto.setZenodoDepositId(zenodoInfo.getId().getDepositId());
+                        partialDto.setZenodoFileUrl(zenodoInfo.getFileUrl());
+                    }
+
+                    return partialDto;
                 })
                 .collect(Collectors.toList());
 
@@ -786,7 +813,19 @@ public class JsonAssessmentService {
                             .collect(Collectors.toList());
 
                     dto.setAdminVersions(prevVersions);
-                    return AssessmentMapper.INSTANCE.adminRegistryAssessmentToPartialJsonAssessment(dto);
+
+                    var partialDto = AssessmentMapper.INSTANCE.adminRegistryAssessmentToPartialJsonAssessment(dto);
+
+                    var zenodoInfoOpt = zenodoAssessmentInfoRepository.getAssessmentByAsessmentId(dto.id);
+                    if (zenodoInfoOpt.isPresent()) {
+                        var zenodoInfo = zenodoInfoOpt.get();
+                        partialDto.setZenodoPublished(zenodoInfo.getIsPublished());
+                        partialDto.setZenodoDepositId(zenodoInfo.getId().getDepositId());
+                        partialDto.setZenodoFileUrl(zenodoInfo.getFileUrl());
+                    }
+
+                    return partialDto;
+
                 })
                 .collect(Collectors.toList());
 

--- a/service/src/main/java/org/grnet/cat/services/zenodo/ZenodoService.java
+++ b/service/src/main/java/org/grnet/cat/services/zenodo/ZenodoService.java
@@ -321,7 +321,7 @@ public class ZenodoService {
     }
 
     private void uploadFile(String accessToken, MotivationAssessment assessment, byte[] binaryContent, String depositId) throws IOException {
-        File tempFile = new File(assessment.getId());
+        File tempFile = new File(assessment.getId() + ".pdf");
         try (FileOutputStream fos = new FileOutputStream(tempFile)) {
             fos.write(binaryContent);
         } catch (IOException e) {
@@ -329,13 +329,13 @@ public class ZenodoService {
         }
         // Step 3: Upload file to Zenodo
         upload(accessToken, tempFile, String.valueOf(depositId));
-
     }
 
     public CompletableFuture<Void> runStepsInSequence(MotivationAssessment assessment, byte[] binaryContent, User activeUser, List<String> sharedUsersIds, Optional<ZenodoAssessmentInfo> parentZenodoOpt) {
         final AtomicReference<ZenodoState> state = new AtomicReference<>(ZenodoState.PROCESS_INIT);
         final AtomicReference<String> depositIdRef = new AtomicReference<>(null);
         final AtomicReference<ZenodoAssessmentInfo> zenodoAssessmentInfoRef = new AtomicReference<>(null);
+        final AtomicReference<String> fileUrlRef = new AtomicReference<>(null);
         String accessToken = getAccessToken();
         System.out.println("*** The access token is : "+accessToken);
         return CompletableFuture
@@ -394,7 +394,7 @@ public class ZenodoService {
 
                     System.out.println("Step 3: Writing to DB before publishing...");
                     try {
-                        var zenodoAssessmentInfo = createInDatabase(assessment, depositIdRef.get(), state.get());
+                        var zenodoAssessmentInfo = createInDatabase(assessment, depositIdRef.get(), state.get(), fileUrlRef.get());
                         zenodoAssessmentInfoRef.set(zenodoAssessmentInfo);
                         return depositId;
                     } catch (Exception dbException) {
@@ -475,13 +475,48 @@ public class ZenodoService {
         zenodoAssessmentInfo.setPublishedAt(Timestamp.from(Instant.now()));
         zenodoAssessmentInfo.setIsPublished(Boolean.TRUE);
         zenodoAssessmentInfo.setZenodoState(ZenodoState.PROCESS_COMPLETED);
+        try {
+            // ✅ Get the latest Zenodo record info after publication
+            var response = zenodoClient.getDeposit(getAccessToken(), zenodoAssessmentInfo.getId().getDepositId());
+
+            Object filesObj = response.get("files");
+            if (filesObj instanceof List && !((List<?>) filesObj).isEmpty()) {
+                Object first = ((List<?>) filesObj).get(0);
+                if (first instanceof Map) {
+                    Object flinks = ((Map<?, ?>) first).get("links");
+                    if (flinks instanceof Map) {
+                        Map<?, ?> links = (Map<?, ?>) flinks;
+
+                        // Sandbox only returns "self", production adds "download"
+                        String fileUrl = null;
+                        if (links.containsKey("download")) {
+                            fileUrl = (String) links.get("download");
+                        } else if (links.containsKey("self")) {
+                            fileUrl = (String) links.get("self");
+                        }
+
+                        if (fileUrl != null) {
+                            zenodoAssessmentInfo.setFileUrl(fileUrl);
+                            Log.infof("Stored Zenodo file URL: %s", fileUrl);
+                        } else {
+                            Log.info("Zenodo record has no file links available yet.");
+                        }
+                    }
+                }
+            } else {
+                Log.info("Zenodo returned no files[] for published record " + zenodoAssessmentInfo.getId().getDepositId());
+            }
+
+        } catch (Exception e) {
+            Log.warn("Could not fetch file URL for deposit " + zenodoAssessmentInfo.getId().getDepositId(), e);
+        }
         zenodoAssessmentInfoRepository.persist(zenodoAssessmentInfo);
         return zenodoAssessmentInfo;
     }
 
 
     @Transactional
-    public ZenodoAssessmentInfo createInDatabase(MotivationAssessment assessment, String depositId, ZenodoState state) {
+    public ZenodoAssessmentInfo createInDatabase(MotivationAssessment assessment, String depositId, ZenodoState state, String fileUrl) {
 
         MotivationAssessment managedAssessment = motivationAssessmentRepository.findById(assessment.getId());
         if (managedAssessment != null) {
@@ -496,6 +531,7 @@ public class ZenodoService {
         zenodoAssessmentInfo.setUploadedAt(Timestamp.from(Instant.now()));
         zenodoAssessmentInfo.setId(new ZenodoAssessmentInfoId(assessment.getId(), String.valueOf(depositId)));
         zenodoAssessmentInfo.setZenodoState(state);
+        zenodoAssessmentInfo.setFileUrl(fileUrl);
         zenodoAssessmentInfoRepository.persist(zenodoAssessmentInfo);
         return zenodoAssessmentInfo;
     }


### PR DESCRIPTION
### Description

This PR introduces Zenodo publication details for assessments in CAT.  
A response of an assessment published to Zenodo now includes:
- **Zenodo deposit ID** – the unique identifier of the published record on Zenodo.  
- **Zenodo file URL** – the link to the uploaded assessment file.  
- **Zenodo publication flag** – indicates whether the assessment is successfully published.

The service (`ZenodoService`) now:
- Fetches the final deposit after publication.
- Extracts the file URL.
- Stores the link in `file_url`.

The API now returns three new fields:
- `zenodo_published`
- `zenodo_deposit_id`
- `zenodo_file_url`

These are included both in user and admin registry assessment responses.

#### File naming improvement
- Uploaded assessment files are now automatically saved with a `.pdf` extension before upload to Zenodo.  
- This ensures that downloaded files retain the correct type and are recognized as PDF documents.

---

### Example API Response

```
{
  "name": "qqqqq",
  "id": "8eb7c991-e2eb-40ee-a9be-fb66da411615",
  "user_id": "admin_voperson_id",
  "validation_id": 3,
  "created_on": "2025-10-07 20:05:34.521333",
  "updated_on": "2025-10-07 20:05:38.276899",
  "updated_by": "admin_voperson_id",
  "published": true,
  "parent_assessment_id": "8eb7c991-e2eb-40ee-a9be-fb66da411615",
  "assessment_doc_version": "v1",
  "type": "EOSC PID Policy",
  "actor": "PID Owner (Role)",
  "organisation": "National Infrastructures for Research and Technology -  GRNET S.A",
  "subject_name": "test-name",
  "subject_type": "test",
  "compliance": false,
  "ranking": 0,
  "shared": false,
  "versions": [],
  "zenodo_published": true,
  "zenodo_deposit_id": "345487",
  "zenodo_file_url": "https://sandbox.zenodo.org/api/records/345487/draft/files/8eb7c991-e2eb-40ee-a9be-fb66da411615.pdf/content",
  "shared_to_user": false,
  "shared_by_user": false
}
```

--- 
