### PR TITLE
CAT-1053: Add Zenodo base URL helper and connection check on settings enable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ According to [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) , the `Unr
 ### Added
 
 - [#558](https://github.com/FC4E-CAT/fc4e-cat-api/pull/558) CAT-1049: Add Zenodo Publication Info to Assesment
+- [#560](https://github.com/FC4E-CAT/fc4e-cat-api/pull/560) CAT-1053: Add Zenodo base URL helper and connection check on settings enable
 
 ### Fixed
 

--- a/api/src/main/resources/application.properties
+++ b/api/src/main/resources/application.properties
@@ -137,7 +137,6 @@ api.name=cat
 quarkus.health.openapi.included=true
 
 quarkus.rest-client."org.grnet.cat.api.health.AAIProxyClient".url=${QUARKUS_OIDC_AUTH_SERVER_URL:https://login-devel.einfra.grnet.gr/auth/realms/einfra}
-quarkus.rest-client."org.grnet.cat.services.zenodo.ZenodoClient".url=https://sandbox.zenodo.org
 
 quarkus.rest-client.naco-service.url=https://cvs.data.kit.edu
 quarkus.rest-client.naco-service.scope=jakarta.inject.Singleton
@@ -158,3 +157,5 @@ zenodo.prod.doi.prefix=10.5281
 zenodo.prod.target.url.resolver=https://doi.org/
 zenodo.sandbox.doi.prefix=10.5072
 zenodo.sandbox.target.url.resolver=https://handle.test.datacite.org/
+zenodo.sandbox.url=https://sandbox.zenodo.org
+zenodo.prod.url=https://zenodo.org

--- a/data-transfer-object/src/main/java/org/grnet/cat/dtos/assessment/AdminPartialJsonAssessmentResponse.java
+++ b/data-transfer-object/src/main/java/org/grnet/cat/dtos/assessment/AdminPartialJsonAssessmentResponse.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Setter;
 import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
+import org.grnet.cat.enums.ZenodoState;
 
 import java.util.List;
 
@@ -139,5 +140,15 @@ public class AdminPartialJsonAssessmentResponse extends AssessmentResponse {
     @JsonProperty("zenodo_file_url")
     @JsonInclude(JsonInclude.Include.NON_NULL)
     public String zenodoFileUrl;
+
+    @Schema(
+            type = SchemaType.BOOLEAN,
+            implementation = ZenodoState.class,
+            description = "Indicates the state of publication of the assessment on Zenodo.",
+            example = "IN PROGRESS"
+    )
+    @Setter
+    @JsonProperty("zenodo_publication_state")
+    public ZenodoState zenodoPublicationState;
 
 }

--- a/data-transfer-object/src/main/java/org/grnet/cat/dtos/assessment/registry/AdminJsonRegistryAssessmentResponse.java
+++ b/data-transfer-object/src/main/java/org/grnet/cat/dtos/assessment/registry/AdminJsonRegistryAssessmentResponse.java
@@ -6,6 +6,7 @@ import lombok.Setter;
 import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
 import org.grnet.cat.dtos.assessment.AssessmentResponse;
+import org.grnet.cat.enums.ZenodoState;
 
 import java.util.List;
 
@@ -69,6 +70,16 @@ public class AdminJsonRegistryAssessmentResponse extends AssessmentResponse {
     @JsonProperty("zenodo_file_url")
     @JsonInclude(JsonInclude.Include.NON_NULL)
     public String zenodoFileUrl;
+
+    @Schema(
+            type = SchemaType.BOOLEAN,
+            implementation = ZenodoState.class,
+            description = "Indicates the state of publication of the assessment on Zenodo.",
+            example = "IN PROGRESS"
+    )
+    @Setter
+    @JsonProperty("zenodo_publication_state")
+    public ZenodoState zenodoPublicationState;
 
 
 }

--- a/entity/src/main/resources/db/migration/tables/setting/V1.105__update_t_settings.sql
+++ b/entity/src/main/resources/db/migration/tables/setting/V1.105__update_t_settings.sql
@@ -1,0 +1,19 @@
+-- ------------------------------------------------
+-- Version:     V1.105
+-- Description: Add zenodo.url to Zenodo setting
+-- ------------------------------------------------
+
+-- ✅ Update Zenodo setting with zenodo.url placeholder
+UPDATE t_Setting
+SET setting_data = jsonb_set(
+    setting_data,
+    '{config}',
+    (
+        setting_data->'config' || jsonb_build_object(
+            'zenodo.api.key', NULL,
+            'zenodo.enabled', true,
+            'zenodo.url', NULL
+        )
+    )
+)
+WHERE id = 1;

--- a/service/src/main/java/org/grnet/cat/services/MailerService.java
+++ b/service/src/main/java/org/grnet/cat/services/MailerService.java
@@ -16,6 +16,7 @@ import org.grnet.cat.enums.MailType;
 import org.grnet.cat.enums.ValidationStatus;
 import org.grnet.cat.repositories.KeycloakAdminRepository;
 import org.grnet.cat.repositories.UserRepository;
+import org.grnet.cat.services.env.EnvironmentDetector;
 import org.jboss.logging.Logger;
 
 import java.util.*;
@@ -39,9 +40,6 @@ public class MailerService {
     UserRepository userRepository;
     @ConfigProperty(name = "api.ui.url")
     String uiBaseUrl;
-    @ConfigProperty(name = "quarkus.rest-client.\"org.grnet.cat.services.zenodo.ZenodoClient\".url")
-    String zenodoUrl;
-
     @ConfigProperty(name = "api.server.url")
     String serviceUrl;
 
@@ -87,6 +85,10 @@ public class MailerService {
 
     @Inject
     EmailBrandingConfig emailBrandingConfig;
+
+    @Inject
+    EnvironmentDetector environmentDetector;
+
     @Inject
     KeycloakAdminRepository keycloakAdminRepository;
     @ConfigProperty(name = "api.keycloak.user.id")
@@ -94,6 +96,7 @@ public class MailerService {
 
     @ConfigProperty(name = "api.name")
     String apiName;
+
     private static final Logger LOG = Logger.getLogger(MailerService.class);
 
     public List<String> retrieveAdminEmails() {
@@ -173,6 +176,8 @@ public class MailerService {
 
     public void sendMails(MotivationAssessment assessment,String depositId, String name,MailType type, List<String> mailAddrs) {
 
+        var zenodoBaseUrl = environmentDetector.getZenodoBaseUrl();
+
         HashMap<String, Object> templateParams = new HashMap<>();
         templateParams.put("contactMail", contactMail);
         templateParams.put("logoUrl", emailBrandingConfig.getLogoUrl().orElse(serviceUrl + "/v1/images/logo.png"))
@@ -187,7 +192,7 @@ public class MailerService {
 
         switch (type) {
             case ZENODO_DRAFT_DEPOSIT:
-                templateParams.put("depositUrl", zenodoUrl + "/uploads/" + depositId);
+                templateParams.put("depositUrl", zenodoBaseUrl + "/uploads/" + depositId);
                 templateParams.put("depositId", depositId);
 
                 templateParams.put("assessmentName", extractAssessmentName(assessment.getAssessmentDoc()));
@@ -198,7 +203,7 @@ public class MailerService {
                 break;
 
             case ZENODO_COMPLETED_PUBLISH_PROCESS:
-                templateParams.put("depositUrl", zenodoUrl + "/records/" + depositId);
+                templateParams.put("depositUrl", zenodoBaseUrl + "/records/" + depositId);
                 templateParams.put("depositId", depositId);
 
                 templateParams.put("assessmentName", extractAssessmentName(assessment.getAssessmentDoc()));
@@ -210,7 +215,7 @@ public class MailerService {
                 break;
 //
             case ZENODO_PUBLISH_ASSESSMENT:
-                templateParams.put("depositUrl", zenodoUrl + "/records/" + depositId);
+                templateParams.put("depositUrl", zenodoBaseUrl + "/records/" + depositId);
                 templateParams.put("depositId", depositId);
 
                 templateParams.put("assessmentName", extractAssessmentName(assessment.getAssessmentDoc()));
@@ -220,7 +225,7 @@ public class MailerService {
                 notifyUser(zenodoPublishAssessment, templateParams, mailAddrs, type);
                 break;
             case ZENODO_PUBLISH_DEPOSIT:
-                templateParams.put("depositUrl", zenodoUrl + "/records/" + depositId);
+                templateParams.put("depositUrl", zenodoBaseUrl + "/records/" + depositId);
                 templateParams.put("depositId", depositId);
 
                 LOG.info("Template parameters: " + templateParams);
@@ -234,14 +239,14 @@ public class MailerService {
                 notifyUser(zenodoFailedPublishProcess, templateParams, mailAddrs, type);
                 break;
             case ZENODO_FAILED_PUBLISH_DEPOSIT:
-                templateParams.put("depositUrl", zenodoUrl + "/records/" + depositId);
+                templateParams.put("depositUrl", zenodoBaseUrl + "/records/" + depositId);
                 templateParams.put("depositId", depositId);
 
                 LOG.info("Template parameters: " + templateParams);
                 notifyUser(zenodoFailedPublishDeposit, templateParams, mailAddrs, type);
                 break;
             case ZENODO_PUBLISH_DEPOSIT_DRAFT_IN_DB:
-                templateParams.put("depositUrl", zenodoUrl + "/records/" + depositId);
+                templateParams.put("depositUrl", zenodoBaseUrl + "/records/" + depositId);
                 templateParams.put("depositId", depositId);
 
                 LOG.info("Template parameters: " + templateParams);

--- a/service/src/main/java/org/grnet/cat/services/SettingService.java
+++ b/service/src/main/java/org/grnet/cat/services/SettingService.java
@@ -1,5 +1,6 @@
 package org.grnet.cat.services;
 
+import io.quarkus.logging.Log;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import jakarta.transaction.Transactional;
@@ -12,6 +13,9 @@ import org.grnet.cat.dtos.setting.SettingUpdateDto;
 import org.grnet.cat.entities.Setting;
 import org.grnet.cat.mappers.SettingMapper;
 import org.grnet.cat.repositories.SettingRepository;
+import org.grnet.cat.services.env.EnvironmentDetector;
+import org.grnet.cat.services.zenodo.ZenodoClient;
+import org.grnet.cat.services.zenodo.ZenodoService;
 
 import javax.crypto.Cipher;
 import javax.crypto.SecretKey;
@@ -35,6 +39,11 @@ public class SettingService {
     @Inject
     SettingRepository settingRepository;
 
+    @Inject
+    ZenodoService zenodoService;
+
+    @Inject
+    EnvironmentDetector environmentDetector;
     /**
      * List of keys considered sensitive and should always be encrypted at rest.
      */
@@ -88,23 +97,76 @@ public class SettingService {
             }
         }
 
+        var labelObj = existingData.get("label");
+        var label = (labelObj instanceof String) ? (String) labelObj : null;
+
+        // Special logic for Zenodo setting
+        if ("Zenodo".equalsIgnoreCase(label) && Boolean.TRUE.equals(request.enabled)) {
+            String tokenFromRequest = null;
+            String zenodoBaseUrl = null;
+
+            // Extract token from request
+            var configObj = request.data.get("config");
+            if (configObj instanceof Map) {
+                var configMap = (Map<?, ?>) configObj;
+                var keyObj = configMap.get("zenodo.api.key");
+                if (keyObj instanceof String && StringUtils.isNotBlank((String) keyObj)) {
+                    tokenFromRequest = (String) keyObj;
+                }
+            }
+
+            // Retrieve existing URL from stored settings (if available)
+            var existingConfig = existingData.get("config");
+            if (existingConfig instanceof Map) {
+                var existingUrl = ((Map<?, ?>) existingConfig).get("zenodo.url");
+                if (existingUrl instanceof String && StringUtils.isNotBlank((String) existingUrl)) {
+                    zenodoBaseUrl = (String) existingUrl;
+                }
+            }
+
+            // If URL not found in settings, detect from environment and store it
+            if (zenodoBaseUrl == null) {
+                zenodoBaseUrl = environmentDetector.getZenodoBaseUrl();
+                existingData.computeIfAbsent("config", k -> new HashMap<String, Object>());
+                ((Map<String, Object>) existingData.get("config")).put("zenodo.url", zenodoBaseUrl);
+            }
+
+            // Require token
+            if (tokenFromRequest == null) {
+                throw new BadRequestException("Zenodo API key is required to enable Zenodo.");
+            }
+
+            // Test connection
+            boolean ok = zenodoService.testZenodoConnection(tokenFromRequest);
+            if (!ok) {
+                throw new BadRequestException("Failed to connect to Zenodo. Please verify your API key.");
+            }
+        }
+
         // Validate config keys
         validateAllowedConfigKeys(request.data, existingData);
-
 
         // Encrypt sensitive values
         encryptNestedSensitiveFields(request.data, "");
 
-        // Merge and inject derived keys
-        existingData.putAll(request.data);
+        // Merge config
+        if (request.data.containsKey("config") && existingData.containsKey("config")) {
+            Map<String, Object> existingConfig = (Map<String, Object>) existingData.get("config");
+            Map<String, Object> requestConfig = (Map<String, Object>) request.data.get("config");
 
-        var labelObj = existingData.get("label");
-        var label = (labelObj instanceof String) ? (String) labelObj : null;
+            for (Map.Entry<String, Object> entry : requestConfig.entrySet()) {
+                existingConfig.put(entry.getKey(), entry.getValue());
+            }
+
+            // Prevent overwriting the entire config map
+            request.data.remove("config");
+        }
 
         if (StringUtils.isNotBlank(label)) {
             injectDerivedConfigKeyForKnownCases(existingData, label, Boolean.TRUE.equals(request.enabled));
         }
 
+        // Persist changes
         setting.setData(existingData);
         setting.setUpdatedBy(userId);
         setting.setUpdatedOn(Timestamp.from(Instant.now()));
@@ -113,6 +175,7 @@ public class SettingService {
 
         return SettingMapper.INSTANCE.settingToDto(setting);
     }
+
 
     /**
      * Retrieves a single setting by ID, decrypting any sensitive values.
@@ -357,6 +420,7 @@ public class SettingService {
         if (reqConfigObj != null && existingConfigObj instanceof Map && reqConfigObj instanceof Map) {
             Map<String, Object> existingConfig = (Map<String, Object>) existingConfigObj;
             Map<String, Object> requestConfig = (Map<String, Object>) reqConfigObj;
+
 
             for (String key : requestConfig.keySet()) {
                 if (!existingConfig.containsKey(key)) {

--- a/service/src/main/java/org/grnet/cat/services/assessment/JsonAssessmentService.java
+++ b/service/src/main/java/org/grnet/cat/services/assessment/JsonAssessmentService.java
@@ -390,6 +390,7 @@ public class JsonAssessmentService {
             response.setZenodoPublished(zenodoInfo.getIsPublished());
             response.setZenodoDepositId(zenodoInfo.getId().getDepositId());
             response.setZenodoFileUrl(zenodoInfo.getFileUrl());
+            response.setZenodoPublicationState(zenodoInfo.getZenodoState());
         } else {
             response.published = false;
         }
@@ -511,6 +512,8 @@ public class JsonAssessmentService {
                         partialDto.setZenodoPublished(zenodoInfo.getIsPublished());
                         partialDto.setZenodoDepositId(zenodoInfo.getId().getDepositId());
                         partialDto.setZenodoFileUrl(zenodoInfo.getFileUrl());
+                        partialDto.setZenodoPublicationState(zenodoInfo.getZenodoState());
+
                     }
 
                     return partialDto;
@@ -822,6 +825,7 @@ public class JsonAssessmentService {
                         partialDto.setZenodoPublished(zenodoInfo.getIsPublished());
                         partialDto.setZenodoDepositId(zenodoInfo.getId().getDepositId());
                         partialDto.setZenodoFileUrl(zenodoInfo.getFileUrl());
+                        partialDto.setZenodoPublicationState(zenodoInfo.getZenodoState());
                     }
 
                     return partialDto;

--- a/service/src/main/java/org/grnet/cat/services/env/EnvironmentDetector.java
+++ b/service/src/main/java/org/grnet/cat/services/env/EnvironmentDetector.java
@@ -1,0 +1,27 @@
+package org.grnet.cat.services.env;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+
+@ApplicationScoped
+public class EnvironmentDetector {
+
+    @ConfigProperty(name = "api.server.url")
+    String apiServerUrl;
+
+    @ConfigProperty(name = "zenodo.sandbox.url")
+    String zenodoSandboxUrl;
+
+    @ConfigProperty(name = "zenodo.prod.url")
+    String zenodoProdUrl;
+
+    public boolean isDevel() {
+        if (apiServerUrl == null) return true;
+        String url = apiServerUrl.toLowerCase();
+        return url.contains("localhost") || url.contains("127.0.0.1") || url.contains("devel");
+    }
+
+    public String getZenodoBaseUrl() {
+        return isDevel() ? zenodoSandboxUrl : zenodoProdUrl;
+    }
+}

--- a/service/src/main/java/org/grnet/cat/services/zenodo/ZenodoClient.java
+++ b/service/src/main/java/org/grnet/cat/services/zenodo/ZenodoClient.java
@@ -7,8 +7,6 @@ import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
 import java.util.List;
 import java.util.Map;
 
-
-@RegisterRestClient
 @Produces(MediaType.APPLICATION_JSON)
 @Consumes(MediaType.APPLICATION_JSON)
 public interface ZenodoClient {

--- a/service/src/main/java/org/grnet/cat/services/zenodo/ZenodoClientFactory.java
+++ b/service/src/main/java/org/grnet/cat/services/zenodo/ZenodoClientFactory.java
@@ -1,0 +1,16 @@
+package org.grnet.cat.services.zenodo;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import org.eclipse.microprofile.rest.client.RestClientBuilder;
+
+import java.net.URI;
+
+@ApplicationScoped
+public class ZenodoClientFactory {
+
+    public ZenodoClient create(String baseUrl) {
+        return RestClientBuilder.newBuilder()
+                .baseUri(URI.create(baseUrl))
+                .build(ZenodoClient.class);
+    }
+}

--- a/service/src/main/java/org/grnet/cat/services/zenodo/ZenodoService.java
+++ b/service/src/main/java/org/grnet/cat/services/zenodo/ZenodoService.java
@@ -30,6 +30,7 @@ import org.grnet.cat.repositories.ZenodoAssessmentInfoRepository;
 import org.grnet.cat.services.KeycloakAdminService;
 import org.grnet.cat.services.MailerService;
 import org.grnet.cat.services.SettingService;
+import org.grnet.cat.services.env.EnvironmentDetector;
 import org.grnet.cat.services.interceptors.ShareableEntity;
 import org.grnet.cat.utils.Utility;
 import org.grnet.cat.utils.ZenodoConfig;
@@ -39,6 +40,7 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
+import java.net.URLDecoder;
 import java.nio.file.Files;
 import java.sql.Timestamp;
 import java.time.Instant;
@@ -54,10 +56,6 @@ import static org.grnet.cat.services.KeycloakAdminService.ENTITLEMENTS_DELIMITER
 @ApplicationScoped
 @MethodValidated
 public class ZenodoService {
-
-    @Inject
-    @RestClient
-    ZenodoClient zenodoClient;
 
     @Inject
     MotivationAssessmentRepository motivationAssessmentRepository;
@@ -77,29 +75,35 @@ public class ZenodoService {
     SettingRepository settingRepository;
 
     @Inject
+    EnvironmentDetector environmentDetector;
+
+    @Inject
+    ZenodoClientFactory zenodoClientFactory;
+
+
+    @Inject
     ZenodoConfig zenodoConfig;
 
-    @ConfigProperty(name = "quarkus.rest-client.\"org.grnet.cat.services.zenodo.ZenodoClient\".url")
-    protected String zenodoBaseUrl;
     private final ExecutorService executorService = Executors.newFixedThreadPool(2); // Adjust as needed
 
+    private ZenodoClient zenodoClient;
+
+    private String zenodoBaseUrl;
+
+    @PostConstruct
+    void initClient() {
+        this.zenodoBaseUrl = environmentDetector.getZenodoBaseUrl();
+        System.out.println("[ZenodoService] Initializing Zenodo client with base URL: " + zenodoBaseUrl);
+        this.zenodoClient = zenodoClientFactory.create(zenodoBaseUrl);
+    }
 
     public String getAccessToken() {
-        String token = settingService.getSettingConfig("1", "zenodo.api.key")
-                // Look for this key anywhere in the JSON
-                .orElseThrow(() -> new IllegalStateException("Zenodo API key is not configured."));
-
-        return "Bearer " + token;
+        var token = settingService.getSettingConfig("1", "zenodo.api.key");
+        return "Bearer " + token.orElseThrow(() -> new IllegalStateException("Zenodo API key is not configured."));
     }
 
     @Inject
     MailerService mailerService;
-
-
-    @PostConstruct
-    void init() {
-        getAccessToken();
-    }
 
     @ShareableEntity(type = ShareableEntityType.ASSESSMENT, id = String.class)
     @Transactional
@@ -734,6 +738,19 @@ public class ZenodoService {
             return "https://handle.test.datacite.org/" + doi; // sandbox
         }
         return null;
+    }
+
+
+    @Transactional
+    public boolean testZenodoConnection(String token) {
+        try {
+            ZenodoClient client = zenodoClient;
+            client.listDeposits("Bearer " + token);
+            return true;
+        } catch (Exception e) {
+            e.printStackTrace();
+            return false;
+        }
     }
 
 }


### PR DESCRIPTION
# Description

This PR improves the **Zenodo integration** by:

## 1. Centralizing the Zenodo base URL logic
- Introduced `EnvironmentDetector.getZenodoBaseUrl()` to determine whether to use:
  - `https://sandbox.zenodo.org` on `localhost` or `devel`
  - `https://zenodo.org` on `production`
- Replaced all Zenodo URLs across the codebase.

## 2. Adding Zenodo connection check on settings enable
- When the Zenodo setting is enabled:
  - Retrieves the API key from the request.
  - Uses the Zenodo client (based on the environment) to call `listDeposits`.
     - If the connection fails → throws a `BadRequestException` with a message:
        ```
        {
       "code": 400,
       "message": "Failed to connect to Zenodo. Please verify your API key."
       }
        ```
     - If successful → enables the setting normally.
- Ensures only valid API keys are stored and prevents broken configurations.

---

# Testing

### Local
- Set a valid **sandbox Zenodo** key → enable setting → connection succeeds.
- Set an invalid key → enable setting → clear error.

---